### PR TITLE
Use SCIP 10.0.2 for from-source, system, and conda CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -71,15 +71,15 @@ jobs:
   linux-system-test:
     runs-on: ubuntu-22.04
     env:
-      SCIP_VERSION: 9.2.4
+      SCIP_VERSION: 10.0.2
     steps:
       - uses: actions/checkout@v3
 
       - name: Install SCIP from debian package
         run: |
-          wget --quiet --no-check-certificate https://github.com/scipopt/scip/releases/download/v$(echo "${{ env.SCIP_VERSION }}" | tr -d '.')/SCIPOptSuite-${{ env.SCIP_VERSION }}-Linux-ubuntu22.deb
+          wget --quiet --no-check-certificate https://github.com/scipopt/scip/releases/download/v${{ env.SCIP_VERSION }}/scipoptsuite_${{ env.SCIP_VERSION }}-1+jammy_amd64.deb
           sudo apt-get update
-          sudo apt install -y ./SCIPOptSuite-${{ env.SCIP_VERSION }}-Linux-ubuntu22.deb
+          sudo apt install -y ./scipoptsuite_${{ env.SCIP_VERSION }}-1+jammy_amd64.deb
 
       - name: Verify SCIP headers are in standard locations
         run: |
@@ -104,7 +104,7 @@ jobs:
 
       - name: Install dependencies (SCIPOptSuite)
         run: |
-          conda install -y --prefix $CONDA/envs/test --channel conda-forge scip
+          conda install -y --prefix $CONDA/envs/test --channel conda-forge scip=10.0.2
           echo "LD_LIBRARY_PATH=$CONDA/envs/test/lib" >> "${GITHUB_ENV}"
           echo "CONDA_PREFIX=$CONDA/envs/test" >> "${GITHUB_ENV}"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ links = "scip"
 
 [features]
 bundled = ["ureq", "zip", "tempfile", "zip-extract"]
-from-source = ["ureq", "zip", "tempfile", "zip-extract", "cmake"]
+from-source = ["ureq", "zip", "tempfile", "zip-extract", "cmake", "flate2", "tar"]
 
 [build-dependencies]
 bindgen = "0.72.0"
@@ -19,6 +19,8 @@ zip = { version = "0.5", optional = true }
 tempfile = { version = "3.2", optional = true }
 zip-extract = { version = "0.1.3", optional = true }
 cmake = { version = "0.1.50", optional = true }
+flate2 = { version = "1", optional = true }
+tar = { version = "0.4", optional = true }
 
 [dependencies]
 cmake = "0.1.50"

--- a/download.rs
+++ b/download.rs
@@ -32,8 +32,28 @@ pub fn download_and_extract_zip(url: &str, extract_path: &Path) -> Result<(), Bo
         false,
     )?;
 
-    // Check if the extracted content is another zip file
-    let extracted_files: Vec<_> = std::fs::read_dir(&target_dir)?.collect();
+    extract_nested_zip(&target_dir)?;
+    Ok(())
+}
+
+/// Downloads a `.tar.gz`/`.tgz` archive and extracts it into `extract_path`.
+#[cfg(feature = "from-source")]
+pub fn download_and_extract_tar_gz(url: &str, extract_path: &Path) -> Result<(), Box<dyn Error>> {
+    println!("cargo:warning=Downloading from {}", url);
+    let resp = ureq::get(url).timeout(Duration::from_secs(300)).call()?;
+    let mut content: Vec<u8> = Vec::new();
+    resp.into_reader().read_to_end(&mut content)?;
+
+    println!("cargo:warning=Extracting to {:?}", extract_path);
+    let decoder = flate2::read::GzDecoder::new(Cursor::new(content));
+    tar::Archive::new(decoder).unpack(extract_path)?;
+    Ok(())
+}
+
+/// If extracting produced a single nested zip file, extract that too (some
+/// release archives wrap the install in another zip).
+fn extract_nested_zip(target_dir: &Path) -> Result<(), Box<dyn Error>> {
+    let extracted_files: Vec<_> = std::fs::read_dir(target_dir)?.collect();
     if extracted_files.len() == 1 {
         let first_file = extracted_files[0].as_ref().unwrap();
         if first_file

--- a/from_source.rs
+++ b/from_source.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "from-source")]
-use crate::download::download_and_extract_zip;
+use crate::download::download_and_extract_tar_gz;
 #[cfg(feature = "from-source")]
 use std::env;
 use std::path::PathBuf;
@@ -21,14 +21,16 @@ pub fn download_scip_source() -> PathBuf {
 
 #[cfg(feature = "from-source")]
 pub fn download_scip_source() -> PathBuf {
-    let scip_version = "9.2.4";
-    let url = format!("https://github.com/scipopt/scip-sys/releases/download/v0.1.9/scipoptsuite-{scip_version}.zip");
+    let scip_version = "10.0.2";
+    let url = format!(
+        "https://github.com/scipopt/scip/releases/download/v{scip_version}/scipoptsuite-{scip_version}.tgz"
+    );
     let target = env::var("OUT_DIR").unwrap();
     let target = std::path::Path::new(&target);
     if target.join(format!("scipoptsuite-{scip_version}")).exists() {
         println!("cargo:warning=SCIP was previously downloaded, skipping download");
     } else {
-        download_and_extract_zip(&url, &*target).expect("Failed to download SCIP");
+        download_and_extract_tar_gz(&url, target).expect("Failed to download SCIP");
     }
     target.join(format!("scipoptsuite-{scip_version}"))
 }


### PR DESCRIPTION
Follow-up to #40 (which moved the `bundled` feature to SCIP 10). This moves the remaining CI jobs off SCIP 9.2.4:

- **from-source**: `from_source.rs` now downloads the official `scipoptsuite-10.0.2.tgz`. Since it's a tarball (no source zip is published for v10), `download.rs` gains a `download_and_extract_tar_gz` helper (new optional `flate2`/`tar` build-deps, gated behind the `from-source` feature).
- **linux-system**: installs the SCIP 10.0.2 Debian package. The v10 asset naming changed (`scipoptsuite_10.0.2-1+jammy_amd64.deb`, tag `v10.0.2` with dots), so the download URL is updated accordingly.
- **conda**: pins `scip=10.0.2` (was unpinned, silently tracking conda-forge latest).

Verified locally: `cargo build --features from-source` builds SCIP 10 from source and `cargo test --features from-source --tests` passes.