### PR TITLE
Release 0.1.27

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scip-sys"
-version = "0.1.26"
+version = "0.1.27"
 edition = "2021"
 description = "Bindings for the C SCIP solver."
 repository = "https://github.com/scipopt/scip-sys"


### PR DESCRIPTION
Version bump to 0.1.27.

Includes the SCIP 10.0.2 migration (#40, #41): the `bundled` feature now fetches SCIP 10.0.2, `from-source` builds SCIP 10 from the official source tarball, the Windows bindgen `SCIP_DEPRECATED` parse issue is fixed, and the system/conda CI jobs use SCIP 10.

To be published to crates.io after merge.