### PR TITLE
Link libscip instead of scip on Windows.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -97,6 +97,9 @@ fn main() -> Result<(), Box<dyn Error>> {
             .clang_arg(format!("-I{}", headers_dir_path));
     }
 
+    #[cfg(windows)]
+    println!("cargo:rustc-link-lib=libscip");
+    #[cfg(not(windows))]
     println!("cargo:rustc-link-lib=scip");
 
     let builder = builder


### PR DESCRIPTION
Currently, this crate fails compilation at the linking stage on Windows MSVC:

```
LINK : fatal error LNK1181: cannot open input file 'scip.lib'
```

This is because the library is actually called `libscip.lib` on Windows, and the `cl.exe` linker does not add a lib prefix automatically. This PR fixes this issue, getting compilation fully working on Windows.