### PR TITLE
 fix: Increase build time downloads timeout to 300s

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,14 +8,14 @@ license = "Apache-2.0"
 links = "scip"
 
 [features]
-bundled = ["reqwest", "zip", "tempfile", "zip-extract"]
-from-source = ["reqwest", "zip", "tempfile", "zip-extract", "cmake"]
+bundled = ["ureq", "zip", "tempfile", "zip-extract"]
+from-source = ["ureq", "zip", "tempfile", "zip-extract", "cmake"]
 
 [build-dependencies]
 bindgen = "0.64"
 cc = "1.0.73"
 glob = "0.3.1"
-reqwest = { version = "0.11", features = ["blocking", "json"], optional = true }
+ureq = { version = "2.9.6", optional = true }
 zip = { version = "0.5", optional = true }
 tempfile = { version = "3.2", optional = true }
 zip-extract = { version = "0.1.3", optional = true }

--- a/download.rs
+++ b/download.rs
@@ -2,6 +2,7 @@ use std::error::Error;
 use tempfile::tempdir;
 use std::fs::File;
 use std::io::Cursor;
+use std::io::Read;
 use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;
@@ -11,8 +12,9 @@ use zip_extract::extract;
 pub fn download_and_extract_zip(url: &str, extract_path: &Path) -> Result<(), Box<dyn Error>> {
     // Download the ZIP file
     println!("cargo:warning=Downloading from {}", url);
-    let response = reqwest::blocking::Client::new().get(url).send()?;
-    let content = response.bytes()?;
+    let resp = ureq::get(url).call()?;
+    let mut content: Vec<u8> = Vec::new();
+    resp.into_reader().read_to_end(&mut content)?;
 
     // Create a temporary file to store the ZIP
     let dir = tempdir()?;

--- a/download.rs
+++ b/download.rs
@@ -6,13 +6,14 @@ use std::io::Read;
 use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;
+use std::time::Duration;
 use zip_extract::extract;
 
 
 pub fn download_and_extract_zip(url: &str, extract_path: &Path) -> Result<(), Box<dyn Error>> {
     // Download the ZIP file
     println!("cargo:warning=Downloading from {}", url);
-    let resp = ureq::get(url).call()?;
+    let resp = ureq::get(url).timeout(Duration::from_secs(300)).call()?;
     let mut content: Vec<u8> = Vec::new();
     resp.into_reader().read_to_end(&mut content)?;
 


### PR DESCRIPTION
Previous implementation used reqwest in blocking mode, which limited download time to 30s. This posed be a problem on slow / flaky connections.

Also: Remove ~100 build dependencies by moving from reqwest to ureq.