### PR TITLE
Bundle SCIP 10.0.2

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -212,6 +212,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     let derive_casted_constant = DeriveCastedConstant::new().target("SCIP_INVALID");
 
     let builder = builder
+        // SCIP 10 annotates the deprecated `SCIP_VARTYPE_IMPLINT` enumerator with
+        // `SCIP_DEPRECATED`. On Windows that expands to `__declspec(deprecated)`,
+        // which clang cannot parse inside an enum; neutralize the macro for bindgen.
+        .clang_arg("-DSCIP_DEPRECATED=")
         .blocklist_item("FP_NAN")
         .blocklist_item("FP_INFINITE")
         .blocklist_item("FP_ZERO")

--- a/bundled.rs
+++ b/bundled.rs
@@ -47,10 +47,11 @@ pub fn download_scip() {
 
     // TODO: enable this when debug builds are available
     // let url = format!(
-    //     "https://github.com/scipopt/scipoptsuite-deploy/releases/download/v0.9.0/libscip-{os_string}{debug_str}.zip",
+    //     "https://github.com/scipopt/scipoptsuite-deploy/releases/download/v0.12.0/libscip-{os_string}{debug_str}.zip",
     // );
+    // v0.12.0 ships SCIP 10.0.2 / SoPlex 8.0.2 / GCG 4.0.2 / IPOPT 3.14.19.
     let url = format!(
-        "https://github.com/scipopt/scipoptsuite-deploy/releases/download/v0.9.0/libscip-{os_string}.zip",
+        "https://github.com/scipopt/scipoptsuite-deploy/releases/download/v0.12.0/libscip-{os_string}.zip",
     );
 
     download_and_extract_zip(&url, &extract_path)


### PR DESCRIPTION
Bumps the `bundled` feature to download SCIP 10 instead of 9.2.4.

The precompiled `libscip-{os}.zip` artifacts in scipoptsuite-deploy [v0.12.0](https://github.com/scipopt/scipoptsuite-deploy/releases/tag/v0.12.0) (SCIP 10.0.2 / SoPlex 8.0.2 / GCG 4.0.2 / IPOPT 3.14.19) use the same per-OS asset names as the previous v0.9.0 release, so only the release tag in the download URL changes.

Verified locally: `cargo build --features bundled` downloads and links the v0.12.0 binaries, and `cargo test --features bundled --tests` passes.