### PR TITLE
Add prebuilt bundled bindings for all platforms + Intel runner fix

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -37,7 +37,7 @@ jobs:
       matrix:
         os: [
           ubuntu-latest,
-          macos-13, # Intel macOS runner
+          macos-15-intel, # Intel macOS runner
           macos-14, # macOS arm runner
           windows-latest,
           ubuntu-24.04-arm
@@ -72,7 +72,7 @@ jobs:
       matrix:
         os: [
           ubuntu-latest,
-          macos-13, # Intel macOS runner
+          macos-15-intel, # Intel macOS runner
           macos-14, # macOS arm runner
           windows-latest,
           ubuntu-24.04-arm

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -37,7 +37,7 @@ jobs:
       matrix:
         os: [
           ubuntu-latest,
-          macos-15,
+          macos-13, # Intel macOS runner
           macos-14, # macOS arm runner
           windows-latest,
           ubuntu-24.04-arm
@@ -72,8 +72,8 @@ jobs:
       matrix:
         os: [
           ubuntu-latest,
-          macos-15,
-          macos-14,
+          macos-13, # Intel macOS runner
+          macos-14, # macOS arm runner
           windows-latest,
           ubuntu-24.04-arm
         ]

--- a/.github/workflows/generate-bindings.yml
+++ b/.github/workflows/generate-bindings.yml
@@ -67,3 +67,5 @@ jobs:
           base: main
           branch: update-bundled-bindings
           delete-branch: true
+          # Only commit the bindings, never the downloaded artifacts/ directory.
+          add-paths: src/bindings/*.rs

--- a/.github/workflows/generate-bindings.yml
+++ b/.github/workflows/generate-bindings.yml
@@ -17,7 +17,7 @@ jobs:
             target: linux
           - os: ubuntu-24.04-arm
             target: linux-arm
-          - os: macos-15
+          - os: macos-13 # last Intel macOS runner
             target: macos-intel
           - os: macos-14 # macOS arm runner
             target: macos-arm
@@ -64,5 +64,6 @@ jobs:
           body: |
             Automated regeneration of the per-platform prebuilt bundled bindings
             (`src/bindings/<target>.rs`) via the `generate-bindings` workflow.
+          base: main
           branch: update-bundled-bindings
           delete-branch: true

--- a/.github/workflows/generate-bindings.yml
+++ b/.github/workflows/generate-bindings.yml
@@ -17,7 +17,7 @@ jobs:
             target: linux
           - os: ubuntu-24.04-arm
             target: linux-arm
-          - os: macos-13 # last Intel macOS runner
+          - os: macos-15-intel # Intel macOS runner
             target: macos-intel
           - os: macos-14 # macOS arm runner
             target: macos-arm

--- a/src/bindings/linux-arm.rs
+++ b/src/bindings/linux-arm.rs
@@ -136,477 +136,167 @@ where
         }
     }
 }
-pub const __has_safe_buffers: u32 = 1;
-pub const __DARWIN_ONLY_64_BIT_INO_T: u32 = 1;
-pub const __DARWIN_ONLY_UNIX_CONFORMANCE: u32 = 1;
-pub const __DARWIN_ONLY_VERS_1050: u32 = 1;
-pub const __DARWIN_UNIX03: u32 = 1;
-pub const __DARWIN_64_BIT_INO_T: u32 = 1;
-pub const __DARWIN_VERS_1050: u32 = 1;
-pub const __DARWIN_NON_CANCELABLE: u32 = 0;
-pub const __DARWIN_SUF_EXTSN: &[u8; 14] = b"$DARWIN_EXTSN\0";
-pub const __DARWIN_C_ANSI: u32 = 4096;
-pub const __DARWIN_C_FULL: u32 = 900000;
-pub const __DARWIN_C_LEVEL: u32 = 900000;
-pub const __STDC_WANT_LIB_EXT1__: u32 = 1;
-pub const __DARWIN_NO_LONG_LONG: u32 = 0;
-pub const _DARWIN_FEATURE_64_BIT_INODE: u32 = 1;
-pub const _DARWIN_FEATURE_ONLY_64_BIT_INODE: u32 = 1;
-pub const _DARWIN_FEATURE_ONLY_VERS_1050: u32 = 1;
-pub const _DARWIN_FEATURE_ONLY_UNIX_CONFORMANCE: u32 = 1;
-pub const _DARWIN_FEATURE_UNIX_CONFORMANCE: u32 = 3;
-pub const __has_ptrcheck: u32 = 0;
-pub const __API_TO_BE_DEPRECATED: u32 = 100000;
-pub const __API_TO_BE_DEPRECATED_MACOS: u32 = 100000;
-pub const __API_TO_BE_DEPRECATED_IOS: u32 = 100000;
-pub const __API_TO_BE_DEPRECATED_MACCATALYST: u32 = 100000;
-pub const __API_TO_BE_DEPRECATED_WATCHOS: u32 = 100000;
-pub const __API_TO_BE_DEPRECATED_TVOS: u32 = 100000;
-pub const __API_TO_BE_DEPRECATED_DRIVERKIT: u32 = 100000;
-pub const __API_TO_BE_DEPRECATED_VISIONOS: u32 = 100000;
-pub const __MAC_10_0: u32 = 1000;
-pub const __MAC_10_1: u32 = 1010;
-pub const __MAC_10_2: u32 = 1020;
-pub const __MAC_10_3: u32 = 1030;
-pub const __MAC_10_4: u32 = 1040;
-pub const __MAC_10_5: u32 = 1050;
-pub const __MAC_10_6: u32 = 1060;
-pub const __MAC_10_7: u32 = 1070;
-pub const __MAC_10_8: u32 = 1080;
-pub const __MAC_10_9: u32 = 1090;
-pub const __MAC_10_10: u32 = 101000;
-pub const __MAC_10_10_2: u32 = 101002;
-pub const __MAC_10_10_3: u32 = 101003;
-pub const __MAC_10_11: u32 = 101100;
-pub const __MAC_10_11_2: u32 = 101102;
-pub const __MAC_10_11_3: u32 = 101103;
-pub const __MAC_10_11_4: u32 = 101104;
-pub const __MAC_10_12: u32 = 101200;
-pub const __MAC_10_12_1: u32 = 101201;
-pub const __MAC_10_12_2: u32 = 101202;
-pub const __MAC_10_12_4: u32 = 101204;
-pub const __MAC_10_13: u32 = 101300;
-pub const __MAC_10_13_1: u32 = 101301;
-pub const __MAC_10_13_2: u32 = 101302;
-pub const __MAC_10_13_4: u32 = 101304;
-pub const __MAC_10_14: u32 = 101400;
-pub const __MAC_10_14_1: u32 = 101401;
-pub const __MAC_10_14_4: u32 = 101404;
-pub const __MAC_10_14_5: u32 = 101405;
-pub const __MAC_10_14_6: u32 = 101406;
-pub const __MAC_10_15: u32 = 101500;
-pub const __MAC_10_15_1: u32 = 101501;
-pub const __MAC_10_15_4: u32 = 101504;
-pub const __MAC_10_16: u32 = 101600;
-pub const __MAC_11_0: u32 = 110000;
-pub const __MAC_11_1: u32 = 110100;
-pub const __MAC_11_3: u32 = 110300;
-pub const __MAC_11_4: u32 = 110400;
-pub const __MAC_11_5: u32 = 110500;
-pub const __MAC_11_6: u32 = 110600;
-pub const __MAC_12_0: u32 = 120000;
-pub const __MAC_12_1: u32 = 120100;
-pub const __MAC_12_2: u32 = 120200;
-pub const __MAC_12_3: u32 = 120300;
-pub const __MAC_12_4: u32 = 120400;
-pub const __MAC_12_5: u32 = 120500;
-pub const __MAC_12_6: u32 = 120600;
-pub const __MAC_12_7: u32 = 120700;
-pub const __MAC_13_0: u32 = 130000;
-pub const __MAC_13_1: u32 = 130100;
-pub const __MAC_13_2: u32 = 130200;
-pub const __MAC_13_3: u32 = 130300;
-pub const __MAC_13_4: u32 = 130400;
-pub const __MAC_13_5: u32 = 130500;
-pub const __MAC_13_6: u32 = 130600;
-pub const __MAC_14_0: u32 = 140000;
-pub const __MAC_14_1: u32 = 140100;
-pub const __MAC_14_2: u32 = 140200;
-pub const __MAC_14_3: u32 = 140300;
-pub const __MAC_14_4: u32 = 140400;
-pub const __MAC_14_5: u32 = 140500;
-pub const __IPHONE_2_0: u32 = 20000;
-pub const __IPHONE_2_1: u32 = 20100;
-pub const __IPHONE_2_2: u32 = 20200;
-pub const __IPHONE_3_0: u32 = 30000;
-pub const __IPHONE_3_1: u32 = 30100;
-pub const __IPHONE_3_2: u32 = 30200;
-pub const __IPHONE_4_0: u32 = 40000;
-pub const __IPHONE_4_1: u32 = 40100;
-pub const __IPHONE_4_2: u32 = 40200;
-pub const __IPHONE_4_3: u32 = 40300;
-pub const __IPHONE_5_0: u32 = 50000;
-pub const __IPHONE_5_1: u32 = 50100;
-pub const __IPHONE_6_0: u32 = 60000;
-pub const __IPHONE_6_1: u32 = 60100;
-pub const __IPHONE_7_0: u32 = 70000;
-pub const __IPHONE_7_1: u32 = 70100;
-pub const __IPHONE_8_0: u32 = 80000;
-pub const __IPHONE_8_1: u32 = 80100;
-pub const __IPHONE_8_2: u32 = 80200;
-pub const __IPHONE_8_3: u32 = 80300;
-pub const __IPHONE_8_4: u32 = 80400;
-pub const __IPHONE_9_0: u32 = 90000;
-pub const __IPHONE_9_1: u32 = 90100;
-pub const __IPHONE_9_2: u32 = 90200;
-pub const __IPHONE_9_3: u32 = 90300;
-pub const __IPHONE_10_0: u32 = 100000;
-pub const __IPHONE_10_1: u32 = 100100;
-pub const __IPHONE_10_2: u32 = 100200;
-pub const __IPHONE_10_3: u32 = 100300;
-pub const __IPHONE_11_0: u32 = 110000;
-pub const __IPHONE_11_1: u32 = 110100;
-pub const __IPHONE_11_2: u32 = 110200;
-pub const __IPHONE_11_3: u32 = 110300;
-pub const __IPHONE_11_4: u32 = 110400;
-pub const __IPHONE_12_0: u32 = 120000;
-pub const __IPHONE_12_1: u32 = 120100;
-pub const __IPHONE_12_2: u32 = 120200;
-pub const __IPHONE_12_3: u32 = 120300;
-pub const __IPHONE_12_4: u32 = 120400;
-pub const __IPHONE_13_0: u32 = 130000;
-pub const __IPHONE_13_1: u32 = 130100;
-pub const __IPHONE_13_2: u32 = 130200;
-pub const __IPHONE_13_3: u32 = 130300;
-pub const __IPHONE_13_4: u32 = 130400;
-pub const __IPHONE_13_5: u32 = 130500;
-pub const __IPHONE_13_6: u32 = 130600;
-pub const __IPHONE_13_7: u32 = 130700;
-pub const __IPHONE_14_0: u32 = 140000;
-pub const __IPHONE_14_1: u32 = 140100;
-pub const __IPHONE_14_2: u32 = 140200;
-pub const __IPHONE_14_3: u32 = 140300;
-pub const __IPHONE_14_5: u32 = 140500;
-pub const __IPHONE_14_4: u32 = 140400;
-pub const __IPHONE_14_6: u32 = 140600;
-pub const __IPHONE_14_7: u32 = 140700;
-pub const __IPHONE_14_8: u32 = 140800;
-pub const __IPHONE_15_0: u32 = 150000;
-pub const __IPHONE_15_1: u32 = 150100;
-pub const __IPHONE_15_2: u32 = 150200;
-pub const __IPHONE_15_3: u32 = 150300;
-pub const __IPHONE_15_4: u32 = 150400;
-pub const __IPHONE_15_5: u32 = 150500;
-pub const __IPHONE_15_6: u32 = 150600;
-pub const __IPHONE_15_7: u32 = 150700;
-pub const __IPHONE_15_8: u32 = 150800;
-pub const __IPHONE_16_0: u32 = 160000;
-pub const __IPHONE_16_1: u32 = 160100;
-pub const __IPHONE_16_2: u32 = 160200;
-pub const __IPHONE_16_3: u32 = 160300;
-pub const __IPHONE_16_4: u32 = 160400;
-pub const __IPHONE_16_5: u32 = 160500;
-pub const __IPHONE_16_6: u32 = 160600;
-pub const __IPHONE_16_7: u32 = 160700;
-pub const __IPHONE_17_0: u32 = 170000;
-pub const __IPHONE_17_1: u32 = 170100;
-pub const __IPHONE_17_2: u32 = 170200;
-pub const __IPHONE_17_3: u32 = 170300;
-pub const __IPHONE_17_4: u32 = 170400;
-pub const __IPHONE_17_5: u32 = 170500;
-pub const __WATCHOS_1_0: u32 = 10000;
-pub const __WATCHOS_2_0: u32 = 20000;
-pub const __WATCHOS_2_1: u32 = 20100;
-pub const __WATCHOS_2_2: u32 = 20200;
-pub const __WATCHOS_3_0: u32 = 30000;
-pub const __WATCHOS_3_1: u32 = 30100;
-pub const __WATCHOS_3_1_1: u32 = 30101;
-pub const __WATCHOS_3_2: u32 = 30200;
-pub const __WATCHOS_4_0: u32 = 40000;
-pub const __WATCHOS_4_1: u32 = 40100;
-pub const __WATCHOS_4_2: u32 = 40200;
-pub const __WATCHOS_4_3: u32 = 40300;
-pub const __WATCHOS_5_0: u32 = 50000;
-pub const __WATCHOS_5_1: u32 = 50100;
-pub const __WATCHOS_5_2: u32 = 50200;
-pub const __WATCHOS_5_3: u32 = 50300;
-pub const __WATCHOS_6_0: u32 = 60000;
-pub const __WATCHOS_6_1: u32 = 60100;
-pub const __WATCHOS_6_2: u32 = 60200;
-pub const __WATCHOS_7_0: u32 = 70000;
-pub const __WATCHOS_7_1: u32 = 70100;
-pub const __WATCHOS_7_2: u32 = 70200;
-pub const __WATCHOS_7_3: u32 = 70300;
-pub const __WATCHOS_7_4: u32 = 70400;
-pub const __WATCHOS_7_5: u32 = 70500;
-pub const __WATCHOS_7_6: u32 = 70600;
-pub const __WATCHOS_8_0: u32 = 80000;
-pub const __WATCHOS_8_1: u32 = 80100;
-pub const __WATCHOS_8_3: u32 = 80300;
-pub const __WATCHOS_8_4: u32 = 80400;
-pub const __WATCHOS_8_5: u32 = 80500;
-pub const __WATCHOS_8_6: u32 = 80600;
-pub const __WATCHOS_8_7: u32 = 80700;
-pub const __WATCHOS_8_8: u32 = 80800;
-pub const __WATCHOS_9_0: u32 = 90000;
-pub const __WATCHOS_9_1: u32 = 90100;
-pub const __WATCHOS_9_2: u32 = 90200;
-pub const __WATCHOS_9_3: u32 = 90300;
-pub const __WATCHOS_9_4: u32 = 90400;
-pub const __WATCHOS_9_5: u32 = 90500;
-pub const __WATCHOS_9_6: u32 = 90600;
-pub const __WATCHOS_10_0: u32 = 100000;
-pub const __WATCHOS_10_1: u32 = 100100;
-pub const __WATCHOS_10_2: u32 = 100200;
-pub const __WATCHOS_10_3: u32 = 100300;
-pub const __WATCHOS_10_4: u32 = 100400;
-pub const __WATCHOS_10_5: u32 = 100500;
-pub const __TVOS_9_0: u32 = 90000;
-pub const __TVOS_9_1: u32 = 90100;
-pub const __TVOS_9_2: u32 = 90200;
-pub const __TVOS_10_0: u32 = 100000;
-pub const __TVOS_10_0_1: u32 = 100001;
-pub const __TVOS_10_1: u32 = 100100;
-pub const __TVOS_10_2: u32 = 100200;
-pub const __TVOS_11_0: u32 = 110000;
-pub const __TVOS_11_1: u32 = 110100;
-pub const __TVOS_11_2: u32 = 110200;
-pub const __TVOS_11_3: u32 = 110300;
-pub const __TVOS_11_4: u32 = 110400;
-pub const __TVOS_12_0: u32 = 120000;
-pub const __TVOS_12_1: u32 = 120100;
-pub const __TVOS_12_2: u32 = 120200;
-pub const __TVOS_12_3: u32 = 120300;
-pub const __TVOS_12_4: u32 = 120400;
-pub const __TVOS_13_0: u32 = 130000;
-pub const __TVOS_13_2: u32 = 130200;
-pub const __TVOS_13_3: u32 = 130300;
-pub const __TVOS_13_4: u32 = 130400;
-pub const __TVOS_14_0: u32 = 140000;
-pub const __TVOS_14_1: u32 = 140100;
-pub const __TVOS_14_2: u32 = 140200;
-pub const __TVOS_14_3: u32 = 140300;
-pub const __TVOS_14_5: u32 = 140500;
-pub const __TVOS_14_6: u32 = 140600;
-pub const __TVOS_14_7: u32 = 140700;
-pub const __TVOS_15_0: u32 = 150000;
-pub const __TVOS_15_1: u32 = 150100;
-pub const __TVOS_15_2: u32 = 150200;
-pub const __TVOS_15_3: u32 = 150300;
-pub const __TVOS_15_4: u32 = 150400;
-pub const __TVOS_15_5: u32 = 150500;
-pub const __TVOS_15_6: u32 = 150600;
-pub const __TVOS_16_0: u32 = 160000;
-pub const __TVOS_16_1: u32 = 160100;
-pub const __TVOS_16_2: u32 = 160200;
-pub const __TVOS_16_3: u32 = 160300;
-pub const __TVOS_16_4: u32 = 160400;
-pub const __TVOS_16_5: u32 = 160500;
-pub const __TVOS_16_6: u32 = 160600;
-pub const __TVOS_17_0: u32 = 170000;
-pub const __TVOS_17_1: u32 = 170100;
-pub const __TVOS_17_2: u32 = 170200;
-pub const __TVOS_17_3: u32 = 170300;
-pub const __TVOS_17_4: u32 = 170400;
-pub const __TVOS_17_5: u32 = 170500;
-pub const __BRIDGEOS_2_0: u32 = 20000;
-pub const __BRIDGEOS_3_0: u32 = 30000;
-pub const __BRIDGEOS_3_1: u32 = 30100;
-pub const __BRIDGEOS_3_4: u32 = 30400;
-pub const __BRIDGEOS_4_0: u32 = 40000;
-pub const __BRIDGEOS_4_1: u32 = 40100;
-pub const __BRIDGEOS_5_0: u32 = 50000;
-pub const __BRIDGEOS_5_1: u32 = 50100;
-pub const __BRIDGEOS_5_3: u32 = 50300;
-pub const __BRIDGEOS_6_0: u32 = 60000;
-pub const __BRIDGEOS_6_2: u32 = 60200;
-pub const __BRIDGEOS_6_4: u32 = 60400;
-pub const __BRIDGEOS_6_5: u32 = 60500;
-pub const __BRIDGEOS_6_6: u32 = 60600;
-pub const __BRIDGEOS_7_0: u32 = 70000;
-pub const __BRIDGEOS_7_1: u32 = 70100;
-pub const __BRIDGEOS_7_2: u32 = 70200;
-pub const __BRIDGEOS_7_3: u32 = 70300;
-pub const __BRIDGEOS_7_4: u32 = 70400;
-pub const __BRIDGEOS_7_6: u32 = 70600;
-pub const __BRIDGEOS_8_0: u32 = 80000;
-pub const __BRIDGEOS_8_1: u32 = 80100;
-pub const __BRIDGEOS_8_2: u32 = 80200;
-pub const __BRIDGEOS_8_3: u32 = 80300;
-pub const __BRIDGEOS_8_4: u32 = 80400;
-pub const __BRIDGEOS_8_5: u32 = 80500;
-pub const __DRIVERKIT_19_0: u32 = 190000;
-pub const __DRIVERKIT_20_0: u32 = 200000;
-pub const __DRIVERKIT_21_0: u32 = 210000;
-pub const __DRIVERKIT_22_0: u32 = 220000;
-pub const __DRIVERKIT_22_4: u32 = 220400;
-pub const __DRIVERKIT_22_5: u32 = 220500;
-pub const __DRIVERKIT_22_6: u32 = 220600;
-pub const __DRIVERKIT_23_0: u32 = 230000;
-pub const __DRIVERKIT_23_1: u32 = 230100;
-pub const __DRIVERKIT_23_2: u32 = 230200;
-pub const __DRIVERKIT_23_3: u32 = 230300;
-pub const __DRIVERKIT_23_4: u32 = 230400;
-pub const __DRIVERKIT_23_5: u32 = 230500;
-pub const __VISIONOS_1_0: u32 = 10000;
-pub const __VISIONOS_1_1: u32 = 10100;
-pub const __VISIONOS_1_2: u32 = 10200;
-pub const MAC_OS_X_VERSION_10_0: u32 = 1000;
-pub const MAC_OS_X_VERSION_10_1: u32 = 1010;
-pub const MAC_OS_X_VERSION_10_2: u32 = 1020;
-pub const MAC_OS_X_VERSION_10_3: u32 = 1030;
-pub const MAC_OS_X_VERSION_10_4: u32 = 1040;
-pub const MAC_OS_X_VERSION_10_5: u32 = 1050;
-pub const MAC_OS_X_VERSION_10_6: u32 = 1060;
-pub const MAC_OS_X_VERSION_10_7: u32 = 1070;
-pub const MAC_OS_X_VERSION_10_8: u32 = 1080;
-pub const MAC_OS_X_VERSION_10_9: u32 = 1090;
-pub const MAC_OS_X_VERSION_10_10: u32 = 101000;
-pub const MAC_OS_X_VERSION_10_10_2: u32 = 101002;
-pub const MAC_OS_X_VERSION_10_10_3: u32 = 101003;
-pub const MAC_OS_X_VERSION_10_11: u32 = 101100;
-pub const MAC_OS_X_VERSION_10_11_2: u32 = 101102;
-pub const MAC_OS_X_VERSION_10_11_3: u32 = 101103;
-pub const MAC_OS_X_VERSION_10_11_4: u32 = 101104;
-pub const MAC_OS_X_VERSION_10_12: u32 = 101200;
-pub const MAC_OS_X_VERSION_10_12_1: u32 = 101201;
-pub const MAC_OS_X_VERSION_10_12_2: u32 = 101202;
-pub const MAC_OS_X_VERSION_10_12_4: u32 = 101204;
-pub const MAC_OS_X_VERSION_10_13: u32 = 101300;
-pub const MAC_OS_X_VERSION_10_13_1: u32 = 101301;
-pub const MAC_OS_X_VERSION_10_13_2: u32 = 101302;
-pub const MAC_OS_X_VERSION_10_13_4: u32 = 101304;
-pub const MAC_OS_X_VERSION_10_14: u32 = 101400;
-pub const MAC_OS_X_VERSION_10_14_1: u32 = 101401;
-pub const MAC_OS_X_VERSION_10_14_4: u32 = 101404;
-pub const MAC_OS_X_VERSION_10_14_5: u32 = 101405;
-pub const MAC_OS_X_VERSION_10_14_6: u32 = 101406;
-pub const MAC_OS_X_VERSION_10_15: u32 = 101500;
-pub const MAC_OS_X_VERSION_10_15_1: u32 = 101501;
-pub const MAC_OS_X_VERSION_10_15_4: u32 = 101504;
-pub const MAC_OS_X_VERSION_10_16: u32 = 101600;
-pub const MAC_OS_VERSION_11_0: u32 = 110000;
-pub const MAC_OS_VERSION_11_1: u32 = 110100;
-pub const MAC_OS_VERSION_11_3: u32 = 110300;
-pub const MAC_OS_VERSION_11_4: u32 = 110400;
-pub const MAC_OS_VERSION_11_5: u32 = 110500;
-pub const MAC_OS_VERSION_11_6: u32 = 110600;
-pub const MAC_OS_VERSION_12_0: u32 = 120000;
-pub const MAC_OS_VERSION_12_1: u32 = 120100;
-pub const MAC_OS_VERSION_12_2: u32 = 120200;
-pub const MAC_OS_VERSION_12_3: u32 = 120300;
-pub const MAC_OS_VERSION_12_4: u32 = 120400;
-pub const MAC_OS_VERSION_12_5: u32 = 120500;
-pub const MAC_OS_VERSION_12_6: u32 = 120600;
-pub const MAC_OS_VERSION_12_7: u32 = 120700;
-pub const MAC_OS_VERSION_13_0: u32 = 130000;
-pub const MAC_OS_VERSION_13_1: u32 = 130100;
-pub const MAC_OS_VERSION_13_2: u32 = 130200;
-pub const MAC_OS_VERSION_13_3: u32 = 130300;
-pub const MAC_OS_VERSION_13_4: u32 = 130400;
-pub const MAC_OS_VERSION_13_5: u32 = 130500;
-pub const MAC_OS_VERSION_13_6: u32 = 130600;
-pub const MAC_OS_VERSION_14_0: u32 = 140000;
-pub const MAC_OS_VERSION_14_1: u32 = 140100;
-pub const MAC_OS_VERSION_14_2: u32 = 140200;
-pub const MAC_OS_VERSION_14_3: u32 = 140300;
-pub const MAC_OS_VERSION_14_4: u32 = 140400;
-pub const MAC_OS_VERSION_14_5: u32 = 140500;
-pub const __MAC_OS_X_VERSION_MAX_ALLOWED: u32 = 140500;
-pub const __ENABLE_LEGACY_MAC_AVAILABILITY: u32 = 1;
-pub const __PTHREAD_SIZE__: u32 = 8176;
-pub const __PTHREAD_ATTR_SIZE__: u32 = 56;
-pub const __PTHREAD_MUTEXATTR_SIZE__: u32 = 8;
-pub const __PTHREAD_MUTEX_SIZE__: u32 = 56;
-pub const __PTHREAD_CONDATTR_SIZE__: u32 = 8;
-pub const __PTHREAD_COND_SIZE__: u32 = 40;
-pub const __PTHREAD_ONCE_SIZE__: u32 = 8;
-pub const __PTHREAD_RWLOCK_SIZE__: u32 = 192;
-pub const __PTHREAD_RWLOCKATTR_SIZE__: u32 = 16;
-pub const __DARWIN_WCHAR_MIN: i32 = -2147483648;
-pub const _FORTIFY_SOURCE: u32 = 2;
-pub const RENAME_SECLUDE: u32 = 1;
-pub const RENAME_SWAP: u32 = 2;
-pub const RENAME_EXCL: u32 = 4;
-pub const RENAME_RESERVED1: u32 = 8;
-pub const RENAME_NOFOLLOW_ANY: u32 = 16;
-pub const SEEK_SET: u32 = 0;
-pub const SEEK_CUR: u32 = 1;
-pub const SEEK_END: u32 = 2;
-pub const SEEK_HOLE: u32 = 3;
-pub const SEEK_DATA: u32 = 4;
-pub const __SLBF: u32 = 1;
-pub const __SNBF: u32 = 2;
-pub const __SRD: u32 = 4;
-pub const __SWR: u32 = 8;
-pub const __SRW: u32 = 16;
-pub const __SEOF: u32 = 32;
-pub const __SERR: u32 = 64;
-pub const __SMBF: u32 = 128;
-pub const __SAPP: u32 = 256;
-pub const __SSTR: u32 = 512;
-pub const __SOPT: u32 = 1024;
-pub const __SNPT: u32 = 2048;
-pub const __SOFF: u32 = 4096;
-pub const __SMOD: u32 = 8192;
-pub const __SALC: u32 = 16384;
-pub const __SIGN: u32 = 32768;
+#[doc = r" If Bindgen could only determine the size and alignment of a"]
+#[doc = r" type, it is represented like this."]
+#[derive(PartialEq, Copy, Clone, Debug, Hash)]
+#[repr(C)]
+pub struct __BindgenOpaqueArray<T: Copy, const N: usize>(pub [T; N]);
+impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray<T, N> {
+    fn default() -> Self {
+        Self([<T as Default>::default(); N])
+    }
+}
+pub const _STDIO_H: u32 = 1;
+pub const _FEATURES_H: u32 = 1;
+pub const _DEFAULT_SOURCE: u32 = 1;
+pub const __GLIBC_USE_ISOC2X: u32 = 0;
+pub const __USE_ISOC11: u32 = 1;
+pub const __USE_ISOC99: u32 = 1;
+pub const __USE_ISOC95: u32 = 1;
+pub const __USE_POSIX_IMPLICITLY: u32 = 1;
+pub const _POSIX_SOURCE: u32 = 1;
+pub const _POSIX_C_SOURCE: u32 = 200809;
+pub const __USE_POSIX: u32 = 1;
+pub const __USE_POSIX2: u32 = 1;
+pub const __USE_POSIX199309: u32 = 1;
+pub const __USE_POSIX199506: u32 = 1;
+pub const __USE_XOPEN2K: u32 = 1;
+pub const __USE_XOPEN2K8: u32 = 1;
+pub const _ATFILE_SOURCE: u32 = 1;
+pub const __WORDSIZE: u32 = 64;
+pub const __WORDSIZE_TIME64_COMPAT32: u32 = 0;
+pub const __TIMESIZE: u32 = 64;
+pub const __USE_MISC: u32 = 1;
+pub const __USE_ATFILE: u32 = 1;
+pub const __USE_FORTIFY_LEVEL: u32 = 0;
+pub const __GLIBC_USE_DEPRECATED_GETS: u32 = 0;
+pub const __GLIBC_USE_DEPRECATED_SCANF: u32 = 0;
+pub const __GLIBC_USE_C2X_STRTOL: u32 = 0;
+pub const _STDC_PREDEF_H: u32 = 1;
+pub const __STDC_IEC_559__: u32 = 1;
+pub const __STDC_IEC_60559_BFP__: u32 = 201404;
+pub const __STDC_IEC_559_COMPLEX__: u32 = 1;
+pub const __STDC_IEC_60559_COMPLEX__: u32 = 201404;
+pub const __STDC_ISO_10646__: u32 = 201706;
+pub const __GNU_LIBRARY__: u32 = 6;
+pub const __GLIBC__: u32 = 2;
+pub const __GLIBC_MINOR__: u32 = 39;
+pub const _SYS_CDEFS_H: u32 = 1;
+pub const __glibc_c99_flexarr_available: u32 = 1;
+pub const __LDOUBLE_REDIRECTS_TO_FLOAT128_ABI: u32 = 0;
+pub const __HAVE_GENERIC_SELECTION: u32 = 1;
+pub const __GLIBC_USE_LIB_EXT2: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_BFP_EXT: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_BFP_EXT_C2X: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_EXT: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_FUNCS_EXT: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_FUNCS_EXT_C2X: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_TYPES_EXT: u32 = 0;
+pub const _BITS_TYPES_H: u32 = 1;
+pub const _BITS_TYPESIZES_H: u32 = 1;
+pub const __OFF_T_MATCHES_OFF64_T: u32 = 1;
+pub const __INO_T_MATCHES_INO64_T: u32 = 1;
+pub const __RLIM_T_MATCHES_RLIM64_T: u32 = 1;
+pub const __STATFS_MATCHES_STATFS64: u32 = 1;
+pub const __FD_SETSIZE: u32 = 1024;
+pub const _BITS_TIME64_H: u32 = 1;
+pub const _____fpos_t_defined: u32 = 1;
+pub const ____mbstate_t_defined: u32 = 1;
+pub const _____fpos64_t_defined: u32 = 1;
+pub const ____FILE_defined: u32 = 1;
+pub const __FILE_defined: u32 = 1;
+pub const __struct_FILE_defined: u32 = 1;
+pub const _IO_EOF_SEEN: u32 = 16;
+pub const _IO_ERR_SEEN: u32 = 32;
+pub const _IO_USER_LOCK: u32 = 32768;
+pub const __cookie_io_functions_t_defined: u32 = 1;
 pub const _IOFBF: u32 = 0;
 pub const _IOLBF: u32 = 1;
 pub const _IONBF: u32 = 2;
-pub const BUFSIZ: u32 = 1024;
+pub const BUFSIZ: u32 = 8192;
 pub const EOF: i32 = -1;
-pub const FOPEN_MAX: u32 = 20;
-pub const FILENAME_MAX: u32 = 1024;
-pub const P_tmpdir: &[u8; 10] = b"/var/tmp/\0";
-pub const L_tmpnam: u32 = 1024;
-pub const TMP_MAX: u32 = 308915776;
-pub const L_ctermid: u32 = 1024;
-pub const _USE_FORTIFY_LEVEL: u32 = 2;
-pub const __WORDSIZE: u32 = 64;
-pub const INT8_MAX: u32 = 127;
-pub const INT16_MAX: u32 = 32767;
-pub const INT32_MAX: u32 = 2147483647;
-pub const INT64_MAX: u64 = 9223372036854775807;
+pub const SEEK_SET: u32 = 0;
+pub const SEEK_CUR: u32 = 1;
+pub const SEEK_END: u32 = 2;
+pub const P_tmpdir: &[u8; 5] = b"/tmp\0";
+pub const L_tmpnam: u32 = 20;
+pub const TMP_MAX: u32 = 238328;
+pub const _BITS_STDIO_LIM_H: u32 = 1;
+pub const FILENAME_MAX: u32 = 4096;
+pub const L_ctermid: u32 = 9;
+pub const FOPEN_MAX: u32 = 16;
+pub const __HAVE_FLOAT128: u32 = 1;
+pub const __HAVE_DISTINCT_FLOAT128: u32 = 0;
+pub const __HAVE_FLOAT64X: u32 = 1;
+pub const __HAVE_FLOAT64X_LONG_DOUBLE: u32 = 1;
+pub const __HAVE_FLOAT16: u32 = 0;
+pub const __HAVE_FLOAT32: u32 = 1;
+pub const __HAVE_FLOAT64: u32 = 1;
+pub const __HAVE_FLOAT32X: u32 = 1;
+pub const __HAVE_FLOAT128X: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT16: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT32: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT64: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT32X: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT64X: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT128X: u32 = 0;
+pub const __HAVE_FLOATN_NOT_TYPEDEF: u32 = 0;
+pub const _STDINT_H: u32 = 1;
+pub const _BITS_WCHAR_H: u32 = 1;
+pub const _BITS_STDINT_INTN_H: u32 = 1;
+pub const _BITS_STDINT_UINTN_H: u32 = 1;
+pub const _BITS_STDINT_LEAST_H: u32 = 1;
 pub const INT8_MIN: i32 = -128;
 pub const INT16_MIN: i32 = -32768;
 pub const INT32_MIN: i32 = -2147483648;
-pub const INT64_MIN: i64 = -9223372036854775808;
+pub const INT8_MAX: u32 = 127;
+pub const INT16_MAX: u32 = 32767;
+pub const INT32_MAX: u32 = 2147483647;
 pub const UINT8_MAX: u32 = 255;
 pub const UINT16_MAX: u32 = 65535;
 pub const UINT32_MAX: u32 = 4294967295;
-pub const UINT64_MAX: i32 = -1;
 pub const INT_LEAST8_MIN: i32 = -128;
 pub const INT_LEAST16_MIN: i32 = -32768;
 pub const INT_LEAST32_MIN: i32 = -2147483648;
-pub const INT_LEAST64_MIN: i64 = -9223372036854775808;
 pub const INT_LEAST8_MAX: u32 = 127;
 pub const INT_LEAST16_MAX: u32 = 32767;
 pub const INT_LEAST32_MAX: u32 = 2147483647;
-pub const INT_LEAST64_MAX: u64 = 9223372036854775807;
 pub const UINT_LEAST8_MAX: u32 = 255;
 pub const UINT_LEAST16_MAX: u32 = 65535;
 pub const UINT_LEAST32_MAX: u32 = 4294967295;
-pub const UINT_LEAST64_MAX: i32 = -1;
 pub const INT_FAST8_MIN: i32 = -128;
-pub const INT_FAST16_MIN: i32 = -32768;
-pub const INT_FAST32_MIN: i32 = -2147483648;
-pub const INT_FAST64_MIN: i64 = -9223372036854775808;
+pub const INT_FAST16_MIN: i64 = -9223372036854775808;
+pub const INT_FAST32_MIN: i64 = -9223372036854775808;
 pub const INT_FAST8_MAX: u32 = 127;
-pub const INT_FAST16_MAX: u32 = 32767;
-pub const INT_FAST32_MAX: u32 = 2147483647;
-pub const INT_FAST64_MAX: u64 = 9223372036854775807;
+pub const INT_FAST16_MAX: u64 = 9223372036854775807;
+pub const INT_FAST32_MAX: u64 = 9223372036854775807;
 pub const UINT_FAST8_MAX: u32 = 255;
-pub const UINT_FAST16_MAX: u32 = 65535;
-pub const UINT_FAST32_MAX: u32 = 4294967295;
-pub const UINT_FAST64_MAX: i32 = -1;
-pub const INTPTR_MAX: u64 = 9223372036854775807;
+pub const UINT_FAST16_MAX: i32 = -1;
+pub const UINT_FAST32_MAX: i32 = -1;
 pub const INTPTR_MIN: i64 = -9223372036854775808;
+pub const INTPTR_MAX: u64 = 9223372036854775807;
 pub const UINTPTR_MAX: i32 = -1;
-pub const SIZE_MAX: i32 = -1;
-pub const RSIZE_MAX: i32 = -1;
-pub const WINT_MIN: i32 = -2147483648;
-pub const WINT_MAX: u32 = 2147483647;
+pub const PTRDIFF_MIN: i64 = -9223372036854775808;
+pub const PTRDIFF_MAX: u64 = 9223372036854775807;
 pub const SIG_ATOMIC_MIN: i32 = -2147483648;
 pub const SIG_ATOMIC_MAX: u32 = 2147483647;
-pub const FP_SUPERNORMAL: u32 = 6;
+pub const SIZE_MAX: i32 = -1;
+pub const WINT_MIN: u32 = 0;
+pub const WINT_MAX: u32 = 4294967295;
+pub const _MATH_H: u32 = 1;
+pub const _BITS_LIBM_SIMD_DECL_STUBS_H: u32 = 1;
+pub const __FP_LOGB0_IS_MIN: u32 = 0;
+pub const __FP_LOGBNAN_IS_MIN: u32 = 0;
+pub const FP_ILOGB0: i32 = -2147483647;
+pub const FP_ILOGBNAN: u32 = 2147483647;
 pub const FP_FAST_FMA: u32 = 1;
 pub const FP_FAST_FMAF: u32 = 1;
-pub const FP_FAST_FMAL: u32 = 1;
-pub const FP_ILOGB0: i32 = -2147483648;
-pub const FP_ILOGBNAN: i32 = -2147483648;
+pub const __MATH_DECLARING_DOUBLE: u32 = 1;
+pub const __MATH_DECLARING_FLOATN: u32 = 0;
+pub const __MATH_DECLARE_LDOUBLE: u32 = 1;
 pub const MATH_ERRNO: u32 = 1;
 pub const MATH_ERREXCEPT: u32 = 2;
+pub const math_errhandling: u32 = 3;
 pub const M_E: f64 = 2.718281828459045;
 pub const M_LOG2E: f64 = 1.4426950408889634;
 pub const M_LOG10E: f64 = 0.4342944819032518;
@@ -620,132 +310,86 @@ pub const M_2_PI: f64 = 0.6366197723675814;
 pub const M_2_SQRTPI: f64 = 1.1283791670955126;
 pub const M_SQRT2: f64 = 1.4142135623730951;
 pub const M_SQRT1_2: f64 = 0.7071067811865476;
-pub const FP_SNAN: u32 = 1;
-pub const FP_QNAN: u32 = 1;
-pub const DOMAIN: u32 = 1;
-pub const SING: u32 = 2;
-pub const OVERFLOW: u32 = 3;
-pub const UNDERFLOW: u32 = 4;
-pub const TLOSS: u32 = 5;
-pub const PLOSS: u32 = 6;
-pub const __DARWIN_CLK_TCK: u32 = 100;
-pub const MB_LEN_MAX: u32 = 6;
-pub const CLK_TCK: u32 = 100;
-pub const CHAR_BIT: u32 = 8;
-pub const SCHAR_MAX: u32 = 127;
-pub const SCHAR_MIN: i32 = -128;
-pub const UCHAR_MAX: u32 = 255;
-pub const CHAR_MAX: u32 = 127;
-pub const CHAR_MIN: i32 = -128;
-pub const USHRT_MAX: u32 = 65535;
-pub const SHRT_MAX: u32 = 32767;
-pub const SHRT_MIN: i32 = -32768;
-pub const UINT_MAX: u32 = 4294967295;
-pub const INT_MAX: u32 = 2147483647;
-pub const INT_MIN: i32 = -2147483648;
-pub const ULONG_MAX: i32 = -1;
-pub const LONG_MAX: u64 = 9223372036854775807;
-pub const LONG_MIN: i64 = -9223372036854775808;
-pub const ULLONG_MAX: i32 = -1;
-pub const LLONG_MAX: u64 = 9223372036854775807;
-pub const LLONG_MIN: i64 = -9223372036854775808;
-pub const LONG_BIT: u32 = 64;
-pub const SSIZE_MAX: u64 = 9223372036854775807;
-pub const WORD_BIT: u32 = 32;
-pub const SIZE_T_MAX: i32 = -1;
-pub const UQUAD_MAX: i32 = -1;
-pub const QUAD_MAX: u64 = 9223372036854775807;
-pub const QUAD_MIN: i64 = -9223372036854775808;
-pub const ARG_MAX: u32 = 1048576;
-pub const CHILD_MAX: u32 = 266;
-pub const GID_MAX: u32 = 2147483647;
-pub const LINK_MAX: u32 = 32767;
-pub const MAX_CANON: u32 = 1024;
-pub const MAX_INPUT: u32 = 1024;
-pub const NAME_MAX: u32 = 255;
-pub const NGROUPS_MAX: u32 = 16;
-pub const UID_MAX: u32 = 2147483647;
-pub const OPEN_MAX: u32 = 10240;
-pub const PATH_MAX: u32 = 1024;
-pub const PIPE_BUF: u32 = 512;
-pub const BC_BASE_MAX: u32 = 99;
-pub const BC_DIM_MAX: u32 = 2048;
-pub const BC_SCALE_MAX: u32 = 99;
-pub const BC_STRING_MAX: u32 = 1000;
-pub const CHARCLASS_NAME_MAX: u32 = 14;
-pub const COLL_WEIGHTS_MAX: u32 = 2;
-pub const EQUIV_CLASS_MAX: u32 = 2;
-pub const EXPR_NEST_MAX: u32 = 32;
-pub const LINE_MAX: u32 = 2048;
-pub const RE_DUP_MAX: u32 = 255;
-pub const NZERO: u32 = 20;
+pub const _LIBC_LIMITS_H_: u32 = 1;
+pub const MB_LEN_MAX: u32 = 16;
+pub const _BITS_POSIX1_LIM_H: u32 = 1;
+pub const _POSIX_AIO_LISTIO_MAX: u32 = 2;
+pub const _POSIX_AIO_MAX: u32 = 1;
 pub const _POSIX_ARG_MAX: u32 = 4096;
 pub const _POSIX_CHILD_MAX: u32 = 25;
+pub const _POSIX_DELAYTIMER_MAX: u32 = 32;
+pub const _POSIX_HOST_NAME_MAX: u32 = 255;
 pub const _POSIX_LINK_MAX: u32 = 8;
+pub const _POSIX_LOGIN_NAME_MAX: u32 = 9;
 pub const _POSIX_MAX_CANON: u32 = 255;
 pub const _POSIX_MAX_INPUT: u32 = 255;
+pub const _POSIX_MQ_OPEN_MAX: u32 = 8;
+pub const _POSIX_MQ_PRIO_MAX: u32 = 32;
 pub const _POSIX_NAME_MAX: u32 = 14;
 pub const _POSIX_NGROUPS_MAX: u32 = 8;
 pub const _POSIX_OPEN_MAX: u32 = 20;
 pub const _POSIX_PATH_MAX: u32 = 256;
 pub const _POSIX_PIPE_BUF: u32 = 512;
-pub const _POSIX_SSIZE_MAX: u32 = 32767;
-pub const _POSIX_STREAM_MAX: u32 = 8;
-pub const _POSIX_TZNAME_MAX: u32 = 6;
-pub const _POSIX2_BC_BASE_MAX: u32 = 99;
-pub const _POSIX2_BC_DIM_MAX: u32 = 2048;
-pub const _POSIX2_BC_SCALE_MAX: u32 = 99;
-pub const _POSIX2_BC_STRING_MAX: u32 = 1000;
-pub const _POSIX2_EQUIV_CLASS_MAX: u32 = 2;
-pub const _POSIX2_EXPR_NEST_MAX: u32 = 32;
-pub const _POSIX2_LINE_MAX: u32 = 2048;
-pub const _POSIX2_RE_DUP_MAX: u32 = 255;
-pub const _POSIX_AIO_LISTIO_MAX: u32 = 2;
-pub const _POSIX_AIO_MAX: u32 = 1;
-pub const _POSIX_DELAYTIMER_MAX: u32 = 32;
-pub const _POSIX_MQ_OPEN_MAX: u32 = 8;
-pub const _POSIX_MQ_PRIO_MAX: u32 = 32;
+pub const _POSIX_RE_DUP_MAX: u32 = 255;
 pub const _POSIX_RTSIG_MAX: u32 = 8;
 pub const _POSIX_SEM_NSEMS_MAX: u32 = 256;
 pub const _POSIX_SEM_VALUE_MAX: u32 = 32767;
 pub const _POSIX_SIGQUEUE_MAX: u32 = 32;
-pub const _POSIX_TIMER_MAX: u32 = 32;
-pub const _POSIX_CLOCKRES_MIN: u32 = 20000000;
-pub const _POSIX_THREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
-pub const _POSIX_THREAD_KEYS_MAX: u32 = 128;
-pub const _POSIX_THREAD_THREADS_MAX: u32 = 64;
-pub const PTHREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
-pub const PTHREAD_KEYS_MAX: u32 = 512;
-pub const PTHREAD_STACK_MIN: u32 = 16384;
-pub const _POSIX_HOST_NAME_MAX: u32 = 255;
-pub const _POSIX_LOGIN_NAME_MAX: u32 = 9;
-pub const _POSIX_SS_REPL_MAX: u32 = 4;
+pub const _POSIX_SSIZE_MAX: u32 = 32767;
+pub const _POSIX_STREAM_MAX: u32 = 8;
 pub const _POSIX_SYMLINK_MAX: u32 = 255;
 pub const _POSIX_SYMLOOP_MAX: u32 = 8;
-pub const _POSIX_TRACE_EVENT_NAME_MAX: u32 = 30;
-pub const _POSIX_TRACE_NAME_MAX: u32 = 8;
-pub const _POSIX_TRACE_SYS_MAX: u32 = 8;
-pub const _POSIX_TRACE_USER_EVENT_MAX: u32 = 32;
+pub const _POSIX_TIMER_MAX: u32 = 32;
 pub const _POSIX_TTY_NAME_MAX: u32 = 9;
-pub const _POSIX2_CHARCLASS_NAME_MAX: u32 = 14;
+pub const _POSIX_TZNAME_MAX: u32 = 6;
+pub const _POSIX_CLOCKRES_MIN: u32 = 20000000;
+pub const NR_OPEN: u32 = 1024;
+pub const NGROUPS_MAX: u32 = 65536;
+pub const ARG_MAX: u32 = 131072;
+pub const LINK_MAX: u32 = 127;
+pub const MAX_CANON: u32 = 255;
+pub const MAX_INPUT: u32 = 255;
+pub const NAME_MAX: u32 = 255;
+pub const PATH_MAX: u32 = 4096;
+pub const PIPE_BUF: u32 = 4096;
+pub const XATTR_NAME_MAX: u32 = 255;
+pub const XATTR_SIZE_MAX: u32 = 65536;
+pub const XATTR_LIST_MAX: u32 = 65536;
+pub const RTSIG_MAX: u32 = 32;
+pub const _POSIX_THREAD_KEYS_MAX: u32 = 128;
+pub const PTHREAD_KEYS_MAX: u32 = 1024;
+pub const _POSIX_THREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
+pub const PTHREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
+pub const _POSIX_THREAD_THREADS_MAX: u32 = 64;
+pub const AIO_PRIO_DELTA_MAX: u32 = 20;
+pub const PTHREAD_STACK_MIN: u32 = 131072;
+pub const DELAYTIMER_MAX: u32 = 2147483647;
+pub const TTY_NAME_MAX: u32 = 32;
+pub const LOGIN_NAME_MAX: u32 = 256;
+pub const HOST_NAME_MAX: u32 = 64;
+pub const MQ_PRIO_MAX: u32 = 32768;
+pub const SEM_VALUE_MAX: u32 = 2147483647;
+pub const _BITS_POSIX2_LIM_H: u32 = 1;
+pub const _POSIX2_BC_BASE_MAX: u32 = 99;
+pub const _POSIX2_BC_DIM_MAX: u32 = 2048;
+pub const _POSIX2_BC_SCALE_MAX: u32 = 99;
+pub const _POSIX2_BC_STRING_MAX: u32 = 1000;
 pub const _POSIX2_COLL_WEIGHTS_MAX: u32 = 2;
-pub const _POSIX_RE_DUP_MAX: u32 = 255;
-pub const OFF_MIN: i64 = -9223372036854775808;
-pub const OFF_MAX: u64 = 9223372036854775807;
-pub const PASS_MAX: u32 = 128;
-pub const NL_ARGMAX: u32 = 9;
-pub const NL_LANGMAX: u32 = 14;
-pub const NL_MSGMAX: u32 = 32767;
-pub const NL_NMAX: u32 = 1;
-pub const NL_SETMAX: u32 = 255;
-pub const NL_TEXTMAX: u32 = 2048;
-pub const _XOPEN_IOV_MAX: u32 = 16;
-pub const IOV_MAX: u32 = 1024;
-pub const _XOPEN_NAME_MAX: u32 = 255;
-pub const _XOPEN_PATH_MAX: u32 = 1024;
-pub const FLT_HAS_SUBNORM: u32 = 1;
-pub const DBL_HAS_SUBNORM: u32 = 1;
-pub const LDBL_HAS_SUBNORM: u32 = 1;
+pub const _POSIX2_EXPR_NEST_MAX: u32 = 32;
+pub const _POSIX2_LINE_MAX: u32 = 2048;
+pub const _POSIX2_RE_DUP_MAX: u32 = 255;
+pub const _POSIX2_CHARCLASS_NAME_MAX: u32 = 14;
+pub const BC_BASE_MAX: u32 = 99;
+pub const BC_DIM_MAX: u32 = 2048;
+pub const BC_SCALE_MAX: u32 = 99;
+pub const BC_STRING_MAX: u32 = 1000;
+pub const COLL_WEIGHTS_MAX: u32 = 255;
+pub const EXPR_NEST_MAX: u32 = 32;
+pub const LINE_MAX: u32 = 2048;
+pub const CHARCLASS_NAME_MAX: u32 = 2048;
+pub const RE_DUP_MAX: u32 = 32767;
+pub const CHAR_MIN: u32 = 0;
+pub const _ASSERT_H: u32 = 1;
 pub const SCIP_BUILD_TYPE: &[u8; 8] = b"Release\0";
 pub const SCIP_VERSION_MAJOR: u32 = 10;
 pub const SCIP_VERSION_MINOR: u32 = 0;
@@ -759,8 +403,6 @@ pub const SCIP_VERSION_SUB: u32 = 0;
 pub const SCIP_SUBVERSION: u32 = 0;
 pub const SCIP_APIVERSION: u32 = 156;
 pub const SCIP_COPYRIGHT: &[u8; 52] = b"Copyright (c) 2002-2026 Zuse Institute Berlin (ZIB)\0";
-pub const SCIP_LONGINT_MAX: u64 = 9223372036854775807;
-pub const SCIP_LONGINT_MIN: i64 = -9223372036854775808;
 pub const SCIP_LONGINT_FORMAT: &[u8; 4] = b"lld\0";
 pub const SCIP_REAL_UNITROUNDOFF: f64 = 0.00000000000000011102230246251565;
 pub const SCIP_REAL_FORMAT: &[u8; 3] = b"lf\0";
@@ -795,221 +437,64 @@ pub const SCIP_DEFAULT_MEM_ARRAYGROWFAC: f64 = 1.2;
 pub const SCIP_DEFAULT_MEM_ARRAYGROWINIT: u32 = 4;
 pub const SCIP_MAXTREEDEPTH: u32 = 1073741822;
 pub const SCIP_PROBINGSCORE_PENALTYRATIO: u32 = 2;
-pub const __DARWIN_NSIG: u32 = 32;
-pub const NSIG: u32 = 32;
-pub const _ARM_SIGNAL_: u32 = 1;
-pub const SIGHUP: u32 = 1;
-pub const SIGINT: u32 = 2;
-pub const SIGQUIT: u32 = 3;
-pub const SIGILL: u32 = 4;
-pub const SIGTRAP: u32 = 5;
-pub const SIGABRT: u32 = 6;
-pub const SIGIOT: u32 = 6;
-pub const SIGEMT: u32 = 7;
-pub const SIGFPE: u32 = 8;
-pub const SIGKILL: u32 = 9;
-pub const SIGBUS: u32 = 10;
-pub const SIGSEGV: u32 = 11;
-pub const SIGSYS: u32 = 12;
-pub const SIGPIPE: u32 = 13;
-pub const SIGALRM: u32 = 14;
-pub const SIGTERM: u32 = 15;
-pub const SIGURG: u32 = 16;
-pub const SIGSTOP: u32 = 17;
-pub const SIGTSTP: u32 = 18;
-pub const SIGCONT: u32 = 19;
-pub const SIGCHLD: u32 = 20;
-pub const SIGTTIN: u32 = 21;
-pub const SIGTTOU: u32 = 22;
-pub const SIGIO: u32 = 23;
-pub const SIGXCPU: u32 = 24;
-pub const SIGXFSZ: u32 = 25;
-pub const SIGVTALRM: u32 = 26;
-pub const SIGPROF: u32 = 27;
-pub const SIGWINCH: u32 = 28;
-pub const SIGINFO: u32 = 29;
-pub const SIGUSR1: u32 = 30;
-pub const SIGUSR2: u32 = 31;
-pub const __DARWIN_OPAQUE_ARM_THREAD_STATE64: u32 = 0;
-pub const SIGEV_NONE: u32 = 0;
-pub const SIGEV_SIGNAL: u32 = 1;
-pub const SIGEV_THREAD: u32 = 3;
-pub const ILL_NOOP: u32 = 0;
-pub const ILL_ILLOPC: u32 = 1;
-pub const ILL_ILLTRP: u32 = 2;
-pub const ILL_PRVOPC: u32 = 3;
-pub const ILL_ILLOPN: u32 = 4;
-pub const ILL_ILLADR: u32 = 5;
-pub const ILL_PRVREG: u32 = 6;
-pub const ILL_COPROC: u32 = 7;
-pub const ILL_BADSTK: u32 = 8;
-pub const FPE_NOOP: u32 = 0;
-pub const FPE_FLTDIV: u32 = 1;
-pub const FPE_FLTOVF: u32 = 2;
-pub const FPE_FLTUND: u32 = 3;
-pub const FPE_FLTRES: u32 = 4;
-pub const FPE_FLTINV: u32 = 5;
-pub const FPE_FLTSUB: u32 = 6;
-pub const FPE_INTDIV: u32 = 7;
-pub const FPE_INTOVF: u32 = 8;
-pub const SEGV_NOOP: u32 = 0;
-pub const SEGV_MAPERR: u32 = 1;
-pub const SEGV_ACCERR: u32 = 2;
-pub const BUS_NOOP: u32 = 0;
-pub const BUS_ADRALN: u32 = 1;
-pub const BUS_ADRERR: u32 = 2;
-pub const BUS_OBJERR: u32 = 3;
-pub const TRAP_BRKPT: u32 = 1;
-pub const TRAP_TRACE: u32 = 2;
-pub const CLD_NOOP: u32 = 0;
-pub const CLD_EXITED: u32 = 1;
-pub const CLD_KILLED: u32 = 2;
-pub const CLD_DUMPED: u32 = 3;
-pub const CLD_TRAPPED: u32 = 4;
-pub const CLD_STOPPED: u32 = 5;
-pub const CLD_CONTINUED: u32 = 6;
-pub const POLL_IN: u32 = 1;
-pub const POLL_OUT: u32 = 2;
-pub const POLL_MSG: u32 = 3;
-pub const POLL_ERR: u32 = 4;
-pub const POLL_PRI: u32 = 5;
-pub const POLL_HUP: u32 = 6;
-pub const SA_ONSTACK: u32 = 1;
-pub const SA_RESTART: u32 = 2;
-pub const SA_RESETHAND: u32 = 4;
-pub const SA_NOCLDSTOP: u32 = 8;
-pub const SA_NODEFER: u32 = 16;
-pub const SA_NOCLDWAIT: u32 = 32;
-pub const SA_SIGINFO: u32 = 64;
-pub const SA_USERTRAMP: u32 = 256;
-pub const SA_64REGSET: u32 = 512;
-pub const SA_USERSPACE_MASK: u32 = 127;
-pub const SIG_BLOCK: u32 = 1;
-pub const SIG_UNBLOCK: u32 = 2;
-pub const SIG_SETMASK: u32 = 3;
-pub const SI_USER: u32 = 65537;
-pub const SI_QUEUE: u32 = 65538;
-pub const SI_TIMER: u32 = 65539;
-pub const SI_ASYNCIO: u32 = 65540;
-pub const SI_MESGQ: u32 = 65541;
-pub const SS_ONSTACK: u32 = 1;
-pub const SS_DISABLE: u32 = 4;
-pub const MINSIGSTKSZ: u32 = 32768;
-pub const SIGSTKSZ: u32 = 131072;
-pub const SV_ONSTACK: u32 = 1;
-pub const SV_INTERRUPT: u32 = 2;
-pub const SV_RESETHAND: u32 = 4;
-pub const SV_NODEFER: u32 = 16;
-pub const SV_NOCLDSTOP: u32 = 8;
-pub const SV_SIGINFO: u32 = 64;
-pub const PRIO_PROCESS: u32 = 0;
-pub const PRIO_PGRP: u32 = 1;
-pub const PRIO_USER: u32 = 2;
-pub const PRIO_DARWIN_THREAD: u32 = 3;
-pub const PRIO_DARWIN_PROCESS: u32 = 4;
-pub const PRIO_MIN: i32 = -20;
-pub const PRIO_MAX: u32 = 20;
-pub const PRIO_DARWIN_BG: u32 = 4096;
-pub const PRIO_DARWIN_NONUI: u32 = 4097;
-pub const RUSAGE_SELF: u32 = 0;
-pub const RUSAGE_CHILDREN: i32 = -1;
-pub const RUSAGE_INFO_V0: u32 = 0;
-pub const RUSAGE_INFO_V1: u32 = 1;
-pub const RUSAGE_INFO_V2: u32 = 2;
-pub const RUSAGE_INFO_V3: u32 = 3;
-pub const RUSAGE_INFO_V4: u32 = 4;
-pub const RUSAGE_INFO_V5: u32 = 5;
-pub const RUSAGE_INFO_V6: u32 = 6;
-pub const RUSAGE_INFO_CURRENT: u32 = 6;
-pub const RU_PROC_RUNS_RESLIDE: u32 = 1;
-pub const RLIMIT_CPU: u32 = 0;
-pub const RLIMIT_FSIZE: u32 = 1;
-pub const RLIMIT_DATA: u32 = 2;
-pub const RLIMIT_STACK: u32 = 3;
-pub const RLIMIT_CORE: u32 = 4;
-pub const RLIMIT_AS: u32 = 5;
-pub const RLIMIT_RSS: u32 = 5;
-pub const RLIMIT_MEMLOCK: u32 = 6;
-pub const RLIMIT_NPROC: u32 = 7;
-pub const RLIMIT_NOFILE: u32 = 8;
-pub const RLIM_NLIMITS: u32 = 9;
-pub const _RLIMIT_POSIX_FLAG: u32 = 4096;
-pub const RLIMIT_WAKEUPS_MONITOR: u32 = 1;
-pub const RLIMIT_CPU_USAGE_MONITOR: u32 = 2;
-pub const RLIMIT_THREAD_CPULIMITS: u32 = 3;
-pub const RLIMIT_FOOTPRINT_INTERVAL: u32 = 4;
-pub const WAKEMON_ENABLE: u32 = 1;
-pub const WAKEMON_DISABLE: u32 = 2;
-pub const WAKEMON_GET_PARAMS: u32 = 4;
-pub const WAKEMON_SET_DEFAULTS: u32 = 8;
-pub const WAKEMON_MAKE_FATAL: u32 = 16;
-pub const CPUMON_MAKE_FATAL: u32 = 4096;
-pub const FOOTPRINT_INTERVAL_RESET: u32 = 1;
-pub const IOPOL_TYPE_DISK: u32 = 0;
-pub const IOPOL_TYPE_VFS_ATIME_UPDATES: u32 = 2;
-pub const IOPOL_TYPE_VFS_MATERIALIZE_DATALESS_FILES: u32 = 3;
-pub const IOPOL_TYPE_VFS_STATFS_NO_DATA_VOLUME: u32 = 4;
-pub const IOPOL_TYPE_VFS_TRIGGER_RESOLVE: u32 = 5;
-pub const IOPOL_TYPE_VFS_IGNORE_CONTENT_PROTECTION: u32 = 6;
-pub const IOPOL_TYPE_VFS_IGNORE_PERMISSIONS: u32 = 7;
-pub const IOPOL_TYPE_VFS_SKIP_MTIME_UPDATE: u32 = 8;
-pub const IOPOL_TYPE_VFS_ALLOW_LOW_SPACE_WRITES: u32 = 9;
-pub const IOPOL_TYPE_VFS_DISALLOW_RW_FOR_O_EVTONLY: u32 = 10;
-pub const IOPOL_SCOPE_PROCESS: u32 = 0;
-pub const IOPOL_SCOPE_THREAD: u32 = 1;
-pub const IOPOL_SCOPE_DARWIN_BG: u32 = 2;
-pub const IOPOL_DEFAULT: u32 = 0;
-pub const IOPOL_IMPORTANT: u32 = 1;
-pub const IOPOL_PASSIVE: u32 = 2;
-pub const IOPOL_THROTTLE: u32 = 3;
-pub const IOPOL_UTILITY: u32 = 4;
-pub const IOPOL_STANDARD: u32 = 5;
-pub const IOPOL_APPLICATION: u32 = 5;
-pub const IOPOL_NORMAL: u32 = 1;
-pub const IOPOL_ATIME_UPDATES_DEFAULT: u32 = 0;
-pub const IOPOL_ATIME_UPDATES_OFF: u32 = 1;
-pub const IOPOL_MATERIALIZE_DATALESS_FILES_DEFAULT: u32 = 0;
-pub const IOPOL_MATERIALIZE_DATALESS_FILES_OFF: u32 = 1;
-pub const IOPOL_MATERIALIZE_DATALESS_FILES_ON: u32 = 2;
-pub const IOPOL_VFS_STATFS_NO_DATA_VOLUME_DEFAULT: u32 = 0;
-pub const IOPOL_VFS_STATFS_FORCE_NO_DATA_VOLUME: u32 = 1;
-pub const IOPOL_VFS_TRIGGER_RESOLVE_DEFAULT: u32 = 0;
-pub const IOPOL_VFS_TRIGGER_RESOLVE_OFF: u32 = 1;
-pub const IOPOL_VFS_CONTENT_PROTECTION_DEFAULT: u32 = 0;
-pub const IOPOL_VFS_CONTENT_PROTECTION_IGNORE: u32 = 1;
-pub const IOPOL_VFS_IGNORE_PERMISSIONS_OFF: u32 = 0;
-pub const IOPOL_VFS_IGNORE_PERMISSIONS_ON: u32 = 1;
-pub const IOPOL_VFS_SKIP_MTIME_UPDATE_OFF: u32 = 0;
-pub const IOPOL_VFS_SKIP_MTIME_UPDATE_ON: u32 = 1;
-pub const IOPOL_VFS_ALLOW_LOW_SPACE_WRITES_OFF: u32 = 0;
-pub const IOPOL_VFS_ALLOW_LOW_SPACE_WRITES_ON: u32 = 1;
-pub const IOPOL_VFS_DISALLOW_RW_FOR_O_EVTONLY_DEFAULT: u32 = 0;
-pub const IOPOL_VFS_DISALLOW_RW_FOR_O_EVTONLY_ON: u32 = 1;
-pub const IOPOL_VFS_NOCACHE_WRITE_FS_BLKSIZE_DEFAULT: u32 = 0;
-pub const IOPOL_VFS_NOCACHE_WRITE_FS_BLKSIZE_ON: u32 = 1;
+pub const _STDLIB_H: u32 = 1;
 pub const WNOHANG: u32 = 1;
 pub const WUNTRACED: u32 = 2;
-pub const WCOREFLAG: u32 = 128;
-pub const _WSTOPPED: u32 = 127;
+pub const WSTOPPED: u32 = 2;
 pub const WEXITED: u32 = 4;
-pub const WSTOPPED: u32 = 8;
-pub const WCONTINUED: u32 = 16;
-pub const WNOWAIT: u32 = 32;
-pub const WAIT_ANY: i32 = -1;
-pub const WAIT_MYPGRP: u32 = 0;
-pub const _QUAD_HIGHWORD: u32 = 1;
-pub const _QUAD_LOWWORD: u32 = 0;
-pub const __DARWIN_LITTLE_ENDIAN: u32 = 1234;
-pub const __DARWIN_BIG_ENDIAN: u32 = 4321;
-pub const __DARWIN_PDP_ENDIAN: u32 = 3412;
-pub const __DARWIN_BYTE_ORDER: u32 = 1234;
+pub const WCONTINUED: u32 = 8;
+pub const WNOWAIT: u32 = 16777216;
+pub const __WNOTHREAD: u32 = 536870912;
+pub const __WALL: u32 = 1073741824;
+pub const __WCLONE: u32 = 2147483648;
+pub const __W_CONTINUED: u32 = 65535;
+pub const __WCOREFLAG: u32 = 128;
+pub const __ldiv_t_defined: u32 = 1;
+pub const __lldiv_t_defined: u32 = 1;
+pub const RAND_MAX: u32 = 2147483647;
+pub const EXIT_FAILURE: u32 = 1;
+pub const EXIT_SUCCESS: u32 = 0;
+pub const _SYS_TYPES_H: u32 = 1;
+pub const __clock_t_defined: u32 = 1;
+pub const __clockid_t_defined: u32 = 1;
+pub const __time_t_defined: u32 = 1;
+pub const __timer_t_defined: u32 = 1;
+pub const __BIT_TYPES_DEFINED__: u32 = 1;
+pub const _ENDIAN_H: u32 = 1;
+pub const _BITS_ENDIAN_H: u32 = 1;
+pub const __LITTLE_ENDIAN: u32 = 1234;
+pub const __BIG_ENDIAN: u32 = 4321;
+pub const __PDP_ENDIAN: u32 = 3412;
+pub const _BITS_ENDIANNESS_H: u32 = 1;
+pub const __BYTE_ORDER: u32 = 1234;
+pub const __FLOAT_WORD_ORDER: u32 = 1234;
 pub const LITTLE_ENDIAN: u32 = 1234;
 pub const BIG_ENDIAN: u32 = 4321;
 pub const PDP_ENDIAN: u32 = 3412;
 pub const BYTE_ORDER: u32 = 1234;
-pub const EXIT_FAILURE: u32 = 1;
-pub const EXIT_SUCCESS: u32 = 0;
-pub const RAND_MAX: u32 = 2147483647;
+pub const _BITS_BYTESWAP_H: u32 = 1;
+pub const _BITS_UINTN_IDENTITY_H: u32 = 1;
+pub const _SYS_SELECT_H: u32 = 1;
+pub const __sigset_t_defined: u32 = 1;
+pub const __timeval_defined: u32 = 1;
+pub const _STRUCT_TIMESPEC: u32 = 1;
+pub const FD_SETSIZE: u32 = 1024;
+pub const _BITS_PTHREADTYPES_COMMON_H: u32 = 1;
+pub const _THREAD_SHARED_TYPES_H: u32 = 1;
+pub const _BITS_PTHREADTYPES_ARCH_H: u32 = 1;
+pub const __SIZEOF_PTHREAD_ATTR_T: u32 = 64;
+pub const __SIZEOF_PTHREAD_MUTEX_T: u32 = 48;
+pub const __SIZEOF_PTHREAD_MUTEXATTR_T: u32 = 8;
+pub const __SIZEOF_PTHREAD_CONDATTR_T: u32 = 8;
+pub const __SIZEOF_PTHREAD_RWLOCK_T: u32 = 56;
+pub const __SIZEOF_PTHREAD_BARRIER_T: u32 = 32;
+pub const __SIZEOF_PTHREAD_BARRIERATTR_T: u32 = 8;
+pub const __SIZEOF_PTHREAD_COND_T: u32 = 48;
+pub const __SIZEOF_PTHREAD_RWLOCKATTR_T: u32 = 8;
+pub const _THREAD_MUTEX_INTERNAL_H: u32 = 1;
+pub const __PTHREAD_MUTEX_HAVE_PREV: u32 = 1;
+pub const __have_pthread_attr_t: u32 = 1;
+pub const _ALLOCA_H: u32 = 1;
 pub const SCIP_PRESOLTIMING_NONE: u32 = 2;
 pub const SCIP_PRESOLTIMING_FAST: u32 = 4;
 pub const SCIP_PRESOLTIMING_MEDIUM: u32 = 8;
@@ -1037,166 +522,165 @@ pub const SCIP_HEURTIMING_DURINGPRESOLLOOP: u32 = 512;
 pub const SCIP_HEURTIMING_AFTERPROPLOOP: u32 = 1024;
 pub const SCIP_HEURTIMING_AFTERNODE: u32 = 24;
 pub const SCIP_HEURTIMING_AFTERPLUNGE: u32 = 96;
-pub const __PRI_8_LENGTH_MODIFIER__: &[u8; 3] = b"hh\0";
-pub const __PRI_64_LENGTH_MODIFIER__: &[u8; 3] = b"ll\0";
-pub const __SCN_64_LENGTH_MODIFIER__: &[u8; 3] = b"ll\0";
-pub const __PRI_MAX_LENGTH_MODIFIER__: &[u8; 2] = b"j\0";
-pub const __SCN_MAX_LENGTH_MODIFIER__: &[u8; 2] = b"j\0";
-pub const PRId8: &[u8; 4] = b"hhd\0";
-pub const PRIi8: &[u8; 4] = b"hhi\0";
-pub const PRIo8: &[u8; 4] = b"hho\0";
-pub const PRIu8: &[u8; 4] = b"hhu\0";
-pub const PRIx8: &[u8; 4] = b"hhx\0";
-pub const PRIX8: &[u8; 4] = b"hhX\0";
-pub const PRId16: &[u8; 3] = b"hd\0";
-pub const PRIi16: &[u8; 3] = b"hi\0";
-pub const PRIo16: &[u8; 3] = b"ho\0";
-pub const PRIu16: &[u8; 3] = b"hu\0";
-pub const PRIx16: &[u8; 3] = b"hx\0";
-pub const PRIX16: &[u8; 3] = b"hX\0";
+pub const _INTTYPES_H: u32 = 1;
+pub const ____gwchar_t_defined: u32 = 1;
+pub const __PRI64_PREFIX: &[u8; 2] = b"l\0";
+pub const __PRIPTR_PREFIX: &[u8; 2] = b"l\0";
+pub const PRId8: &[u8; 2] = b"d\0";
+pub const PRId16: &[u8; 2] = b"d\0";
 pub const PRId32: &[u8; 2] = b"d\0";
-pub const PRIi32: &[u8; 2] = b"i\0";
-pub const PRIo32: &[u8; 2] = b"o\0";
-pub const PRIu32: &[u8; 2] = b"u\0";
-pub const PRIx32: &[u8; 2] = b"x\0";
-pub const PRIX32: &[u8; 2] = b"X\0";
-pub const PRId64: &[u8; 4] = b"lld\0";
-pub const PRIi64: &[u8; 4] = b"lli\0";
-pub const PRIo64: &[u8; 4] = b"llo\0";
-pub const PRIu64: &[u8; 4] = b"llu\0";
-pub const PRIx64: &[u8; 4] = b"llx\0";
-pub const PRIX64: &[u8; 4] = b"llX\0";
-pub const PRIdLEAST8: &[u8; 4] = b"hhd\0";
-pub const PRIiLEAST8: &[u8; 4] = b"hhi\0";
-pub const PRIoLEAST8: &[u8; 4] = b"hho\0";
-pub const PRIuLEAST8: &[u8; 4] = b"hhu\0";
-pub const PRIxLEAST8: &[u8; 4] = b"hhx\0";
-pub const PRIXLEAST8: &[u8; 4] = b"hhX\0";
-pub const PRIdLEAST16: &[u8; 3] = b"hd\0";
-pub const PRIiLEAST16: &[u8; 3] = b"hi\0";
-pub const PRIoLEAST16: &[u8; 3] = b"ho\0";
-pub const PRIuLEAST16: &[u8; 3] = b"hu\0";
-pub const PRIxLEAST16: &[u8; 3] = b"hx\0";
-pub const PRIXLEAST16: &[u8; 3] = b"hX\0";
+pub const PRId64: &[u8; 3] = b"ld\0";
+pub const PRIdLEAST8: &[u8; 2] = b"d\0";
+pub const PRIdLEAST16: &[u8; 2] = b"d\0";
 pub const PRIdLEAST32: &[u8; 2] = b"d\0";
+pub const PRIdLEAST64: &[u8; 3] = b"ld\0";
+pub const PRIdFAST8: &[u8; 2] = b"d\0";
+pub const PRIdFAST16: &[u8; 3] = b"ld\0";
+pub const PRIdFAST32: &[u8; 3] = b"ld\0";
+pub const PRIdFAST64: &[u8; 3] = b"ld\0";
+pub const PRIi8: &[u8; 2] = b"i\0";
+pub const PRIi16: &[u8; 2] = b"i\0";
+pub const PRIi32: &[u8; 2] = b"i\0";
+pub const PRIi64: &[u8; 3] = b"li\0";
+pub const PRIiLEAST8: &[u8; 2] = b"i\0";
+pub const PRIiLEAST16: &[u8; 2] = b"i\0";
 pub const PRIiLEAST32: &[u8; 2] = b"i\0";
+pub const PRIiLEAST64: &[u8; 3] = b"li\0";
+pub const PRIiFAST8: &[u8; 2] = b"i\0";
+pub const PRIiFAST16: &[u8; 3] = b"li\0";
+pub const PRIiFAST32: &[u8; 3] = b"li\0";
+pub const PRIiFAST64: &[u8; 3] = b"li\0";
+pub const PRIo8: &[u8; 2] = b"o\0";
+pub const PRIo16: &[u8; 2] = b"o\0";
+pub const PRIo32: &[u8; 2] = b"o\0";
+pub const PRIo64: &[u8; 3] = b"lo\0";
+pub const PRIoLEAST8: &[u8; 2] = b"o\0";
+pub const PRIoLEAST16: &[u8; 2] = b"o\0";
 pub const PRIoLEAST32: &[u8; 2] = b"o\0";
+pub const PRIoLEAST64: &[u8; 3] = b"lo\0";
+pub const PRIoFAST8: &[u8; 2] = b"o\0";
+pub const PRIoFAST16: &[u8; 3] = b"lo\0";
+pub const PRIoFAST32: &[u8; 3] = b"lo\0";
+pub const PRIoFAST64: &[u8; 3] = b"lo\0";
+pub const PRIu8: &[u8; 2] = b"u\0";
+pub const PRIu16: &[u8; 2] = b"u\0";
+pub const PRIu32: &[u8; 2] = b"u\0";
+pub const PRIu64: &[u8; 3] = b"lu\0";
+pub const PRIuLEAST8: &[u8; 2] = b"u\0";
+pub const PRIuLEAST16: &[u8; 2] = b"u\0";
 pub const PRIuLEAST32: &[u8; 2] = b"u\0";
+pub const PRIuLEAST64: &[u8; 3] = b"lu\0";
+pub const PRIuFAST8: &[u8; 2] = b"u\0";
+pub const PRIuFAST16: &[u8; 3] = b"lu\0";
+pub const PRIuFAST32: &[u8; 3] = b"lu\0";
+pub const PRIuFAST64: &[u8; 3] = b"lu\0";
+pub const PRIx8: &[u8; 2] = b"x\0";
+pub const PRIx16: &[u8; 2] = b"x\0";
+pub const PRIx32: &[u8; 2] = b"x\0";
+pub const PRIx64: &[u8; 3] = b"lx\0";
+pub const PRIxLEAST8: &[u8; 2] = b"x\0";
+pub const PRIxLEAST16: &[u8; 2] = b"x\0";
 pub const PRIxLEAST32: &[u8; 2] = b"x\0";
+pub const PRIxLEAST64: &[u8; 3] = b"lx\0";
+pub const PRIxFAST8: &[u8; 2] = b"x\0";
+pub const PRIxFAST16: &[u8; 3] = b"lx\0";
+pub const PRIxFAST32: &[u8; 3] = b"lx\0";
+pub const PRIxFAST64: &[u8; 3] = b"lx\0";
+pub const PRIX8: &[u8; 2] = b"X\0";
+pub const PRIX16: &[u8; 2] = b"X\0";
+pub const PRIX32: &[u8; 2] = b"X\0";
+pub const PRIX64: &[u8; 3] = b"lX\0";
+pub const PRIXLEAST8: &[u8; 2] = b"X\0";
+pub const PRIXLEAST16: &[u8; 2] = b"X\0";
 pub const PRIXLEAST32: &[u8; 2] = b"X\0";
-pub const PRIdLEAST64: &[u8; 4] = b"lld\0";
-pub const PRIiLEAST64: &[u8; 4] = b"lli\0";
-pub const PRIoLEAST64: &[u8; 4] = b"llo\0";
-pub const PRIuLEAST64: &[u8; 4] = b"llu\0";
-pub const PRIxLEAST64: &[u8; 4] = b"llx\0";
-pub const PRIXLEAST64: &[u8; 4] = b"llX\0";
-pub const PRIdFAST8: &[u8; 4] = b"hhd\0";
-pub const PRIiFAST8: &[u8; 4] = b"hhi\0";
-pub const PRIoFAST8: &[u8; 4] = b"hho\0";
-pub const PRIuFAST8: &[u8; 4] = b"hhu\0";
-pub const PRIxFAST8: &[u8; 4] = b"hhx\0";
-pub const PRIXFAST8: &[u8; 4] = b"hhX\0";
-pub const PRIdFAST16: &[u8; 3] = b"hd\0";
-pub const PRIiFAST16: &[u8; 3] = b"hi\0";
-pub const PRIoFAST16: &[u8; 3] = b"ho\0";
-pub const PRIuFAST16: &[u8; 3] = b"hu\0";
-pub const PRIxFAST16: &[u8; 3] = b"hx\0";
-pub const PRIXFAST16: &[u8; 3] = b"hX\0";
-pub const PRIdFAST32: &[u8; 2] = b"d\0";
-pub const PRIiFAST32: &[u8; 2] = b"i\0";
-pub const PRIoFAST32: &[u8; 2] = b"o\0";
-pub const PRIuFAST32: &[u8; 2] = b"u\0";
-pub const PRIxFAST32: &[u8; 2] = b"x\0";
-pub const PRIXFAST32: &[u8; 2] = b"X\0";
-pub const PRIdFAST64: &[u8; 4] = b"lld\0";
-pub const PRIiFAST64: &[u8; 4] = b"lli\0";
-pub const PRIoFAST64: &[u8; 4] = b"llo\0";
-pub const PRIuFAST64: &[u8; 4] = b"llu\0";
-pub const PRIxFAST64: &[u8; 4] = b"llx\0";
-pub const PRIXFAST64: &[u8; 4] = b"llX\0";
+pub const PRIXLEAST64: &[u8; 3] = b"lX\0";
+pub const PRIXFAST8: &[u8; 2] = b"X\0";
+pub const PRIXFAST16: &[u8; 3] = b"lX\0";
+pub const PRIXFAST32: &[u8; 3] = b"lX\0";
+pub const PRIXFAST64: &[u8; 3] = b"lX\0";
+pub const PRIdMAX: &[u8; 3] = b"ld\0";
+pub const PRIiMAX: &[u8; 3] = b"li\0";
+pub const PRIoMAX: &[u8; 3] = b"lo\0";
+pub const PRIuMAX: &[u8; 3] = b"lu\0";
+pub const PRIxMAX: &[u8; 3] = b"lx\0";
+pub const PRIXMAX: &[u8; 3] = b"lX\0";
 pub const PRIdPTR: &[u8; 3] = b"ld\0";
 pub const PRIiPTR: &[u8; 3] = b"li\0";
 pub const PRIoPTR: &[u8; 3] = b"lo\0";
 pub const PRIuPTR: &[u8; 3] = b"lu\0";
 pub const PRIxPTR: &[u8; 3] = b"lx\0";
 pub const PRIXPTR: &[u8; 3] = b"lX\0";
-pub const PRIdMAX: &[u8; 3] = b"jd\0";
-pub const PRIiMAX: &[u8; 3] = b"ji\0";
-pub const PRIoMAX: &[u8; 3] = b"jo\0";
-pub const PRIuMAX: &[u8; 3] = b"ju\0";
-pub const PRIxMAX: &[u8; 3] = b"jx\0";
-pub const PRIXMAX: &[u8; 3] = b"jX\0";
 pub const SCNd8: &[u8; 4] = b"hhd\0";
-pub const SCNi8: &[u8; 4] = b"hhi\0";
-pub const SCNo8: &[u8; 4] = b"hho\0";
-pub const SCNu8: &[u8; 4] = b"hhu\0";
-pub const SCNx8: &[u8; 4] = b"hhx\0";
 pub const SCNd16: &[u8; 3] = b"hd\0";
-pub const SCNi16: &[u8; 3] = b"hi\0";
-pub const SCNo16: &[u8; 3] = b"ho\0";
-pub const SCNu16: &[u8; 3] = b"hu\0";
-pub const SCNx16: &[u8; 3] = b"hx\0";
 pub const SCNd32: &[u8; 2] = b"d\0";
-pub const SCNi32: &[u8; 2] = b"i\0";
-pub const SCNo32: &[u8; 2] = b"o\0";
-pub const SCNu32: &[u8; 2] = b"u\0";
-pub const SCNx32: &[u8; 2] = b"x\0";
-pub const SCNd64: &[u8; 4] = b"lld\0";
-pub const SCNi64: &[u8; 4] = b"lli\0";
-pub const SCNo64: &[u8; 4] = b"llo\0";
-pub const SCNu64: &[u8; 4] = b"llu\0";
-pub const SCNx64: &[u8; 4] = b"llx\0";
+pub const SCNd64: &[u8; 3] = b"ld\0";
 pub const SCNdLEAST8: &[u8; 4] = b"hhd\0";
-pub const SCNiLEAST8: &[u8; 4] = b"hhi\0";
-pub const SCNoLEAST8: &[u8; 4] = b"hho\0";
-pub const SCNuLEAST8: &[u8; 4] = b"hhu\0";
-pub const SCNxLEAST8: &[u8; 4] = b"hhx\0";
 pub const SCNdLEAST16: &[u8; 3] = b"hd\0";
-pub const SCNiLEAST16: &[u8; 3] = b"hi\0";
-pub const SCNoLEAST16: &[u8; 3] = b"ho\0";
-pub const SCNuLEAST16: &[u8; 3] = b"hu\0";
-pub const SCNxLEAST16: &[u8; 3] = b"hx\0";
 pub const SCNdLEAST32: &[u8; 2] = b"d\0";
-pub const SCNiLEAST32: &[u8; 2] = b"i\0";
-pub const SCNoLEAST32: &[u8; 2] = b"o\0";
-pub const SCNuLEAST32: &[u8; 2] = b"u\0";
-pub const SCNxLEAST32: &[u8; 2] = b"x\0";
-pub const SCNdLEAST64: &[u8; 4] = b"lld\0";
-pub const SCNiLEAST64: &[u8; 4] = b"lli\0";
-pub const SCNoLEAST64: &[u8; 4] = b"llo\0";
-pub const SCNuLEAST64: &[u8; 4] = b"llu\0";
-pub const SCNxLEAST64: &[u8; 4] = b"llx\0";
+pub const SCNdLEAST64: &[u8; 3] = b"ld\0";
 pub const SCNdFAST8: &[u8; 4] = b"hhd\0";
+pub const SCNdFAST16: &[u8; 3] = b"ld\0";
+pub const SCNdFAST32: &[u8; 3] = b"ld\0";
+pub const SCNdFAST64: &[u8; 3] = b"ld\0";
+pub const SCNi8: &[u8; 4] = b"hhi\0";
+pub const SCNi16: &[u8; 3] = b"hi\0";
+pub const SCNi32: &[u8; 2] = b"i\0";
+pub const SCNi64: &[u8; 3] = b"li\0";
+pub const SCNiLEAST8: &[u8; 4] = b"hhi\0";
+pub const SCNiLEAST16: &[u8; 3] = b"hi\0";
+pub const SCNiLEAST32: &[u8; 2] = b"i\0";
+pub const SCNiLEAST64: &[u8; 3] = b"li\0";
 pub const SCNiFAST8: &[u8; 4] = b"hhi\0";
-pub const SCNoFAST8: &[u8; 4] = b"hho\0";
+pub const SCNiFAST16: &[u8; 3] = b"li\0";
+pub const SCNiFAST32: &[u8; 3] = b"li\0";
+pub const SCNiFAST64: &[u8; 3] = b"li\0";
+pub const SCNu8: &[u8; 4] = b"hhu\0";
+pub const SCNu16: &[u8; 3] = b"hu\0";
+pub const SCNu32: &[u8; 2] = b"u\0";
+pub const SCNu64: &[u8; 3] = b"lu\0";
+pub const SCNuLEAST8: &[u8; 4] = b"hhu\0";
+pub const SCNuLEAST16: &[u8; 3] = b"hu\0";
+pub const SCNuLEAST32: &[u8; 2] = b"u\0";
+pub const SCNuLEAST64: &[u8; 3] = b"lu\0";
 pub const SCNuFAST8: &[u8; 4] = b"hhu\0";
+pub const SCNuFAST16: &[u8; 3] = b"lu\0";
+pub const SCNuFAST32: &[u8; 3] = b"lu\0";
+pub const SCNuFAST64: &[u8; 3] = b"lu\0";
+pub const SCNo8: &[u8; 4] = b"hho\0";
+pub const SCNo16: &[u8; 3] = b"ho\0";
+pub const SCNo32: &[u8; 2] = b"o\0";
+pub const SCNo64: &[u8; 3] = b"lo\0";
+pub const SCNoLEAST8: &[u8; 4] = b"hho\0";
+pub const SCNoLEAST16: &[u8; 3] = b"ho\0";
+pub const SCNoLEAST32: &[u8; 2] = b"o\0";
+pub const SCNoLEAST64: &[u8; 3] = b"lo\0";
+pub const SCNoFAST8: &[u8; 4] = b"hho\0";
+pub const SCNoFAST16: &[u8; 3] = b"lo\0";
+pub const SCNoFAST32: &[u8; 3] = b"lo\0";
+pub const SCNoFAST64: &[u8; 3] = b"lo\0";
+pub const SCNx8: &[u8; 4] = b"hhx\0";
+pub const SCNx16: &[u8; 3] = b"hx\0";
+pub const SCNx32: &[u8; 2] = b"x\0";
+pub const SCNx64: &[u8; 3] = b"lx\0";
+pub const SCNxLEAST8: &[u8; 4] = b"hhx\0";
+pub const SCNxLEAST16: &[u8; 3] = b"hx\0";
+pub const SCNxLEAST32: &[u8; 2] = b"x\0";
+pub const SCNxLEAST64: &[u8; 3] = b"lx\0";
 pub const SCNxFAST8: &[u8; 4] = b"hhx\0";
-pub const SCNdFAST16: &[u8; 3] = b"hd\0";
-pub const SCNiFAST16: &[u8; 3] = b"hi\0";
-pub const SCNoFAST16: &[u8; 3] = b"ho\0";
-pub const SCNuFAST16: &[u8; 3] = b"hu\0";
-pub const SCNxFAST16: &[u8; 3] = b"hx\0";
-pub const SCNdFAST32: &[u8; 2] = b"d\0";
-pub const SCNiFAST32: &[u8; 2] = b"i\0";
-pub const SCNoFAST32: &[u8; 2] = b"o\0";
-pub const SCNuFAST32: &[u8; 2] = b"u\0";
-pub const SCNxFAST32: &[u8; 2] = b"x\0";
-pub const SCNdFAST64: &[u8; 4] = b"lld\0";
-pub const SCNiFAST64: &[u8; 4] = b"lli\0";
-pub const SCNoFAST64: &[u8; 4] = b"llo\0";
-pub const SCNuFAST64: &[u8; 4] = b"llu\0";
-pub const SCNxFAST64: &[u8; 4] = b"llx\0";
+pub const SCNxFAST16: &[u8; 3] = b"lx\0";
+pub const SCNxFAST32: &[u8; 3] = b"lx\0";
+pub const SCNxFAST64: &[u8; 3] = b"lx\0";
+pub const SCNdMAX: &[u8; 3] = b"ld\0";
+pub const SCNiMAX: &[u8; 3] = b"li\0";
+pub const SCNoMAX: &[u8; 3] = b"lo\0";
+pub const SCNuMAX: &[u8; 3] = b"lu\0";
+pub const SCNxMAX: &[u8; 3] = b"lx\0";
 pub const SCNdPTR: &[u8; 3] = b"ld\0";
 pub const SCNiPTR: &[u8; 3] = b"li\0";
 pub const SCNoPTR: &[u8; 3] = b"lo\0";
 pub const SCNuPTR: &[u8; 3] = b"lu\0";
 pub const SCNxPTR: &[u8; 3] = b"lx\0";
-pub const SCNdMAX: &[u8; 3] = b"jd\0";
-pub const SCNiMAX: &[u8; 3] = b"ji\0";
-pub const SCNoMAX: &[u8; 3] = b"jo\0";
-pub const SCNuMAX: &[u8; 3] = b"ju\0";
-pub const SCNxMAX: &[u8; 3] = b"jx\0";
-pub const SCIP_EVENTTYPE_FORMAT: &[u8; 4] = b"llx\0";
+pub const SCIP_EVENTTYPE_FORMAT: &[u8; 3] = b"lx\0";
 pub const SCIP_VARTYPE_BINARY_CHAR: u8 = 66u8;
 pub const SCIP_VARTYPE_INTEGER_CHAR: u8 = 73u8;
 pub const SCIP_VARTYPE_CONTINUOUS_CHAR: u8 = 67u8;
@@ -1231,8 +715,10 @@ pub const SCIP_EXPRPRINT_ALL: u32 = 255;
 pub const SCIP_NLPPARAM_DEFAULT_VERBLEVEL: u32 = 0;
 pub const SCIP_DECOMP_LINKVAR: i32 = -1;
 pub const SCIP_DECOMP_LINKCONS: i32 = -2;
-pub const __GNUC_VA_LIST: u32 = 1;
-pub const __HAS_FIXED_CHK_PROTOTYPES: u32 = 1;
+pub const _STRING_H: u32 = 1;
+pub const _BITS_TYPES_LOCALE_T_H: u32 = 1;
+pub const _BITS_TYPES___LOCALE_T_H: u32 = 1;
+pub const _STRINGS_H: u32 = 1;
 pub const QUAD_EPSILON: f64 = 0.000000000001;
 pub const __bool_true_false_are_defined: u32 = 1;
 pub const true_: u32 = 1;
@@ -1251,498 +737,306 @@ pub const SYM_COMPUTETIMING_BEFOREPRESOL: u32 = 0;
 pub const SYM_COMPUTETIMING_DURINGPRESOL: u32 = 1;
 pub const SYM_COMPUTETIMING_AFTERPRESOL: u32 = 2;
 pub const ARTIFICIALVARNAMEPREFIX: &[u8; 14] = b"andresultant_\0";
+pub type __gnuc_va_list = __BindgenOpaqueArray<u64, 4usize>;
+pub type __u_char = ::std::os::raw::c_uchar;
+pub type __u_short = ::std::os::raw::c_ushort;
+pub type __u_int = ::std::os::raw::c_uint;
+pub type __u_long = ::std::os::raw::c_ulong;
 pub type __int8_t = ::std::os::raw::c_schar;
 pub type __uint8_t = ::std::os::raw::c_uchar;
 pub type __int16_t = ::std::os::raw::c_short;
 pub type __uint16_t = ::std::os::raw::c_ushort;
 pub type __int32_t = ::std::os::raw::c_int;
 pub type __uint32_t = ::std::os::raw::c_uint;
-pub type __int64_t = ::std::os::raw::c_longlong;
-pub type __uint64_t = ::std::os::raw::c_ulonglong;
-pub type __darwin_intptr_t = ::std::os::raw::c_long;
-pub type __darwin_natural_t = ::std::os::raw::c_uint;
-pub type __darwin_ct_rune_t = ::std::os::raw::c_int;
+pub type __int64_t = ::std::os::raw::c_long;
+pub type __uint64_t = ::std::os::raw::c_ulong;
+pub type __int_least8_t = __int8_t;
+pub type __uint_least8_t = __uint8_t;
+pub type __int_least16_t = __int16_t;
+pub type __uint_least16_t = __uint16_t;
+pub type __int_least32_t = __int32_t;
+pub type __uint_least32_t = __uint32_t;
+pub type __int_least64_t = __int64_t;
+pub type __uint_least64_t = __uint64_t;
+pub type __quad_t = ::std::os::raw::c_long;
+pub type __u_quad_t = ::std::os::raw::c_ulong;
+pub type __intmax_t = ::std::os::raw::c_long;
+pub type __uintmax_t = ::std::os::raw::c_ulong;
+pub type __dev_t = ::std::os::raw::c_ulong;
+pub type __uid_t = ::std::os::raw::c_uint;
+pub type __gid_t = ::std::os::raw::c_uint;
+pub type __ino_t = ::std::os::raw::c_ulong;
+pub type __ino64_t = ::std::os::raw::c_ulong;
+pub type __mode_t = ::std::os::raw::c_uint;
+pub type __nlink_t = ::std::os::raw::c_uint;
+pub type __off_t = ::std::os::raw::c_long;
+pub type __off64_t = ::std::os::raw::c_long;
+pub type __pid_t = ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __fsid_t {
+    pub __val: [::std::os::raw::c_int; 2usize],
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of __fsid_t"][::std::mem::size_of::<__fsid_t>() - 8usize];
+    ["Alignment of __fsid_t"][::std::mem::align_of::<__fsid_t>() - 4usize];
+    ["Offset of field: __fsid_t::__val"][::std::mem::offset_of!(__fsid_t, __val) - 0usize];
+};
+pub type __clock_t = ::std::os::raw::c_long;
+pub type __rlim_t = ::std::os::raw::c_ulong;
+pub type __rlim64_t = ::std::os::raw::c_ulong;
+pub type __id_t = ::std::os::raw::c_uint;
+pub type __time_t = ::std::os::raw::c_long;
+pub type __useconds_t = ::std::os::raw::c_uint;
+pub type __suseconds_t = ::std::os::raw::c_long;
+pub type __suseconds64_t = ::std::os::raw::c_long;
+pub type __daddr_t = ::std::os::raw::c_int;
+pub type __key_t = ::std::os::raw::c_int;
+pub type __clockid_t = ::std::os::raw::c_int;
+pub type __timer_t = *mut ::std::os::raw::c_void;
+pub type __blksize_t = ::std::os::raw::c_int;
+pub type __blkcnt_t = ::std::os::raw::c_long;
+pub type __blkcnt64_t = ::std::os::raw::c_long;
+pub type __fsblkcnt_t = ::std::os::raw::c_ulong;
+pub type __fsblkcnt64_t = ::std::os::raw::c_ulong;
+pub type __fsfilcnt_t = ::std::os::raw::c_ulong;
+pub type __fsfilcnt64_t = ::std::os::raw::c_ulong;
+pub type __fsword_t = ::std::os::raw::c_long;
+pub type __ssize_t = ::std::os::raw::c_long;
+pub type __syscall_slong_t = ::std::os::raw::c_long;
+pub type __syscall_ulong_t = ::std::os::raw::c_ulong;
+pub type __loff_t = __off64_t;
+pub type __caddr_t = *mut ::std::os::raw::c_char;
+pub type __intptr_t = ::std::os::raw::c_long;
+pub type __socklen_t = ::std::os::raw::c_uint;
+pub type __sig_atomic_t = ::std::os::raw::c_int;
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub union __mbstate_t {
-    pub __mbstate8: [::std::os::raw::c_char; 128usize],
-    pub _mbstateL: ::std::os::raw::c_longlong,
+pub struct __mbstate_t {
+    pub __count: ::std::os::raw::c_int,
+    pub __value: __mbstate_t__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union __mbstate_t__bindgen_ty_1 {
+    pub __wch: ::std::os::raw::c_uint,
+    pub __wchb: [::std::os::raw::c_char; 4usize],
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of __mbstate_t"][::std::mem::size_of::<__mbstate_t>() - 128usize];
-    ["Alignment of __mbstate_t"][::std::mem::align_of::<__mbstate_t>() - 8usize];
-    ["Offset of field: __mbstate_t::__mbstate8"]
-        [::std::mem::offset_of!(__mbstate_t, __mbstate8) - 0usize];
-    ["Offset of field: __mbstate_t::_mbstateL"]
-        [::std::mem::offset_of!(__mbstate_t, _mbstateL) - 0usize];
+    ["Size of __mbstate_t__bindgen_ty_1"]
+        [::std::mem::size_of::<__mbstate_t__bindgen_ty_1>() - 4usize];
+    ["Alignment of __mbstate_t__bindgen_ty_1"]
+        [::std::mem::align_of::<__mbstate_t__bindgen_ty_1>() - 4usize];
+    ["Offset of field: __mbstate_t__bindgen_ty_1::__wch"]
+        [::std::mem::offset_of!(__mbstate_t__bindgen_ty_1, __wch) - 0usize];
+    ["Offset of field: __mbstate_t__bindgen_ty_1::__wchb"]
+        [::std::mem::offset_of!(__mbstate_t__bindgen_ty_1, __wchb) - 0usize];
 };
-pub type __darwin_mbstate_t = __mbstate_t;
-pub type __darwin_ptrdiff_t = ::std::os::raw::c_long;
-pub type __darwin_size_t = ::std::os::raw::c_ulong;
-pub type __darwin_va_list = __builtin_va_list;
-pub type __darwin_wchar_t = ::std::os::raw::c_int;
-pub type __darwin_rune_t = __darwin_wchar_t;
-pub type __darwin_wint_t = ::std::os::raw::c_int;
-pub type __darwin_clock_t = ::std::os::raw::c_ulong;
-pub type __darwin_socklen_t = __uint32_t;
-pub type __darwin_ssize_t = ::std::os::raw::c_long;
-pub type __darwin_time_t = ::std::os::raw::c_long;
-pub type __darwin_blkcnt_t = __int64_t;
-pub type __darwin_blksize_t = __int32_t;
-pub type __darwin_dev_t = __int32_t;
-pub type __darwin_fsblkcnt_t = ::std::os::raw::c_uint;
-pub type __darwin_fsfilcnt_t = ::std::os::raw::c_uint;
-pub type __darwin_gid_t = __uint32_t;
-pub type __darwin_id_t = __uint32_t;
-pub type __darwin_ino64_t = __uint64_t;
-pub type __darwin_ino_t = __darwin_ino64_t;
-pub type __darwin_mach_port_name_t = __darwin_natural_t;
-pub type __darwin_mach_port_t = __darwin_mach_port_name_t;
-pub type __darwin_mode_t = __uint16_t;
-pub type __darwin_off_t = __int64_t;
-pub type __darwin_pid_t = __int32_t;
-pub type __darwin_sigset_t = __uint32_t;
-pub type __darwin_suseconds_t = __int32_t;
-pub type __darwin_uid_t = __uint32_t;
-pub type __darwin_useconds_t = __uint32_t;
-pub type __darwin_uuid_t = [::std::os::raw::c_uchar; 16usize];
-pub type __darwin_uuid_string_t = [::std::os::raw::c_char; 37usize];
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of __mbstate_t"][::std::mem::size_of::<__mbstate_t>() - 8usize];
+    ["Alignment of __mbstate_t"][::std::mem::align_of::<__mbstate_t>() - 4usize];
+    ["Offset of field: __mbstate_t::__count"]
+        [::std::mem::offset_of!(__mbstate_t, __count) - 0usize];
+    ["Offset of field: __mbstate_t::__value"]
+        [::std::mem::offset_of!(__mbstate_t, __value) - 4usize];
+};
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_pthread_handler_rec {
-    pub __routine: ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
-    pub __arg: *mut ::std::os::raw::c_void,
-    pub __next: *mut __darwin_pthread_handler_rec,
+#[derive(Copy, Clone)]
+pub struct _G_fpos_t {
+    pub __pos: __off_t,
+    pub __state: __mbstate_t,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of __darwin_pthread_handler_rec"]
-        [::std::mem::size_of::<__darwin_pthread_handler_rec>() - 24usize];
-    ["Alignment of __darwin_pthread_handler_rec"]
-        [::std::mem::align_of::<__darwin_pthread_handler_rec>() - 8usize];
-    ["Offset of field: __darwin_pthread_handler_rec::__routine"]
-        [::std::mem::offset_of!(__darwin_pthread_handler_rec, __routine) - 0usize];
-    ["Offset of field: __darwin_pthread_handler_rec::__arg"]
-        [::std::mem::offset_of!(__darwin_pthread_handler_rec, __arg) - 8usize];
-    ["Offset of field: __darwin_pthread_handler_rec::__next"]
-        [::std::mem::offset_of!(__darwin_pthread_handler_rec, __next) - 16usize];
+    ["Size of _G_fpos_t"][::std::mem::size_of::<_G_fpos_t>() - 16usize];
+    ["Alignment of _G_fpos_t"][::std::mem::align_of::<_G_fpos_t>() - 8usize];
+    ["Offset of field: _G_fpos_t::__pos"][::std::mem::offset_of!(_G_fpos_t, __pos) - 0usize];
+    ["Offset of field: _G_fpos_t::__state"][::std::mem::offset_of!(_G_fpos_t, __state) - 8usize];
 };
+pub type __fpos_t = _G_fpos_t;
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_attr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 56usize],
+#[derive(Copy, Clone)]
+pub struct _G_fpos64_t {
+    pub __pos: __off64_t,
+    pub __state: __mbstate_t,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of _opaque_pthread_attr_t"][::std::mem::size_of::<_opaque_pthread_attr_t>() - 64usize];
-    ["Alignment of _opaque_pthread_attr_t"]
-        [::std::mem::align_of::<_opaque_pthread_attr_t>() - 8usize];
-    ["Offset of field: _opaque_pthread_attr_t::__sig"]
-        [::std::mem::offset_of!(_opaque_pthread_attr_t, __sig) - 0usize];
-    ["Offset of field: _opaque_pthread_attr_t::__opaque"]
-        [::std::mem::offset_of!(_opaque_pthread_attr_t, __opaque) - 8usize];
+    ["Size of _G_fpos64_t"][::std::mem::size_of::<_G_fpos64_t>() - 16usize];
+    ["Alignment of _G_fpos64_t"][::std::mem::align_of::<_G_fpos64_t>() - 8usize];
+    ["Offset of field: _G_fpos64_t::__pos"][::std::mem::offset_of!(_G_fpos64_t, __pos) - 0usize];
+    ["Offset of field: _G_fpos64_t::__state"]
+        [::std::mem::offset_of!(_G_fpos64_t, __state) - 8usize];
 };
+pub type __fpos64_t = _G_fpos64_t;
+pub type __FILE = _IO_FILE;
+pub type FILE = _IO_FILE;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_cond_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 40usize],
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of _opaque_pthread_cond_t"][::std::mem::size_of::<_opaque_pthread_cond_t>() - 48usize];
-    ["Alignment of _opaque_pthread_cond_t"]
-        [::std::mem::align_of::<_opaque_pthread_cond_t>() - 8usize];
-    ["Offset of field: _opaque_pthread_cond_t::__sig"]
-        [::std::mem::offset_of!(_opaque_pthread_cond_t, __sig) - 0usize];
-    ["Offset of field: _opaque_pthread_cond_t::__opaque"]
-        [::std::mem::offset_of!(_opaque_pthread_cond_t, __opaque) - 8usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_condattr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 8usize],
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of _opaque_pthread_condattr_t"]
-        [::std::mem::size_of::<_opaque_pthread_condattr_t>() - 16usize];
-    ["Alignment of _opaque_pthread_condattr_t"]
-        [::std::mem::align_of::<_opaque_pthread_condattr_t>() - 8usize];
-    ["Offset of field: _opaque_pthread_condattr_t::__sig"]
-        [::std::mem::offset_of!(_opaque_pthread_condattr_t, __sig) - 0usize];
-    ["Offset of field: _opaque_pthread_condattr_t::__opaque"]
-        [::std::mem::offset_of!(_opaque_pthread_condattr_t, __opaque) - 8usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_mutex_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 56usize],
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of _opaque_pthread_mutex_t"][::std::mem::size_of::<_opaque_pthread_mutex_t>() - 64usize];
-    ["Alignment of _opaque_pthread_mutex_t"]
-        [::std::mem::align_of::<_opaque_pthread_mutex_t>() - 8usize];
-    ["Offset of field: _opaque_pthread_mutex_t::__sig"]
-        [::std::mem::offset_of!(_opaque_pthread_mutex_t, __sig) - 0usize];
-    ["Offset of field: _opaque_pthread_mutex_t::__opaque"]
-        [::std::mem::offset_of!(_opaque_pthread_mutex_t, __opaque) - 8usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_mutexattr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 8usize],
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of _opaque_pthread_mutexattr_t"]
-        [::std::mem::size_of::<_opaque_pthread_mutexattr_t>() - 16usize];
-    ["Alignment of _opaque_pthread_mutexattr_t"]
-        [::std::mem::align_of::<_opaque_pthread_mutexattr_t>() - 8usize];
-    ["Offset of field: _opaque_pthread_mutexattr_t::__sig"]
-        [::std::mem::offset_of!(_opaque_pthread_mutexattr_t, __sig) - 0usize];
-    ["Offset of field: _opaque_pthread_mutexattr_t::__opaque"]
-        [::std::mem::offset_of!(_opaque_pthread_mutexattr_t, __opaque) - 8usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_once_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 8usize],
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of _opaque_pthread_once_t"][::std::mem::size_of::<_opaque_pthread_once_t>() - 16usize];
-    ["Alignment of _opaque_pthread_once_t"]
-        [::std::mem::align_of::<_opaque_pthread_once_t>() - 8usize];
-    ["Offset of field: _opaque_pthread_once_t::__sig"]
-        [::std::mem::offset_of!(_opaque_pthread_once_t, __sig) - 0usize];
-    ["Offset of field: _opaque_pthread_once_t::__opaque"]
-        [::std::mem::offset_of!(_opaque_pthread_once_t, __opaque) - 8usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_rwlock_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 192usize],
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of _opaque_pthread_rwlock_t"]
-        [::std::mem::size_of::<_opaque_pthread_rwlock_t>() - 200usize];
-    ["Alignment of _opaque_pthread_rwlock_t"]
-        [::std::mem::align_of::<_opaque_pthread_rwlock_t>() - 8usize];
-    ["Offset of field: _opaque_pthread_rwlock_t::__sig"]
-        [::std::mem::offset_of!(_opaque_pthread_rwlock_t, __sig) - 0usize];
-    ["Offset of field: _opaque_pthread_rwlock_t::__opaque"]
-        [::std::mem::offset_of!(_opaque_pthread_rwlock_t, __opaque) - 8usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_rwlockattr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 16usize],
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of _opaque_pthread_rwlockattr_t"]
-        [::std::mem::size_of::<_opaque_pthread_rwlockattr_t>() - 24usize];
-    ["Alignment of _opaque_pthread_rwlockattr_t"]
-        [::std::mem::align_of::<_opaque_pthread_rwlockattr_t>() - 8usize];
-    ["Offset of field: _opaque_pthread_rwlockattr_t::__sig"]
-        [::std::mem::offset_of!(_opaque_pthread_rwlockattr_t, __sig) - 0usize];
-    ["Offset of field: _opaque_pthread_rwlockattr_t::__opaque"]
-        [::std::mem::offset_of!(_opaque_pthread_rwlockattr_t, __opaque) - 8usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __cleanup_stack: *mut __darwin_pthread_handler_rec,
-    pub __opaque: [::std::os::raw::c_char; 8176usize],
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of _opaque_pthread_t"][::std::mem::size_of::<_opaque_pthread_t>() - 8192usize];
-    ["Alignment of _opaque_pthread_t"][::std::mem::align_of::<_opaque_pthread_t>() - 8usize];
-    ["Offset of field: _opaque_pthread_t::__sig"]
-        [::std::mem::offset_of!(_opaque_pthread_t, __sig) - 0usize];
-    ["Offset of field: _opaque_pthread_t::__cleanup_stack"]
-        [::std::mem::offset_of!(_opaque_pthread_t, __cleanup_stack) - 8usize];
-    ["Offset of field: _opaque_pthread_t::__opaque"]
-        [::std::mem::offset_of!(_opaque_pthread_t, __opaque) - 16usize];
-};
-pub type __darwin_pthread_attr_t = _opaque_pthread_attr_t;
-pub type __darwin_pthread_cond_t = _opaque_pthread_cond_t;
-pub type __darwin_pthread_condattr_t = _opaque_pthread_condattr_t;
-pub type __darwin_pthread_key_t = ::std::os::raw::c_ulong;
-pub type __darwin_pthread_mutex_t = _opaque_pthread_mutex_t;
-pub type __darwin_pthread_mutexattr_t = _opaque_pthread_mutexattr_t;
-pub type __darwin_pthread_once_t = _opaque_pthread_once_t;
-pub type __darwin_pthread_rwlock_t = _opaque_pthread_rwlock_t;
-pub type __darwin_pthread_rwlockattr_t = _opaque_pthread_rwlockattr_t;
-pub type __darwin_pthread_t = *mut _opaque_pthread_t;
-pub type __darwin_nl_item = ::std::os::raw::c_int;
-pub type __darwin_wctrans_t = ::std::os::raw::c_int;
-pub type __darwin_wctype_t = __uint32_t;
-pub type u_int8_t = ::std::os::raw::c_uchar;
-pub type u_int16_t = ::std::os::raw::c_ushort;
-pub type u_int32_t = ::std::os::raw::c_uint;
-pub type u_int64_t = ::std::os::raw::c_ulonglong;
-pub type register_t = i64;
-pub type user_addr_t = u_int64_t;
-pub type user_size_t = u_int64_t;
-pub type user_ssize_t = i64;
-pub type user_long_t = i64;
-pub type user_ulong_t = u_int64_t;
-pub type user_time_t = i64;
-pub type user_off_t = i64;
-pub type syscall_arg_t = u_int64_t;
-pub type va_list = __darwin_va_list;
-unsafe extern "C" {
-    pub fn renameat(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
-        arg4: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn renamex_np(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_uint,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn renameatx_np(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
-        arg4: *const ::std::os::raw::c_char,
-        arg5: ::std::os::raw::c_uint,
-    ) -> ::std::os::raw::c_int;
-}
-pub type fpos_t = __darwin_off_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __sbuf {
-    pub _base: *mut ::std::os::raw::c_uchar,
-    pub _size: ::std::os::raw::c_int,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __sbuf"][::std::mem::size_of::<__sbuf>() - 16usize];
-    ["Alignment of __sbuf"][::std::mem::align_of::<__sbuf>() - 8usize];
-    ["Offset of field: __sbuf::_base"][::std::mem::offset_of!(__sbuf, _base) - 0usize];
-    ["Offset of field: __sbuf::_size"][::std::mem::offset_of!(__sbuf, _size) - 8usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __sFILEX {
+pub struct _IO_marker {
     _unused: [u8; 0],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct __sFILE {
-    pub _p: *mut ::std::os::raw::c_uchar,
-    pub _r: ::std::os::raw::c_int,
-    pub _w: ::std::os::raw::c_int,
-    pub _flags: ::std::os::raw::c_short,
-    pub _file: ::std::os::raw::c_short,
-    pub _bf: __sbuf,
-    pub _lbfsize: ::std::os::raw::c_int,
-    pub _cookie: *mut ::std::os::raw::c_void,
-    pub _close: ::std::option::Option<
-        unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
-    >,
-    pub _read: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: *mut ::std::os::raw::c_char,
-            arg3: ::std::os::raw::c_int,
-        ) -> ::std::os::raw::c_int,
-    >,
-    pub _seek: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: fpos_t,
-            arg3: ::std::os::raw::c_int,
-        ) -> fpos_t,
-    >,
-    pub _write: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_char,
-            arg3: ::std::os::raw::c_int,
-        ) -> ::std::os::raw::c_int,
-    >,
-    pub _ub: __sbuf,
-    pub _extra: *mut __sFILEX,
-    pub _ur: ::std::os::raw::c_int,
-    pub _ubuf: [::std::os::raw::c_uchar; 3usize],
-    pub _nbuf: [::std::os::raw::c_uchar; 1usize],
-    pub _lb: __sbuf,
-    pub _blksize: ::std::os::raw::c_int,
-    pub _offset: fpos_t,
+pub struct _IO_codecvt {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _IO_wide_data {
+    _unused: [u8; 0],
+}
+pub type _IO_lock_t = ::std::os::raw::c_void;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _IO_FILE {
+    pub _flags: ::std::os::raw::c_int,
+    pub _IO_read_ptr: *mut ::std::os::raw::c_char,
+    pub _IO_read_end: *mut ::std::os::raw::c_char,
+    pub _IO_read_base: *mut ::std::os::raw::c_char,
+    pub _IO_write_base: *mut ::std::os::raw::c_char,
+    pub _IO_write_ptr: *mut ::std::os::raw::c_char,
+    pub _IO_write_end: *mut ::std::os::raw::c_char,
+    pub _IO_buf_base: *mut ::std::os::raw::c_char,
+    pub _IO_buf_end: *mut ::std::os::raw::c_char,
+    pub _IO_save_base: *mut ::std::os::raw::c_char,
+    pub _IO_backup_base: *mut ::std::os::raw::c_char,
+    pub _IO_save_end: *mut ::std::os::raw::c_char,
+    pub _markers: *mut _IO_marker,
+    pub _chain: *mut _IO_FILE,
+    pub _fileno: ::std::os::raw::c_int,
+    pub _flags2: ::std::os::raw::c_int,
+    pub _old_offset: __off_t,
+    pub _cur_column: ::std::os::raw::c_ushort,
+    pub _vtable_offset: ::std::os::raw::c_schar,
+    pub _shortbuf: [::std::os::raw::c_char; 1usize],
+    pub _lock: *mut _IO_lock_t,
+    pub _offset: __off64_t,
+    pub _codecvt: *mut _IO_codecvt,
+    pub _wide_data: *mut _IO_wide_data,
+    pub _freeres_list: *mut _IO_FILE,
+    pub _freeres_buf: *mut ::std::os::raw::c_void,
+    pub __pad5: usize,
+    pub _mode: ::std::os::raw::c_int,
+    pub _unused2: [::std::os::raw::c_char; 20usize],
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of __sFILE"][::std::mem::size_of::<__sFILE>() - 152usize];
-    ["Alignment of __sFILE"][::std::mem::align_of::<__sFILE>() - 8usize];
-    ["Offset of field: __sFILE::_p"][::std::mem::offset_of!(__sFILE, _p) - 0usize];
-    ["Offset of field: __sFILE::_r"][::std::mem::offset_of!(__sFILE, _r) - 8usize];
-    ["Offset of field: __sFILE::_w"][::std::mem::offset_of!(__sFILE, _w) - 12usize];
-    ["Offset of field: __sFILE::_flags"][::std::mem::offset_of!(__sFILE, _flags) - 16usize];
-    ["Offset of field: __sFILE::_file"][::std::mem::offset_of!(__sFILE, _file) - 18usize];
-    ["Offset of field: __sFILE::_bf"][::std::mem::offset_of!(__sFILE, _bf) - 24usize];
-    ["Offset of field: __sFILE::_lbfsize"][::std::mem::offset_of!(__sFILE, _lbfsize) - 40usize];
-    ["Offset of field: __sFILE::_cookie"][::std::mem::offset_of!(__sFILE, _cookie) - 48usize];
-    ["Offset of field: __sFILE::_close"][::std::mem::offset_of!(__sFILE, _close) - 56usize];
-    ["Offset of field: __sFILE::_read"][::std::mem::offset_of!(__sFILE, _read) - 64usize];
-    ["Offset of field: __sFILE::_seek"][::std::mem::offset_of!(__sFILE, _seek) - 72usize];
-    ["Offset of field: __sFILE::_write"][::std::mem::offset_of!(__sFILE, _write) - 80usize];
-    ["Offset of field: __sFILE::_ub"][::std::mem::offset_of!(__sFILE, _ub) - 88usize];
-    ["Offset of field: __sFILE::_extra"][::std::mem::offset_of!(__sFILE, _extra) - 104usize];
-    ["Offset of field: __sFILE::_ur"][::std::mem::offset_of!(__sFILE, _ur) - 112usize];
-    ["Offset of field: __sFILE::_ubuf"][::std::mem::offset_of!(__sFILE, _ubuf) - 116usize];
-    ["Offset of field: __sFILE::_nbuf"][::std::mem::offset_of!(__sFILE, _nbuf) - 119usize];
-    ["Offset of field: __sFILE::_lb"][::std::mem::offset_of!(__sFILE, _lb) - 120usize];
-    ["Offset of field: __sFILE::_blksize"][::std::mem::offset_of!(__sFILE, _blksize) - 136usize];
-    ["Offset of field: __sFILE::_offset"][::std::mem::offset_of!(__sFILE, _offset) - 144usize];
+    ["Size of _IO_FILE"][::std::mem::size_of::<_IO_FILE>() - 216usize];
+    ["Alignment of _IO_FILE"][::std::mem::align_of::<_IO_FILE>() - 8usize];
+    ["Offset of field: _IO_FILE::_flags"][::std::mem::offset_of!(_IO_FILE, _flags) - 0usize];
+    ["Offset of field: _IO_FILE::_IO_read_ptr"]
+        [::std::mem::offset_of!(_IO_FILE, _IO_read_ptr) - 8usize];
+    ["Offset of field: _IO_FILE::_IO_read_end"]
+        [::std::mem::offset_of!(_IO_FILE, _IO_read_end) - 16usize];
+    ["Offset of field: _IO_FILE::_IO_read_base"]
+        [::std::mem::offset_of!(_IO_FILE, _IO_read_base) - 24usize];
+    ["Offset of field: _IO_FILE::_IO_write_base"]
+        [::std::mem::offset_of!(_IO_FILE, _IO_write_base) - 32usize];
+    ["Offset of field: _IO_FILE::_IO_write_ptr"]
+        [::std::mem::offset_of!(_IO_FILE, _IO_write_ptr) - 40usize];
+    ["Offset of field: _IO_FILE::_IO_write_end"]
+        [::std::mem::offset_of!(_IO_FILE, _IO_write_end) - 48usize];
+    ["Offset of field: _IO_FILE::_IO_buf_base"]
+        [::std::mem::offset_of!(_IO_FILE, _IO_buf_base) - 56usize];
+    ["Offset of field: _IO_FILE::_IO_buf_end"]
+        [::std::mem::offset_of!(_IO_FILE, _IO_buf_end) - 64usize];
+    ["Offset of field: _IO_FILE::_IO_save_base"]
+        [::std::mem::offset_of!(_IO_FILE, _IO_save_base) - 72usize];
+    ["Offset of field: _IO_FILE::_IO_backup_base"]
+        [::std::mem::offset_of!(_IO_FILE, _IO_backup_base) - 80usize];
+    ["Offset of field: _IO_FILE::_IO_save_end"]
+        [::std::mem::offset_of!(_IO_FILE, _IO_save_end) - 88usize];
+    ["Offset of field: _IO_FILE::_markers"][::std::mem::offset_of!(_IO_FILE, _markers) - 96usize];
+    ["Offset of field: _IO_FILE::_chain"][::std::mem::offset_of!(_IO_FILE, _chain) - 104usize];
+    ["Offset of field: _IO_FILE::_fileno"][::std::mem::offset_of!(_IO_FILE, _fileno) - 112usize];
+    ["Offset of field: _IO_FILE::_flags2"][::std::mem::offset_of!(_IO_FILE, _flags2) - 116usize];
+    ["Offset of field: _IO_FILE::_old_offset"]
+        [::std::mem::offset_of!(_IO_FILE, _old_offset) - 120usize];
+    ["Offset of field: _IO_FILE::_cur_column"]
+        [::std::mem::offset_of!(_IO_FILE, _cur_column) - 128usize];
+    ["Offset of field: _IO_FILE::_vtable_offset"]
+        [::std::mem::offset_of!(_IO_FILE, _vtable_offset) - 130usize];
+    ["Offset of field: _IO_FILE::_shortbuf"]
+        [::std::mem::offset_of!(_IO_FILE, _shortbuf) - 131usize];
+    ["Offset of field: _IO_FILE::_lock"][::std::mem::offset_of!(_IO_FILE, _lock) - 136usize];
+    ["Offset of field: _IO_FILE::_offset"][::std::mem::offset_of!(_IO_FILE, _offset) - 144usize];
+    ["Offset of field: _IO_FILE::_codecvt"][::std::mem::offset_of!(_IO_FILE, _codecvt) - 152usize];
+    ["Offset of field: _IO_FILE::_wide_data"]
+        [::std::mem::offset_of!(_IO_FILE, _wide_data) - 160usize];
+    ["Offset of field: _IO_FILE::_freeres_list"]
+        [::std::mem::offset_of!(_IO_FILE, _freeres_list) - 168usize];
+    ["Offset of field: _IO_FILE::_freeres_buf"]
+        [::std::mem::offset_of!(_IO_FILE, _freeres_buf) - 176usize];
+    ["Offset of field: _IO_FILE::__pad5"][::std::mem::offset_of!(_IO_FILE, __pad5) - 184usize];
+    ["Offset of field: _IO_FILE::_mode"][::std::mem::offset_of!(_IO_FILE, _mode) - 192usize];
+    ["Offset of field: _IO_FILE::_unused2"][::std::mem::offset_of!(_IO_FILE, _unused2) - 196usize];
 };
-pub type FILE = __sFILE;
+pub type cookie_read_function_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        __cookie: *mut ::std::os::raw::c_void,
+        __buf: *mut ::std::os::raw::c_char,
+        __nbytes: usize,
+    ) -> __ssize_t,
+>;
+pub type cookie_write_function_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        __cookie: *mut ::std::os::raw::c_void,
+        __buf: *const ::std::os::raw::c_char,
+        __nbytes: usize,
+    ) -> __ssize_t,
+>;
+pub type cookie_seek_function_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        __cookie: *mut ::std::os::raw::c_void,
+        __pos: *mut __off64_t,
+        __w: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int,
+>;
+pub type cookie_close_function_t = ::std::option::Option<
+    unsafe extern "C" fn(__cookie: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
+>;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _IO_cookie_io_functions_t {
+    pub read: cookie_read_function_t,
+    pub write: cookie_write_function_t,
+    pub seek: cookie_seek_function_t,
+    pub close: cookie_close_function_t,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of _IO_cookie_io_functions_t"]
+        [::std::mem::size_of::<_IO_cookie_io_functions_t>() - 32usize];
+    ["Alignment of _IO_cookie_io_functions_t"]
+        [::std::mem::align_of::<_IO_cookie_io_functions_t>() - 8usize];
+    ["Offset of field: _IO_cookie_io_functions_t::read"]
+        [::std::mem::offset_of!(_IO_cookie_io_functions_t, read) - 0usize];
+    ["Offset of field: _IO_cookie_io_functions_t::write"]
+        [::std::mem::offset_of!(_IO_cookie_io_functions_t, write) - 8usize];
+    ["Offset of field: _IO_cookie_io_functions_t::seek"]
+        [::std::mem::offset_of!(_IO_cookie_io_functions_t, seek) - 16usize];
+    ["Offset of field: _IO_cookie_io_functions_t::close"]
+        [::std::mem::offset_of!(_IO_cookie_io_functions_t, close) - 24usize];
+};
+pub type cookie_io_functions_t = _IO_cookie_io_functions_t;
+pub type va_list = __gnuc_va_list;
+pub type off_t = __off_t;
+pub type fpos_t = __fpos_t;
 unsafe extern "C" {
-    pub static mut __stdinp: *mut FILE;
+    pub static mut stdin: *mut FILE;
 }
 unsafe extern "C" {
-    pub static mut __stdoutp: *mut FILE;
+    pub static mut stdout: *mut FILE;
 }
 unsafe extern "C" {
-    pub static mut __stderrp: *mut FILE;
+    pub static mut stderr: *mut FILE;
 }
 unsafe extern "C" {
-    pub fn clearerr(arg1: *mut FILE);
-}
-unsafe extern "C" {
-    pub fn fclose(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn feof(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn ferror(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn fflush(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn fgetc(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn fgetpos(arg1: *mut FILE, arg2: *mut fpos_t) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn fgets(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
-        arg3: *mut FILE,
-    ) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn fopen(
-        __filename: *const ::std::os::raw::c_char,
-        __mode: *const ::std::os::raw::c_char,
-    ) -> *mut FILE;
-}
-unsafe extern "C" {
-    pub fn fprintf(
-        arg1: *mut FILE,
-        arg2: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn fputc(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn fputs(arg1: *const ::std::os::raw::c_char, arg2: *mut FILE) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn fread(
-        __ptr: *mut ::std::os::raw::c_void,
-        __size: ::std::os::raw::c_ulong,
-        __nitems: ::std::os::raw::c_ulong,
-        __stream: *mut FILE,
-    ) -> ::std::os::raw::c_ulong;
-}
-unsafe extern "C" {
-    pub fn freopen(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut FILE,
-    ) -> *mut FILE;
-}
-unsafe extern "C" {
-    pub fn fscanf(
-        arg1: *mut FILE,
-        arg2: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn fseek(
-        arg1: *mut FILE,
-        arg2: ::std::os::raw::c_long,
-        arg3: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn fsetpos(arg1: *mut FILE, arg2: *const fpos_t) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn ftell(arg1: *mut FILE) -> ::std::os::raw::c_long;
-}
-unsafe extern "C" {
-    pub fn fwrite(
-        __ptr: *const ::std::os::raw::c_void,
-        __size: ::std::os::raw::c_ulong,
-        __nitems: ::std::os::raw::c_ulong,
-        __stream: *mut FILE,
-    ) -> ::std::os::raw::c_ulong;
-}
-unsafe extern "C" {
-    pub fn getc(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn getchar() -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn gets(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn perror(arg1: *const ::std::os::raw::c_char);
-}
-unsafe extern "C" {
-    pub fn printf(arg1: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn putc(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn putchar(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn puts(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn remove(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+    pub fn remove(__filename: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
     pub fn rename(
@@ -1751,35 +1045,15 @@ unsafe extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn rewind(arg1: *mut FILE);
-}
-unsafe extern "C" {
-    pub fn scanf(arg1: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn setbuf(arg1: *mut FILE, arg2: *mut ::std::os::raw::c_char);
-}
-unsafe extern "C" {
-    pub fn setvbuf(
-        arg1: *mut FILE,
-        arg2: *mut ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
-        arg4: usize,
+    pub fn renameat(
+        __oldfd: ::std::os::raw::c_int,
+        __old: *const ::std::os::raw::c_char,
+        __newfd: ::std::os::raw::c_int,
+        __new: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn sprintf(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn sscanf(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
+    pub fn fclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
     pub fn tmpfile() -> *mut FILE;
@@ -1788,2639 +1062,1906 @@ unsafe extern "C" {
     pub fn tmpnam(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn ungetc(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn vfprintf(
-        arg1: *mut FILE,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: __builtin_va_list,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn vprintf(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: __builtin_va_list,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn vsprintf(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: __builtin_va_list,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn ctermid(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn fdopen(arg1: ::std::os::raw::c_int, arg2: *const ::std::os::raw::c_char) -> *mut FILE;
-}
-unsafe extern "C" {
-    pub fn fileno(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn pclose(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn popen(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-    ) -> *mut FILE;
-}
-unsafe extern "C" {
-    pub fn __srget(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn __svfscanf(
-        arg1: *mut FILE,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: va_list,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn __swbuf(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn flockfile(arg1: *mut FILE);
-}
-unsafe extern "C" {
-    pub fn ftrylockfile(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn funlockfile(arg1: *mut FILE);
-}
-unsafe extern "C" {
-    pub fn getc_unlocked(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn getchar_unlocked() -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn putc_unlocked(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn putchar_unlocked(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn getw(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn putw(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn tmpnam_r(__s: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     pub fn tempnam(
         __dir: *const ::std::os::raw::c_char,
-        __prefix: *const ::std::os::raw::c_char,
+        __pfx: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
-pub type off_t = __darwin_off_t;
 unsafe extern "C" {
-    pub fn fseeko(
+    pub fn fflush(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn fflush_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn fopen(
+        __filename: *const ::std::os::raw::c_char,
+        __modes: *const ::std::os::raw::c_char,
+    ) -> *mut FILE;
+}
+unsafe extern "C" {
+    pub fn freopen(
+        __filename: *const ::std::os::raw::c_char,
+        __modes: *const ::std::os::raw::c_char,
         __stream: *mut FILE,
-        __offset: off_t,
-        __whence: ::std::os::raw::c_int,
+    ) -> *mut FILE;
+}
+unsafe extern "C" {
+    pub fn fdopen(__fd: ::std::os::raw::c_int, __modes: *const ::std::os::raw::c_char)
+    -> *mut FILE;
+}
+unsafe extern "C" {
+    pub fn fopencookie(
+        __magic_cookie: *mut ::std::os::raw::c_void,
+        __modes: *const ::std::os::raw::c_char,
+        __io_funcs: cookie_io_functions_t,
+    ) -> *mut FILE;
+}
+unsafe extern "C" {
+    pub fn fmemopen(
+        __s: *mut ::std::os::raw::c_void,
+        __len: usize,
+        __modes: *const ::std::os::raw::c_char,
+    ) -> *mut FILE;
+}
+unsafe extern "C" {
+    pub fn open_memstream(
+        __bufloc: *mut *mut ::std::os::raw::c_char,
+        __sizeloc: *mut usize,
+    ) -> *mut FILE;
+}
+unsafe extern "C" {
+    pub fn setbuf(__stream: *mut FILE, __buf: *mut ::std::os::raw::c_char);
+}
+unsafe extern "C" {
+    pub fn setvbuf(
+        __stream: *mut FILE,
+        __buf: *mut ::std::os::raw::c_char,
+        __modes: ::std::os::raw::c_int,
+        __n: usize,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn ftello(__stream: *mut FILE) -> off_t;
+    pub fn setbuffer(__stream: *mut FILE, __buf: *mut ::std::os::raw::c_char, __size: usize);
+}
+unsafe extern "C" {
+    pub fn setlinebuf(__stream: *mut FILE);
+}
+unsafe extern "C" {
+    pub fn fprintf(
+        __stream: *mut FILE,
+        __format: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn printf(__format: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn sprintf(
+        __s: *mut ::std::os::raw::c_char,
+        __format: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn vfprintf(
+        __s: *mut FILE,
+        __format: *const ::std::os::raw::c_char,
+        __arg: __BindgenOpaqueArray<u64, 4usize>,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn vprintf(
+        __format: *const ::std::os::raw::c_char,
+        __arg: __BindgenOpaqueArray<u64, 4usize>,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn vsprintf(
+        __s: *mut ::std::os::raw::c_char,
+        __format: *const ::std::os::raw::c_char,
+        __arg: __BindgenOpaqueArray<u64, 4usize>,
+    ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
     pub fn snprintf(
-        __str: *mut ::std::os::raw::c_char,
-        __size: ::std::os::raw::c_ulong,
+        __s: *mut ::std::os::raw::c_char,
+        __maxlen: ::std::os::raw::c_ulong,
+        __format: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn vsnprintf(
+        __s: *mut ::std::os::raw::c_char,
+        __maxlen: ::std::os::raw::c_ulong,
+        __format: *const ::std::os::raw::c_char,
+        __arg: __BindgenOpaqueArray<u64, 4usize>,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn vasprintf(
+        __ptr: *mut *mut ::std::os::raw::c_char,
+        __f: *const ::std::os::raw::c_char,
+        __arg: __gnuc_va_list,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn __asprintf(
+        __ptr: *mut *mut ::std::os::raw::c_char,
+        __fmt: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn asprintf(
+        __ptr: *mut *mut ::std::os::raw::c_char,
+        __fmt: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn vdprintf(
+        __fd: ::std::os::raw::c_int,
+        __fmt: *const ::std::os::raw::c_char,
+        __arg: __gnuc_va_list,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn dprintf(
+        __fd: ::std::os::raw::c_int,
+        __fmt: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn fscanf(
+        __stream: *mut FILE,
+        __format: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn scanf(__format: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn sscanf(
+        __s: *const ::std::os::raw::c_char,
+        __format: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+pub type _Float128 = u128;
+pub type _Float32 = f32;
+pub type _Float64 = f64;
+pub type _Float32x = f64;
+pub type _Float64x = u128;
+unsafe extern "C" {
+    #[link_name = "\u{1}__isoc99_fscanf"]
+    pub fn fscanf1(
+        __stream: *mut FILE,
+        __format: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    #[link_name = "\u{1}__isoc99_scanf"]
+    pub fn scanf1(__format: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    #[link_name = "\u{1}__isoc99_sscanf"]
+    pub fn sscanf1(
+        __s: *const ::std::os::raw::c_char,
         __format: *const ::std::os::raw::c_char,
         ...
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
     pub fn vfscanf(
-        __stream: *mut FILE,
+        __s: *mut FILE,
         __format: *const ::std::os::raw::c_char,
-        arg1: __builtin_va_list,
+        __arg: __BindgenOpaqueArray<u64, 4usize>,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
     pub fn vscanf(
         __format: *const ::std::os::raw::c_char,
-        arg1: __builtin_va_list,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn vsnprintf(
-        __str: *mut ::std::os::raw::c_char,
-        __size: ::std::os::raw::c_ulong,
-        __format: *const ::std::os::raw::c_char,
-        arg1: __builtin_va_list,
+        __arg: __BindgenOpaqueArray<u64, 4usize>,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
     pub fn vsscanf(
-        __str: *const ::std::os::raw::c_char,
+        __s: *const ::std::os::raw::c_char,
         __format: *const ::std::os::raw::c_char,
-        arg1: __builtin_va_list,
+        __arg: __BindgenOpaqueArray<u64, 4usize>,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn dprintf(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_char,
-        ...
+    #[link_name = "\u{1}__isoc99_vfscanf"]
+    pub fn vfscanf1(
+        __s: *mut FILE,
+        __format: *const ::std::os::raw::c_char,
+        __arg: __BindgenOpaqueArray<u64, 4usize>,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn vdprintf(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: va_list,
+    #[link_name = "\u{1}__isoc99_vscanf"]
+    pub fn vscanf1(
+        __format: *const ::std::os::raw::c_char,
+        __arg: __BindgenOpaqueArray<u64, 4usize>,
     ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    #[link_name = "\u{1}__isoc99_vsscanf"]
+    pub fn vsscanf1(
+        __s: *const ::std::os::raw::c_char,
+        __format: *const ::std::os::raw::c_char,
+        __arg: __BindgenOpaqueArray<u64, 4usize>,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn fgetc(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn getc(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn getchar() -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn getc_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn getchar_unlocked() -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn fgetc_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn fputc(__c: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn putc(__c: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn putchar(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn fputc_unlocked(__c: ::std::os::raw::c_int, __stream: *mut FILE)
+    -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn putc_unlocked(__c: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn putchar_unlocked(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn getw(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn putw(__w: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn fgets(
+        __s: *mut ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_int,
+        __stream: *mut FILE,
+    ) -> *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn __getdelim(
+        __lineptr: *mut *mut ::std::os::raw::c_char,
+        __n: *mut usize,
+        __delimiter: ::std::os::raw::c_int,
+        __stream: *mut FILE,
+    ) -> __ssize_t;
 }
 unsafe extern "C" {
     pub fn getdelim(
-        __linep: *mut *mut ::std::os::raw::c_char,
-        __linecapp: *mut usize,
+        __lineptr: *mut *mut ::std::os::raw::c_char,
+        __n: *mut usize,
         __delimiter: ::std::os::raw::c_int,
         __stream: *mut FILE,
-    ) -> isize;
+    ) -> __ssize_t;
 }
 unsafe extern "C" {
     pub fn getline(
-        __linep: *mut *mut ::std::os::raw::c_char,
-        __linecapp: *mut usize,
+        __lineptr: *mut *mut ::std::os::raw::c_char,
+        __n: *mut usize,
         __stream: *mut FILE,
-    ) -> isize;
+    ) -> __ssize_t;
 }
 unsafe extern "C" {
-    pub fn fmemopen(
-        __buf: *mut ::std::os::raw::c_void,
+    pub fn fputs(__s: *const ::std::os::raw::c_char, __stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn puts(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn ungetc(__c: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn fread(
+        __ptr: *mut ::std::os::raw::c_void,
+        __size: ::std::os::raw::c_ulong,
+        __n: ::std::os::raw::c_ulong,
+        __stream: *mut FILE,
+    ) -> ::std::os::raw::c_ulong;
+}
+unsafe extern "C" {
+    pub fn fwrite(
+        __ptr: *const ::std::os::raw::c_void,
+        __size: ::std::os::raw::c_ulong,
+        __n: ::std::os::raw::c_ulong,
+        __s: *mut FILE,
+    ) -> ::std::os::raw::c_ulong;
+}
+unsafe extern "C" {
+    pub fn fread_unlocked(
+        __ptr: *mut ::std::os::raw::c_void,
         __size: usize,
-        __mode: *const ::std::os::raw::c_char,
+        __n: usize,
+        __stream: *mut FILE,
+    ) -> usize;
+}
+unsafe extern "C" {
+    pub fn fwrite_unlocked(
+        __ptr: *const ::std::os::raw::c_void,
+        __size: usize,
+        __n: usize,
+        __stream: *mut FILE,
+    ) -> usize;
+}
+unsafe extern "C" {
+    pub fn fseek(
+        __stream: *mut FILE,
+        __off: ::std::os::raw::c_long,
+        __whence: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn ftell(__stream: *mut FILE) -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn rewind(__stream: *mut FILE);
+}
+unsafe extern "C" {
+    pub fn fseeko(
+        __stream: *mut FILE,
+        __off: __off_t,
+        __whence: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn ftello(__stream: *mut FILE) -> __off_t;
+}
+unsafe extern "C" {
+    pub fn fgetpos(__stream: *mut FILE, __pos: *mut fpos_t) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn fsetpos(__stream: *mut FILE, __pos: *const fpos_t) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn clearerr(__stream: *mut FILE);
+}
+unsafe extern "C" {
+    pub fn feof(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn ferror(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn clearerr_unlocked(__stream: *mut FILE);
+}
+unsafe extern "C" {
+    pub fn feof_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn ferror_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn perror(__s: *const ::std::os::raw::c_char);
+}
+unsafe extern "C" {
+    pub fn fileno(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn fileno_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn pclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn popen(
+        __command: *const ::std::os::raw::c_char,
+        __modes: *const ::std::os::raw::c_char,
     ) -> *mut FILE;
 }
 unsafe extern "C" {
-    pub fn open_memstream(
-        __bufp: *mut *mut ::std::os::raw::c_char,
-        __sizep: *mut usize,
-    ) -> *mut FILE;
+    pub fn ctermid(__s: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub static sys_nerr: ::std::os::raw::c_int;
+    pub fn flockfile(__stream: *mut FILE);
 }
 unsafe extern "C" {
-    pub static sys_errlist: [*const ::std::os::raw::c_char; 0usize];
+    pub fn ftrylockfile(__stream: *mut FILE) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn asprintf(
-        arg1: *mut *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
+    pub fn funlockfile(__stream: *mut FILE);
 }
 unsafe extern "C" {
-    pub fn ctermid_r(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+    pub fn __uflow(arg1: *mut FILE) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn fgetln(arg1: *mut FILE, arg2: *mut usize) -> *mut ::std::os::raw::c_char;
+    pub fn __overflow(arg1: *mut FILE, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+pub type int_least8_t = __int_least8_t;
+pub type int_least16_t = __int_least16_t;
+pub type int_least32_t = __int_least32_t;
+pub type int_least64_t = __int_least64_t;
+pub type uint_least8_t = __uint_least8_t;
+pub type uint_least16_t = __uint_least16_t;
+pub type uint_least32_t = __uint_least32_t;
+pub type uint_least64_t = __uint_least64_t;
+pub type int_fast8_t = ::std::os::raw::c_schar;
+pub type int_fast16_t = ::std::os::raw::c_long;
+pub type int_fast32_t = ::std::os::raw::c_long;
+pub type int_fast64_t = ::std::os::raw::c_long;
+pub type uint_fast8_t = ::std::os::raw::c_uchar;
+pub type uint_fast16_t = ::std::os::raw::c_ulong;
+pub type uint_fast32_t = ::std::os::raw::c_ulong;
+pub type uint_fast64_t = ::std::os::raw::c_ulong;
+pub type intmax_t = __intmax_t;
+pub type uintmax_t = __uintmax_t;
+pub type __f32x4_t = [f32; 4usize];
+pub type __f64x2_t = [f64; 2usize];
+pub type __sv_f32_t = __BindgenOpaqueArray<u128, 0usize>;
+pub type __sv_f64_t = __BindgenOpaqueArray<u128, 0usize>;
+pub type __sv_bool_t = __BindgenOpaqueArray<u16, 0usize>;
+unsafe extern "C" {
+    pub fn _ZGVsMxvv_atan2f(arg1: __sv_f32_t, arg2: __sv_f32_t, arg3: __sv_bool_t) -> __sv_f32_t;
 }
 unsafe extern "C" {
-    pub fn fmtcheck(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-    ) -> *const ::std::os::raw::c_char;
+    pub fn _ZGVsMxv_acosf(arg1: __sv_f32_t, arg2: __sv_bool_t) -> __sv_f32_t;
 }
 unsafe extern "C" {
-    pub fn fpurge(arg1: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn _ZGVsMxv_asinf(arg1: __sv_f32_t, arg2: __sv_bool_t) -> __sv_f32_t;
 }
 unsafe extern "C" {
-    pub fn setbuffer(
-        arg1: *mut FILE,
-        arg2: *mut ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
-    );
+    pub fn _ZGVsMxv_atanf(arg1: __sv_f32_t, arg2: __sv_bool_t) -> __sv_f32_t;
 }
 unsafe extern "C" {
-    pub fn setlinebuf(arg1: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn _ZGVsMxv_cosf(arg1: __sv_f32_t, arg2: __sv_bool_t) -> __sv_f32_t;
 }
 unsafe extern "C" {
-    pub fn vasprintf(
-        arg1: *mut *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: va_list,
-    ) -> ::std::os::raw::c_int;
+    pub fn _ZGVsMxv_expf(arg1: __sv_f32_t, arg2: __sv_bool_t) -> __sv_f32_t;
 }
 unsafe extern "C" {
-    pub fn funopen(
-        arg1: *const ::std::os::raw::c_void,
-        arg2: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: *mut ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int,
-        >,
-        arg3: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int,
-        >,
-        arg4: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: fpos_t,
-                arg3: ::std::os::raw::c_int,
-            ) -> fpos_t,
-        >,
-        arg5: ::std::option::Option<
-            unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
-        >,
-    ) -> *mut FILE;
+    pub fn _ZGVsMxv_exp10f(arg1: __sv_f32_t, arg2: __sv_bool_t) -> __sv_f32_t;
 }
 unsafe extern "C" {
-    pub fn __sprintf_chk(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
-        arg3: usize,
-        arg4: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
+    pub fn _ZGVsMxv_exp2f(arg1: __sv_f32_t, arg2: __sv_bool_t) -> __sv_f32_t;
 }
 unsafe extern "C" {
-    pub fn __snprintf_chk(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: usize,
-        arg3: ::std::os::raw::c_int,
-        arg4: usize,
-        arg5: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
+    pub fn _ZGVsMxv_expm1f(arg1: __sv_f32_t, arg2: __sv_bool_t) -> __sv_f32_t;
 }
 unsafe extern "C" {
-    pub fn __vsprintf_chk(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
-        arg3: usize,
-        arg4: *const ::std::os::raw::c_char,
-        arg5: va_list,
-    ) -> ::std::os::raw::c_int;
+    pub fn _ZGVsMxv_logf(arg1: __sv_f32_t, arg2: __sv_bool_t) -> __sv_f32_t;
 }
 unsafe extern "C" {
-    pub fn __vsnprintf_chk(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: usize,
-        arg3: ::std::os::raw::c_int,
-        arg4: usize,
-        arg5: *const ::std::os::raw::c_char,
-        arg6: va_list,
-    ) -> ::std::os::raw::c_int;
+    pub fn _ZGVsMxv_log10f(arg1: __sv_f32_t, arg2: __sv_bool_t) -> __sv_f32_t;
 }
-pub type int_least8_t = i8;
-pub type int_least16_t = i16;
-pub type int_least32_t = i32;
-pub type int_least64_t = i64;
-pub type uint_least8_t = u8;
-pub type uint_least16_t = u16;
-pub type uint_least32_t = u32;
-pub type uint_least64_t = u64;
-pub type int_fast8_t = i8;
-pub type int_fast16_t = i16;
-pub type int_fast32_t = i32;
-pub type int_fast64_t = i64;
-pub type uint_fast8_t = u8;
-pub type uint_fast16_t = u16;
-pub type uint_fast32_t = u32;
-pub type uint_fast64_t = u64;
-pub type intmax_t = ::std::os::raw::c_long;
-pub type uintmax_t = ::std::os::raw::c_ulong;
+unsafe extern "C" {
+    pub fn _ZGVsMxv_log1pf(arg1: __sv_f32_t, arg2: __sv_bool_t) -> __sv_f32_t;
+}
+unsafe extern "C" {
+    pub fn _ZGVsMxv_log2f(arg1: __sv_f32_t, arg2: __sv_bool_t) -> __sv_f32_t;
+}
+unsafe extern "C" {
+    pub fn _ZGVsMxv_sinf(arg1: __sv_f32_t, arg2: __sv_bool_t) -> __sv_f32_t;
+}
+unsafe extern "C" {
+    pub fn _ZGVsMxv_tanf(arg1: __sv_f32_t, arg2: __sv_bool_t) -> __sv_f32_t;
+}
+unsafe extern "C" {
+    pub fn _ZGVsMxvv_atan2(arg1: __sv_f64_t, arg2: __sv_f64_t, arg3: __sv_bool_t) -> __sv_f64_t;
+}
+unsafe extern "C" {
+    pub fn _ZGVsMxv_acos(arg1: __sv_f64_t, arg2: __sv_bool_t) -> __sv_f64_t;
+}
+unsafe extern "C" {
+    pub fn _ZGVsMxv_asin(arg1: __sv_f64_t, arg2: __sv_bool_t) -> __sv_f64_t;
+}
+unsafe extern "C" {
+    pub fn _ZGVsMxv_atan(arg1: __sv_f64_t, arg2: __sv_bool_t) -> __sv_f64_t;
+}
+unsafe extern "C" {
+    pub fn _ZGVsMxv_cos(arg1: __sv_f64_t, arg2: __sv_bool_t) -> __sv_f64_t;
+}
+unsafe extern "C" {
+    pub fn _ZGVsMxv_exp(arg1: __sv_f64_t, arg2: __sv_bool_t) -> __sv_f64_t;
+}
+unsafe extern "C" {
+    pub fn _ZGVsMxv_exp10(arg1: __sv_f64_t, arg2: __sv_bool_t) -> __sv_f64_t;
+}
+unsafe extern "C" {
+    pub fn _ZGVsMxv_exp2(arg1: __sv_f64_t, arg2: __sv_bool_t) -> __sv_f64_t;
+}
+unsafe extern "C" {
+    pub fn _ZGVsMxv_expm1(arg1: __sv_f64_t, arg2: __sv_bool_t) -> __sv_f64_t;
+}
+unsafe extern "C" {
+    pub fn _ZGVsMxv_log(arg1: __sv_f64_t, arg2: __sv_bool_t) -> __sv_f64_t;
+}
+unsafe extern "C" {
+    pub fn _ZGVsMxv_log10(arg1: __sv_f64_t, arg2: __sv_bool_t) -> __sv_f64_t;
+}
+unsafe extern "C" {
+    pub fn _ZGVsMxv_log1p(arg1: __sv_f64_t, arg2: __sv_bool_t) -> __sv_f64_t;
+}
+unsafe extern "C" {
+    pub fn _ZGVsMxv_log2(arg1: __sv_f64_t, arg2: __sv_bool_t) -> __sv_f64_t;
+}
+unsafe extern "C" {
+    pub fn _ZGVsMxv_sin(arg1: __sv_f64_t, arg2: __sv_bool_t) -> __sv_f64_t;
+}
+unsafe extern "C" {
+    pub fn _ZGVsMxv_tan(arg1: __sv_f64_t, arg2: __sv_bool_t) -> __sv_f64_t;
+}
 pub type float_t = f32;
 pub type double_t = f64;
 unsafe extern "C" {
-    pub fn __math_errhandling() -> ::std::os::raw::c_int;
+    pub fn __fpclassify(__value: f64) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn __fpclassifyf(arg1: f32) -> ::std::os::raw::c_int;
+    pub fn __signbit(__value: f64) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn __fpclassifyd(arg1: f64) -> ::std::os::raw::c_int;
+    pub fn __isinf(__value: f64) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn __fpclassifyl(arg1: f64) -> ::std::os::raw::c_int;
+    pub fn __finite(__value: f64) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn acosf(arg1: f32) -> f32;
+    pub fn __isnan(__value: f64) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn acos(arg1: f64) -> f64;
+    pub fn __iseqsig(__x: f64, __y: f64) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn acosl(arg1: f64) -> f64;
+    pub fn __issignaling(__value: f64) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn asinf(arg1: f32) -> f32;
+    pub fn acos(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn asin(arg1: f64) -> f64;
+    pub fn __acos(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn asinl(arg1: f64) -> f64;
+    pub fn asin(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn atanf(arg1: f32) -> f32;
+    pub fn __asin(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn atan(arg1: f64) -> f64;
+    pub fn atan(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn atanl(arg1: f64) -> f64;
+    pub fn __atan(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn atan2f(arg1: f32, arg2: f32) -> f32;
+    pub fn atan2(__y: f64, __x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn atan2(arg1: f64, arg2: f64) -> f64;
+    pub fn __atan2(__y: f64, __x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn atan2l(arg1: f64, arg2: f64) -> f64;
+    pub fn cos(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn cosf(arg1: f32) -> f32;
+    pub fn __cos(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn cos(arg1: f64) -> f64;
+    pub fn sin(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn cosl(arg1: f64) -> f64;
+    pub fn __sin(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn sinf(arg1: f32) -> f32;
+    pub fn tan(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn sin(arg1: f64) -> f64;
+    pub fn __tan(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn sinl(arg1: f64) -> f64;
+    pub fn cosh(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn tanf(arg1: f32) -> f32;
+    pub fn __cosh(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn tan(arg1: f64) -> f64;
+    pub fn sinh(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn tanl(arg1: f64) -> f64;
+    pub fn __sinh(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn acoshf(arg1: f32) -> f32;
+    pub fn tanh(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn acosh(arg1: f64) -> f64;
+    pub fn __tanh(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn acoshl(arg1: f64) -> f64;
+    pub fn acosh(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn asinhf(arg1: f32) -> f32;
+    pub fn __acosh(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn asinh(arg1: f64) -> f64;
+    pub fn asinh(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn asinhl(arg1: f64) -> f64;
+    pub fn __asinh(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn atanhf(arg1: f32) -> f32;
+    pub fn atanh(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn atanh(arg1: f64) -> f64;
+    pub fn __atanh(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn atanhl(arg1: f64) -> f64;
+    pub fn exp(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn coshf(arg1: f32) -> f32;
+    pub fn __exp(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn cosh(arg1: f64) -> f64;
+    pub fn frexp(__x: f64, __exponent: *mut ::std::os::raw::c_int) -> f64;
 }
 unsafe extern "C" {
-    pub fn coshl(arg1: f64) -> f64;
+    pub fn __frexp(__x: f64, __exponent: *mut ::std::os::raw::c_int) -> f64;
 }
 unsafe extern "C" {
-    pub fn sinhf(arg1: f32) -> f32;
+    pub fn ldexp(__x: f64, __exponent: ::std::os::raw::c_int) -> f64;
 }
 unsafe extern "C" {
-    pub fn sinh(arg1: f64) -> f64;
+    pub fn __ldexp(__x: f64, __exponent: ::std::os::raw::c_int) -> f64;
 }
 unsafe extern "C" {
-    pub fn sinhl(arg1: f64) -> f64;
+    pub fn log(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn tanhf(arg1: f32) -> f32;
+    pub fn __log(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn tanh(arg1: f64) -> f64;
+    pub fn log10(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn tanhl(arg1: f64) -> f64;
+    pub fn __log10(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn expf(arg1: f32) -> f32;
+    pub fn modf(__x: f64, __iptr: *mut f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn exp(arg1: f64) -> f64;
+    pub fn __modf(__x: f64, __iptr: *mut f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn expl(arg1: f64) -> f64;
+    pub fn expm1(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn exp2f(arg1: f32) -> f32;
+    pub fn __expm1(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn exp2(arg1: f64) -> f64;
+    pub fn log1p(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn exp2l(arg1: f64) -> f64;
+    pub fn __log1p(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn expm1f(arg1: f32) -> f32;
+    pub fn logb(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn expm1(arg1: f64) -> f64;
+    pub fn __logb(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn expm1l(arg1: f64) -> f64;
+    pub fn exp2(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn logf(arg1: f32) -> f32;
+    pub fn __exp2(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn log(arg1: f64) -> f64;
+    pub fn log2(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn logl(arg1: f64) -> f64;
+    pub fn __log2(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn log10f(arg1: f32) -> f32;
+    pub fn pow(__x: f64, __y: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn log10(arg1: f64) -> f64;
+    pub fn __pow(__x: f64, __y: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn log10l(arg1: f64) -> f64;
+    pub fn sqrt(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn log2f(arg1: f32) -> f32;
+    pub fn __sqrt(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn log2(arg1: f64) -> f64;
+    pub fn hypot(__x: f64, __y: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn log2l(arg1: f64) -> f64;
+    pub fn __hypot(__x: f64, __y: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn log1pf(arg1: f32) -> f32;
+    pub fn cbrt(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn log1p(arg1: f64) -> f64;
+    pub fn __cbrt(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn log1pl(arg1: f64) -> f64;
+    pub fn ceil(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn logbf(arg1: f32) -> f32;
+    pub fn __ceil(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn logb(arg1: f64) -> f64;
+    pub fn fabs(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn logbl(arg1: f64) -> f64;
+    pub fn __fabs(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn modff(arg1: f32, arg2: *mut f32) -> f32;
+    pub fn floor(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn modf(arg1: f64, arg2: *mut f64) -> f64;
+    pub fn __floor(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn modfl(arg1: f64, arg2: *mut f64) -> f64;
+    pub fn fmod(__x: f64, __y: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn ldexpf(arg1: f32, arg2: ::std::os::raw::c_int) -> f32;
+    pub fn __fmod(__x: f64, __y: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn ldexp(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
+    pub fn isinf(__value: f64) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn ldexpl(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
+    pub fn finite(__value: f64) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn frexpf(arg1: f32, arg2: *mut ::std::os::raw::c_int) -> f32;
+    pub fn drem(__x: f64, __y: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn frexp(arg1: f64, arg2: *mut ::std::os::raw::c_int) -> f64;
+    pub fn __drem(__x: f64, __y: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn frexpl(arg1: f64, arg2: *mut ::std::os::raw::c_int) -> f64;
+    pub fn significand(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn ilogbf(arg1: f32) -> ::std::os::raw::c_int;
+    pub fn __significand(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn ilogb(arg1: f64) -> ::std::os::raw::c_int;
+    pub fn copysign(__x: f64, __y: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn ilogbl(arg1: f64) -> ::std::os::raw::c_int;
+    pub fn __copysign(__x: f64, __y: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn scalbnf(arg1: f32, arg2: ::std::os::raw::c_int) -> f32;
+    pub fn nan(__tagb: *const ::std::os::raw::c_char) -> f64;
 }
 unsafe extern "C" {
-    pub fn scalbn(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
+    pub fn __nan(__tagb: *const ::std::os::raw::c_char) -> f64;
 }
 unsafe extern "C" {
-    pub fn scalbnl(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
-}
-unsafe extern "C" {
-    pub fn scalblnf(arg1: f32, arg2: ::std::os::raw::c_long) -> f32;
-}
-unsafe extern "C" {
-    pub fn scalbln(arg1: f64, arg2: ::std::os::raw::c_long) -> f64;
-}
-unsafe extern "C" {
-    pub fn scalblnl(arg1: f64, arg2: ::std::os::raw::c_long) -> f64;
-}
-unsafe extern "C" {
-    pub fn fabsf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn fabs(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn fabsl(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn cbrtf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn cbrt(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn cbrtl(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn hypotf(arg1: f32, arg2: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn hypot(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn hypotl(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn powf(arg1: f32, arg2: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn pow(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn powl(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn sqrtf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn sqrt(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn sqrtl(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn erff(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn erf(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn erfl(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn erfcf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn erfc(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn erfcl(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn lgammaf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn lgamma(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn lgammal(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn tgammaf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn tgamma(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn tgammal(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn ceilf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn ceil(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn ceill(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn floorf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn floor(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn floorl(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn nearbyintf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn nearbyint(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn nearbyintl(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn rintf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn rint(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn rintl(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn lrintf(arg1: f32) -> ::std::os::raw::c_long;
-}
-unsafe extern "C" {
-    pub fn lrint(arg1: f64) -> ::std::os::raw::c_long;
-}
-unsafe extern "C" {
-    pub fn lrintl(arg1: f64) -> ::std::os::raw::c_long;
-}
-unsafe extern "C" {
-    pub fn roundf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn round(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn roundl(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn lroundf(arg1: f32) -> ::std::os::raw::c_long;
-}
-unsafe extern "C" {
-    pub fn lround(arg1: f64) -> ::std::os::raw::c_long;
-}
-unsafe extern "C" {
-    pub fn lroundl(arg1: f64) -> ::std::os::raw::c_long;
-}
-unsafe extern "C" {
-    pub fn llrintf(arg1: f32) -> ::std::os::raw::c_longlong;
-}
-unsafe extern "C" {
-    pub fn llrint(arg1: f64) -> ::std::os::raw::c_longlong;
-}
-unsafe extern "C" {
-    pub fn llrintl(arg1: f64) -> ::std::os::raw::c_longlong;
-}
-unsafe extern "C" {
-    pub fn llroundf(arg1: f32) -> ::std::os::raw::c_longlong;
-}
-unsafe extern "C" {
-    pub fn llround(arg1: f64) -> ::std::os::raw::c_longlong;
-}
-unsafe extern "C" {
-    pub fn llroundl(arg1: f64) -> ::std::os::raw::c_longlong;
-}
-unsafe extern "C" {
-    pub fn truncf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn trunc(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn truncl(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn fmodf(arg1: f32, arg2: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn fmod(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn fmodl(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn remainderf(arg1: f32, arg2: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn remainder(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn remainderl(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn remquof(arg1: f32, arg2: f32, arg3: *mut ::std::os::raw::c_int) -> f32;
-}
-unsafe extern "C" {
-    pub fn remquo(arg1: f64, arg2: f64, arg3: *mut ::std::os::raw::c_int) -> f64;
-}
-unsafe extern "C" {
-    pub fn remquol(arg1: f64, arg2: f64, arg3: *mut ::std::os::raw::c_int) -> f64;
-}
-unsafe extern "C" {
-    pub fn copysignf(arg1: f32, arg2: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn copysign(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn copysignl(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn nanf(arg1: *const ::std::os::raw::c_char) -> f32;
-}
-unsafe extern "C" {
-    pub fn nan(arg1: *const ::std::os::raw::c_char) -> f64;
-}
-unsafe extern "C" {
-    pub fn nanl(arg1: *const ::std::os::raw::c_char) -> f64;
-}
-unsafe extern "C" {
-    pub fn nextafterf(arg1: f32, arg2: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn nextafter(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn nextafterl(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn nexttoward(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn nexttowardf(arg1: f32, arg2: f64) -> f32;
-}
-unsafe extern "C" {
-    pub fn nexttowardl(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn fdimf(arg1: f32, arg2: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn fdim(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn fdiml(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn fmaxf(arg1: f32, arg2: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn fmax(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn fmaxl(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn fminf(arg1: f32, arg2: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn fmin(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn fminl(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn fmaf(arg1: f32, arg2: f32, arg3: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn fma(arg1: f64, arg2: f64, arg3: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn fmal(arg1: f64, arg2: f64, arg3: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn __exp10f(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn __exp10(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn __cospif(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn __cospi(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn __sinpif(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn __sinpi(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn __tanpif(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn __tanpi(arg1: f64) -> f64;
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __float2 {
-    pub __sinval: f32,
-    pub __cosval: f32,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __float2"][::std::mem::size_of::<__float2>() - 8usize];
-    ["Alignment of __float2"][::std::mem::align_of::<__float2>() - 4usize];
-    ["Offset of field: __float2::__sinval"][::std::mem::offset_of!(__float2, __sinval) - 0usize];
-    ["Offset of field: __float2::__cosval"][::std::mem::offset_of!(__float2, __cosval) - 4usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __double2 {
-    pub __sinval: f64,
-    pub __cosval: f64,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __double2"][::std::mem::size_of::<__double2>() - 16usize];
-    ["Alignment of __double2"][::std::mem::align_of::<__double2>() - 8usize];
-    ["Offset of field: __double2::__sinval"][::std::mem::offset_of!(__double2, __sinval) - 0usize];
-    ["Offset of field: __double2::__cosval"][::std::mem::offset_of!(__double2, __cosval) - 8usize];
-};
-unsafe extern "C" {
-    pub fn __sincosf_stret(arg1: f32) -> __float2;
-}
-unsafe extern "C" {
-    pub fn __sincos_stret(arg1: f64) -> __double2;
-}
-unsafe extern "C" {
-    pub fn __sincospif_stret(arg1: f32) -> __float2;
-}
-unsafe extern "C" {
-    pub fn __sincospi_stret(arg1: f64) -> __double2;
+    pub fn isnan(__value: f64) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
     pub fn j0(arg1: f64) -> f64;
 }
 unsafe extern "C" {
+    pub fn __j0(arg1: f64) -> f64;
+}
+unsafe extern "C" {
     pub fn j1(arg1: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn __j1(arg1: f64) -> f64;
 }
 unsafe extern "C" {
     pub fn jn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
 }
 unsafe extern "C" {
+    pub fn __jn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
+}
+unsafe extern "C" {
     pub fn y0(arg1: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn __y0(arg1: f64) -> f64;
 }
 unsafe extern "C" {
     pub fn y1(arg1: f64) -> f64;
 }
 unsafe extern "C" {
+    pub fn __y1(arg1: f64) -> f64;
+}
+unsafe extern "C" {
     pub fn yn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn scalb(arg1: f64, arg2: f64) -> f64;
+    pub fn __yn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn erf(arg1: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn __erf(arg1: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn erfc(arg1: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn __erfc(arg1: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn lgamma(arg1: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn __lgamma(arg1: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn tgamma(arg1: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn __tgamma(arg1: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn gamma(arg1: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn __gamma(arg1: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn lgamma_r(arg1: f64, __signgamp: *mut ::std::os::raw::c_int) -> f64;
+}
+unsafe extern "C" {
+    pub fn __lgamma_r(arg1: f64, __signgamp: *mut ::std::os::raw::c_int) -> f64;
+}
+unsafe extern "C" {
+    pub fn rint(__x: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn __rint(__x: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn nextafter(__x: f64, __y: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn __nextafter(__x: f64, __y: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn nexttoward(__x: f64, __y: u128) -> f64;
+}
+unsafe extern "C" {
+    pub fn __nexttoward(__x: f64, __y: u128) -> f64;
+}
+unsafe extern "C" {
+    pub fn remainder(__x: f64, __y: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn __remainder(__x: f64, __y: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn scalbn(__x: f64, __n: ::std::os::raw::c_int) -> f64;
+}
+unsafe extern "C" {
+    pub fn __scalbn(__x: f64, __n: ::std::os::raw::c_int) -> f64;
+}
+unsafe extern "C" {
+    pub fn ilogb(__x: f64) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn __ilogb(__x: f64) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn scalbln(__x: f64, __n: ::std::os::raw::c_long) -> f64;
+}
+unsafe extern "C" {
+    pub fn __scalbln(__x: f64, __n: ::std::os::raw::c_long) -> f64;
+}
+unsafe extern "C" {
+    pub fn nearbyint(__x: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn __nearbyint(__x: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn round(__x: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn __round(__x: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn trunc(__x: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn __trunc(__x: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn remquo(__x: f64, __y: f64, __quo: *mut ::std::os::raw::c_int) -> f64;
+}
+unsafe extern "C" {
+    pub fn __remquo(__x: f64, __y: f64, __quo: *mut ::std::os::raw::c_int) -> f64;
+}
+unsafe extern "C" {
+    pub fn lrint(__x: f64) -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn __lrint(__x: f64) -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn llrint(__x: f64) -> ::std::os::raw::c_longlong;
+}
+unsafe extern "C" {
+    pub fn __llrint(__x: f64) -> ::std::os::raw::c_longlong;
+}
+unsafe extern "C" {
+    pub fn lround(__x: f64) -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn __lround(__x: f64) -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn llround(__x: f64) -> ::std::os::raw::c_longlong;
+}
+unsafe extern "C" {
+    pub fn __llround(__x: f64) -> ::std::os::raw::c_longlong;
+}
+unsafe extern "C" {
+    pub fn fdim(__x: f64, __y: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn __fdim(__x: f64, __y: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn fmax(__x: f64, __y: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn __fmax(__x: f64, __y: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn fmin(__x: f64, __y: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn __fmin(__x: f64, __y: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn fma(__x: f64, __y: f64, __z: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn __fma(__x: f64, __y: f64, __z: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn scalb(__x: f64, __n: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn __scalb(__x: f64, __n: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn __fpclassifyf(__value: f32) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn __signbitf(__value: f32) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn __isinff(__value: f32) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn __finitef(__value: f32) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn __isnanf(__value: f32) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn __iseqsigf(__x: f32, __y: f32) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn __issignalingf(__value: f32) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn acosf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __acosf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn asinf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __asinf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn atanf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __atanf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn atan2f(__y: f32, __x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __atan2f(__y: f32, __x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn cosf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __cosf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn sinf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __sinf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn tanf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __tanf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn coshf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __coshf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn sinhf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __sinhf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn tanhf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __tanhf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn acoshf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __acoshf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn asinhf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __asinhf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn atanhf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __atanhf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn expf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __expf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn frexpf(__x: f32, __exponent: *mut ::std::os::raw::c_int) -> f32;
+}
+unsafe extern "C" {
+    pub fn __frexpf(__x: f32, __exponent: *mut ::std::os::raw::c_int) -> f32;
+}
+unsafe extern "C" {
+    pub fn ldexpf(__x: f32, __exponent: ::std::os::raw::c_int) -> f32;
+}
+unsafe extern "C" {
+    pub fn __ldexpf(__x: f32, __exponent: ::std::os::raw::c_int) -> f32;
+}
+unsafe extern "C" {
+    pub fn logf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __logf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn log10f(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __log10f(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn modff(__x: f32, __iptr: *mut f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __modff(__x: f32, __iptr: *mut f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn expm1f(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __expm1f(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn log1pf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __log1pf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn logbf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __logbf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn exp2f(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __exp2f(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn log2f(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __log2f(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn powf(__x: f32, __y: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __powf(__x: f32, __y: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn sqrtf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __sqrtf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn hypotf(__x: f32, __y: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __hypotf(__x: f32, __y: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn cbrtf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __cbrtf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn ceilf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __ceilf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn fabsf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __fabsf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn floorf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __floorf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn fmodf(__x: f32, __y: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __fmodf(__x: f32, __y: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn isinff(__value: f32) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn finitef(__value: f32) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn dremf(__x: f32, __y: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __dremf(__x: f32, __y: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn significandf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __significandf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn copysignf(__x: f32, __y: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __copysignf(__x: f32, __y: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn nanf(__tagb: *const ::std::os::raw::c_char) -> f32;
+}
+unsafe extern "C" {
+    pub fn __nanf(__tagb: *const ::std::os::raw::c_char) -> f32;
+}
+unsafe extern "C" {
+    pub fn isnanf(__value: f32) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn j0f(arg1: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __j0f(arg1: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn j1f(arg1: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __j1f(arg1: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn jnf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __jnf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn y0f(arg1: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __y0f(arg1: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn y1f(arg1: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __y1f(arg1: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn ynf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __ynf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn erff(arg1: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __erff(arg1: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn erfcf(arg1: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __erfcf(arg1: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn lgammaf(arg1: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __lgammaf(arg1: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn tgammaf(arg1: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __tgammaf(arg1: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn gammaf(arg1: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __gammaf(arg1: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn lgammaf_r(arg1: f32, __signgamp: *mut ::std::os::raw::c_int) -> f32;
+}
+unsafe extern "C" {
+    pub fn __lgammaf_r(arg1: f32, __signgamp: *mut ::std::os::raw::c_int) -> f32;
+}
+unsafe extern "C" {
+    pub fn rintf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __rintf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn nextafterf(__x: f32, __y: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __nextafterf(__x: f32, __y: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn nexttowardf(__x: f32, __y: u128) -> f32;
+}
+unsafe extern "C" {
+    pub fn __nexttowardf(__x: f32, __y: u128) -> f32;
+}
+unsafe extern "C" {
+    pub fn remainderf(__x: f32, __y: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __remainderf(__x: f32, __y: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn scalbnf(__x: f32, __n: ::std::os::raw::c_int) -> f32;
+}
+unsafe extern "C" {
+    pub fn __scalbnf(__x: f32, __n: ::std::os::raw::c_int) -> f32;
+}
+unsafe extern "C" {
+    pub fn ilogbf(__x: f32) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn __ilogbf(__x: f32) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn scalblnf(__x: f32, __n: ::std::os::raw::c_long) -> f32;
+}
+unsafe extern "C" {
+    pub fn __scalblnf(__x: f32, __n: ::std::os::raw::c_long) -> f32;
+}
+unsafe extern "C" {
+    pub fn nearbyintf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __nearbyintf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn roundf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __roundf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn truncf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __truncf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn remquof(__x: f32, __y: f32, __quo: *mut ::std::os::raw::c_int) -> f32;
+}
+unsafe extern "C" {
+    pub fn __remquof(__x: f32, __y: f32, __quo: *mut ::std::os::raw::c_int) -> f32;
+}
+unsafe extern "C" {
+    pub fn lrintf(__x: f32) -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn __lrintf(__x: f32) -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn llrintf(__x: f32) -> ::std::os::raw::c_longlong;
+}
+unsafe extern "C" {
+    pub fn __llrintf(__x: f32) -> ::std::os::raw::c_longlong;
+}
+unsafe extern "C" {
+    pub fn lroundf(__x: f32) -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn __lroundf(__x: f32) -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn llroundf(__x: f32) -> ::std::os::raw::c_longlong;
+}
+unsafe extern "C" {
+    pub fn __llroundf(__x: f32) -> ::std::os::raw::c_longlong;
+}
+unsafe extern "C" {
+    pub fn fdimf(__x: f32, __y: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __fdimf(__x: f32, __y: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn fmaxf(__x: f32, __y: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __fmaxf(__x: f32, __y: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn fminf(__x: f32, __y: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __fminf(__x: f32, __y: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn fmaf(__x: f32, __y: f32, __z: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __fmaf(__x: f32, __y: f32, __z: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn scalbf(__x: f32, __n: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __scalbf(__x: f32, __n: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __fpclassifyl(__value: u128) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn __signbitl(__value: u128) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn __isinfl(__value: u128) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn __finitel(__value: u128) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn __isnanl(__value: u128) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn __iseqsigl(__x: u128, __y: u128) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn __issignalingl(__value: u128) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn acosl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __acosl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn asinl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __asinl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn atanl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __atanl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn atan2l(__y: u128, __x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __atan2l(__y: u128, __x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn cosl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __cosl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn sinl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __sinl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn tanl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __tanl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn coshl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __coshl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn sinhl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __sinhl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn tanhl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __tanhl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn acoshl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __acoshl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn asinhl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __asinhl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn atanhl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __atanhl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn expl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __expl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn frexpl(__x: u128, __exponent: *mut ::std::os::raw::c_int) -> u128;
+}
+unsafe extern "C" {
+    pub fn __frexpl(__x: u128, __exponent: *mut ::std::os::raw::c_int) -> u128;
+}
+unsafe extern "C" {
+    pub fn ldexpl(__x: u128, __exponent: ::std::os::raw::c_int) -> u128;
+}
+unsafe extern "C" {
+    pub fn __ldexpl(__x: u128, __exponent: ::std::os::raw::c_int) -> u128;
+}
+unsafe extern "C" {
+    pub fn logl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __logl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn log10l(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __log10l(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn modfl(__x: u128, __iptr: *mut u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __modfl(__x: u128, __iptr: *mut u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn expm1l(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __expm1l(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn log1pl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __log1pl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn logbl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __logbl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn exp2l(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __exp2l(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn log2l(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __log2l(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn powl(__x: u128, __y: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __powl(__x: u128, __y: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn sqrtl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __sqrtl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn hypotl(__x: u128, __y: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __hypotl(__x: u128, __y: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn cbrtl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __cbrtl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn ceill(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __ceill(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn fabsl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __fabsl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn floorl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __floorl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn fmodl(__x: u128, __y: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __fmodl(__x: u128, __y: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn isinfl(__value: u128) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn finitel(__value: u128) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn dreml(__x: u128, __y: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __dreml(__x: u128, __y: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn significandl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __significandl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn copysignl(__x: u128, __y: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __copysignl(__x: u128, __y: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn nanl(__tagb: *const ::std::os::raw::c_char) -> u128;
+}
+unsafe extern "C" {
+    pub fn __nanl(__tagb: *const ::std::os::raw::c_char) -> u128;
+}
+unsafe extern "C" {
+    pub fn isnanl(__value: u128) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn j0l(arg1: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __j0l(arg1: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn j1l(arg1: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __j1l(arg1: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn jnl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __jnl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn y0l(arg1: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __y0l(arg1: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn y1l(arg1: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __y1l(arg1: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn ynl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __ynl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn erfl(arg1: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __erfl(arg1: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn erfcl(arg1: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __erfcl(arg1: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn lgammal(arg1: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __lgammal(arg1: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn tgammal(arg1: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __tgammal(arg1: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn gammal(arg1: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __gammal(arg1: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn lgammal_r(arg1: u128, __signgamp: *mut ::std::os::raw::c_int) -> u128;
+}
+unsafe extern "C" {
+    pub fn __lgammal_r(arg1: u128, __signgamp: *mut ::std::os::raw::c_int) -> u128;
+}
+unsafe extern "C" {
+    pub fn rintl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __rintl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn nextafterl(__x: u128, __y: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __nextafterl(__x: u128, __y: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn nexttowardl(__x: u128, __y: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __nexttowardl(__x: u128, __y: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn remainderl(__x: u128, __y: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __remainderl(__x: u128, __y: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn scalbnl(__x: u128, __n: ::std::os::raw::c_int) -> u128;
+}
+unsafe extern "C" {
+    pub fn __scalbnl(__x: u128, __n: ::std::os::raw::c_int) -> u128;
+}
+unsafe extern "C" {
+    pub fn ilogbl(__x: u128) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn __ilogbl(__x: u128) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn scalblnl(__x: u128, __n: ::std::os::raw::c_long) -> u128;
+}
+unsafe extern "C" {
+    pub fn __scalblnl(__x: u128, __n: ::std::os::raw::c_long) -> u128;
+}
+unsafe extern "C" {
+    pub fn nearbyintl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __nearbyintl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn roundl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __roundl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn truncl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __truncl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn remquol(__x: u128, __y: u128, __quo: *mut ::std::os::raw::c_int) -> u128;
+}
+unsafe extern "C" {
+    pub fn __remquol(__x: u128, __y: u128, __quo: *mut ::std::os::raw::c_int) -> u128;
+}
+unsafe extern "C" {
+    pub fn lrintl(__x: u128) -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn __lrintl(__x: u128) -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn llrintl(__x: u128) -> ::std::os::raw::c_longlong;
+}
+unsafe extern "C" {
+    pub fn __llrintl(__x: u128) -> ::std::os::raw::c_longlong;
+}
+unsafe extern "C" {
+    pub fn lroundl(__x: u128) -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn __lroundl(__x: u128) -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn llroundl(__x: u128) -> ::std::os::raw::c_longlong;
+}
+unsafe extern "C" {
+    pub fn __llroundl(__x: u128) -> ::std::os::raw::c_longlong;
+}
+unsafe extern "C" {
+    pub fn fdiml(__x: u128, __y: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __fdiml(__x: u128, __y: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn fmaxl(__x: u128, __y: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __fmaxl(__x: u128, __y: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn fminl(__x: u128, __y: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __fminl(__x: u128, __y: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn fmal(__x: u128, __y: u128, __z: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __fmal(__x: u128, __y: u128, __z: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn scalbl(__x: u128, __n: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __scalbl(__x: u128, __n: u128) -> u128;
 }
 unsafe extern "C" {
     pub static mut signgam: ::std::os::raw::c_int;
 }
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct exception {
-    pub type_: ::std::os::raw::c_int,
-    pub name: *mut ::std::os::raw::c_char,
-    pub arg1: f64,
-    pub arg2: f64,
-    pub retval: f64,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of exception"][::std::mem::size_of::<exception>() - 40usize];
-    ["Alignment of exception"][::std::mem::align_of::<exception>() - 8usize];
-    ["Offset of field: exception::type_"][::std::mem::offset_of!(exception, type_) - 0usize];
-    ["Offset of field: exception::name"][::std::mem::offset_of!(exception, name) - 8usize];
-    ["Offset of field: exception::arg1"][::std::mem::offset_of!(exception, arg1) - 16usize];
-    ["Offset of field: exception::arg2"][::std::mem::offset_of!(exception, arg2) - 24usize];
-    ["Offset of field: exception::retval"][::std::mem::offset_of!(exception, retval) - 32usize];
-};
+pub const FP_NAN: _bindgen_ty_1 = 0;
+pub const FP_INFINITE: _bindgen_ty_1 = 1;
+pub const FP_ZERO: _bindgen_ty_1 = 2;
+pub const FP_SUBNORMAL: _bindgen_ty_1 = 3;
+pub const FP_NORMAL: _bindgen_ty_1 = 4;
+pub type _bindgen_ty_1 = ::std::os::raw::c_uint;
 unsafe extern "C" {
-    pub fn __assert_rtn(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
-        arg4: *const ::std::os::raw::c_char,
+    pub fn __assert_fail(
+        __assertion: *const ::std::os::raw::c_char,
+        __file: *const ::std::os::raw::c_char,
+        __line: ::std::os::raw::c_uint,
+        __function: *const ::std::os::raw::c_char,
     ) -> !;
 }
-pub const idtype_t_P_ALL: idtype_t = 0;
-pub const idtype_t_P_PID: idtype_t = 1;
-pub const idtype_t_P_PGID: idtype_t = 2;
-pub type idtype_t = ::std::os::raw::c_uint;
-pub type pid_t = __darwin_pid_t;
-pub type id_t = __darwin_id_t;
-pub type sig_atomic_t = ::std::os::raw::c_int;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_arm_exception_state {
-    pub __exception: __uint32_t,
-    pub __fsr: __uint32_t,
-    pub __far: __uint32_t,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __darwin_arm_exception_state"]
-        [::std::mem::size_of::<__darwin_arm_exception_state>() - 12usize];
-    ["Alignment of __darwin_arm_exception_state"]
-        [::std::mem::align_of::<__darwin_arm_exception_state>() - 4usize];
-    ["Offset of field: __darwin_arm_exception_state::__exception"]
-        [::std::mem::offset_of!(__darwin_arm_exception_state, __exception) - 0usize];
-    ["Offset of field: __darwin_arm_exception_state::__fsr"]
-        [::std::mem::offset_of!(__darwin_arm_exception_state, __fsr) - 4usize];
-    ["Offset of field: __darwin_arm_exception_state::__far"]
-        [::std::mem::offset_of!(__darwin_arm_exception_state, __far) - 8usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_arm_exception_state64 {
-    pub __far: __uint64_t,
-    pub __esr: __uint32_t,
-    pub __exception: __uint32_t,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __darwin_arm_exception_state64"]
-        [::std::mem::size_of::<__darwin_arm_exception_state64>() - 16usize];
-    ["Alignment of __darwin_arm_exception_state64"]
-        [::std::mem::align_of::<__darwin_arm_exception_state64>() - 8usize];
-    ["Offset of field: __darwin_arm_exception_state64::__far"]
-        [::std::mem::offset_of!(__darwin_arm_exception_state64, __far) - 0usize];
-    ["Offset of field: __darwin_arm_exception_state64::__esr"]
-        [::std::mem::offset_of!(__darwin_arm_exception_state64, __esr) - 8usize];
-    ["Offset of field: __darwin_arm_exception_state64::__exception"]
-        [::std::mem::offset_of!(__darwin_arm_exception_state64, __exception) - 12usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_arm_thread_state {
-    pub __r: [__uint32_t; 13usize],
-    pub __sp: __uint32_t,
-    pub __lr: __uint32_t,
-    pub __pc: __uint32_t,
-    pub __cpsr: __uint32_t,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __darwin_arm_thread_state"]
-        [::std::mem::size_of::<__darwin_arm_thread_state>() - 68usize];
-    ["Alignment of __darwin_arm_thread_state"]
-        [::std::mem::align_of::<__darwin_arm_thread_state>() - 4usize];
-    ["Offset of field: __darwin_arm_thread_state::__r"]
-        [::std::mem::offset_of!(__darwin_arm_thread_state, __r) - 0usize];
-    ["Offset of field: __darwin_arm_thread_state::__sp"]
-        [::std::mem::offset_of!(__darwin_arm_thread_state, __sp) - 52usize];
-    ["Offset of field: __darwin_arm_thread_state::__lr"]
-        [::std::mem::offset_of!(__darwin_arm_thread_state, __lr) - 56usize];
-    ["Offset of field: __darwin_arm_thread_state::__pc"]
-        [::std::mem::offset_of!(__darwin_arm_thread_state, __pc) - 60usize];
-    ["Offset of field: __darwin_arm_thread_state::__cpsr"]
-        [::std::mem::offset_of!(__darwin_arm_thread_state, __cpsr) - 64usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_arm_thread_state64 {
-    pub __x: [__uint64_t; 29usize],
-    pub __fp: __uint64_t,
-    pub __lr: __uint64_t,
-    pub __sp: __uint64_t,
-    pub __pc: __uint64_t,
-    pub __cpsr: __uint32_t,
-    pub __pad: __uint32_t,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __darwin_arm_thread_state64"]
-        [::std::mem::size_of::<__darwin_arm_thread_state64>() - 272usize];
-    ["Alignment of __darwin_arm_thread_state64"]
-        [::std::mem::align_of::<__darwin_arm_thread_state64>() - 8usize];
-    ["Offset of field: __darwin_arm_thread_state64::__x"]
-        [::std::mem::offset_of!(__darwin_arm_thread_state64, __x) - 0usize];
-    ["Offset of field: __darwin_arm_thread_state64::__fp"]
-        [::std::mem::offset_of!(__darwin_arm_thread_state64, __fp) - 232usize];
-    ["Offset of field: __darwin_arm_thread_state64::__lr"]
-        [::std::mem::offset_of!(__darwin_arm_thread_state64, __lr) - 240usize];
-    ["Offset of field: __darwin_arm_thread_state64::__sp"]
-        [::std::mem::offset_of!(__darwin_arm_thread_state64, __sp) - 248usize];
-    ["Offset of field: __darwin_arm_thread_state64::__pc"]
-        [::std::mem::offset_of!(__darwin_arm_thread_state64, __pc) - 256usize];
-    ["Offset of field: __darwin_arm_thread_state64::__cpsr"]
-        [::std::mem::offset_of!(__darwin_arm_thread_state64, __cpsr) - 264usize];
-    ["Offset of field: __darwin_arm_thread_state64::__pad"]
-        [::std::mem::offset_of!(__darwin_arm_thread_state64, __pad) - 268usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_arm_vfp_state {
-    pub __r: [__uint32_t; 64usize],
-    pub __fpscr: __uint32_t,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __darwin_arm_vfp_state"][::std::mem::size_of::<__darwin_arm_vfp_state>() - 260usize];
-    ["Alignment of __darwin_arm_vfp_state"]
-        [::std::mem::align_of::<__darwin_arm_vfp_state>() - 4usize];
-    ["Offset of field: __darwin_arm_vfp_state::__r"]
-        [::std::mem::offset_of!(__darwin_arm_vfp_state, __r) - 0usize];
-    ["Offset of field: __darwin_arm_vfp_state::__fpscr"]
-        [::std::mem::offset_of!(__darwin_arm_vfp_state, __fpscr) - 256usize];
-};
-#[repr(C)]
-#[repr(align(16))]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_arm_neon_state64 {
-    pub __v: [__uint128_t; 32usize],
-    pub __fpsr: __uint32_t,
-    pub __fpcr: __uint32_t,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __darwin_arm_neon_state64"]
-        [::std::mem::size_of::<__darwin_arm_neon_state64>() - 528usize];
-    ["Alignment of __darwin_arm_neon_state64"]
-        [::std::mem::align_of::<__darwin_arm_neon_state64>() - 16usize];
-    ["Offset of field: __darwin_arm_neon_state64::__v"]
-        [::std::mem::offset_of!(__darwin_arm_neon_state64, __v) - 0usize];
-    ["Offset of field: __darwin_arm_neon_state64::__fpsr"]
-        [::std::mem::offset_of!(__darwin_arm_neon_state64, __fpsr) - 512usize];
-    ["Offset of field: __darwin_arm_neon_state64::__fpcr"]
-        [::std::mem::offset_of!(__darwin_arm_neon_state64, __fpcr) - 516usize];
-};
-#[repr(C)]
-#[repr(align(16))]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_arm_neon_state {
-    pub __v: [__uint128_t; 16usize],
-    pub __fpsr: __uint32_t,
-    pub __fpcr: __uint32_t,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __darwin_arm_neon_state"]
-        [::std::mem::size_of::<__darwin_arm_neon_state>() - 272usize];
-    ["Alignment of __darwin_arm_neon_state"]
-        [::std::mem::align_of::<__darwin_arm_neon_state>() - 16usize];
-    ["Offset of field: __darwin_arm_neon_state::__v"]
-        [::std::mem::offset_of!(__darwin_arm_neon_state, __v) - 0usize];
-    ["Offset of field: __darwin_arm_neon_state::__fpsr"]
-        [::std::mem::offset_of!(__darwin_arm_neon_state, __fpsr) - 256usize];
-    ["Offset of field: __darwin_arm_neon_state::__fpcr"]
-        [::std::mem::offset_of!(__darwin_arm_neon_state, __fpcr) - 260usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __arm_pagein_state {
-    pub __pagein_error: ::std::os::raw::c_int,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __arm_pagein_state"][::std::mem::size_of::<__arm_pagein_state>() - 4usize];
-    ["Alignment of __arm_pagein_state"][::std::mem::align_of::<__arm_pagein_state>() - 4usize];
-    ["Offset of field: __arm_pagein_state::__pagein_error"]
-        [::std::mem::offset_of!(__arm_pagein_state, __pagein_error) - 0usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __arm_legacy_debug_state {
-    pub __bvr: [__uint32_t; 16usize],
-    pub __bcr: [__uint32_t; 16usize],
-    pub __wvr: [__uint32_t; 16usize],
-    pub __wcr: [__uint32_t; 16usize],
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __arm_legacy_debug_state"]
-        [::std::mem::size_of::<__arm_legacy_debug_state>() - 256usize];
-    ["Alignment of __arm_legacy_debug_state"]
-        [::std::mem::align_of::<__arm_legacy_debug_state>() - 4usize];
-    ["Offset of field: __arm_legacy_debug_state::__bvr"]
-        [::std::mem::offset_of!(__arm_legacy_debug_state, __bvr) - 0usize];
-    ["Offset of field: __arm_legacy_debug_state::__bcr"]
-        [::std::mem::offset_of!(__arm_legacy_debug_state, __bcr) - 64usize];
-    ["Offset of field: __arm_legacy_debug_state::__wvr"]
-        [::std::mem::offset_of!(__arm_legacy_debug_state, __wvr) - 128usize];
-    ["Offset of field: __arm_legacy_debug_state::__wcr"]
-        [::std::mem::offset_of!(__arm_legacy_debug_state, __wcr) - 192usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_arm_debug_state32 {
-    pub __bvr: [__uint32_t; 16usize],
-    pub __bcr: [__uint32_t; 16usize],
-    pub __wvr: [__uint32_t; 16usize],
-    pub __wcr: [__uint32_t; 16usize],
-    pub __mdscr_el1: __uint64_t,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __darwin_arm_debug_state32"]
-        [::std::mem::size_of::<__darwin_arm_debug_state32>() - 264usize];
-    ["Alignment of __darwin_arm_debug_state32"]
-        [::std::mem::align_of::<__darwin_arm_debug_state32>() - 8usize];
-    ["Offset of field: __darwin_arm_debug_state32::__bvr"]
-        [::std::mem::offset_of!(__darwin_arm_debug_state32, __bvr) - 0usize];
-    ["Offset of field: __darwin_arm_debug_state32::__bcr"]
-        [::std::mem::offset_of!(__darwin_arm_debug_state32, __bcr) - 64usize];
-    ["Offset of field: __darwin_arm_debug_state32::__wvr"]
-        [::std::mem::offset_of!(__darwin_arm_debug_state32, __wvr) - 128usize];
-    ["Offset of field: __darwin_arm_debug_state32::__wcr"]
-        [::std::mem::offset_of!(__darwin_arm_debug_state32, __wcr) - 192usize];
-    ["Offset of field: __darwin_arm_debug_state32::__mdscr_el1"]
-        [::std::mem::offset_of!(__darwin_arm_debug_state32, __mdscr_el1) - 256usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_arm_debug_state64 {
-    pub __bvr: [__uint64_t; 16usize],
-    pub __bcr: [__uint64_t; 16usize],
-    pub __wvr: [__uint64_t; 16usize],
-    pub __wcr: [__uint64_t; 16usize],
-    pub __mdscr_el1: __uint64_t,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __darwin_arm_debug_state64"]
-        [::std::mem::size_of::<__darwin_arm_debug_state64>() - 520usize];
-    ["Alignment of __darwin_arm_debug_state64"]
-        [::std::mem::align_of::<__darwin_arm_debug_state64>() - 8usize];
-    ["Offset of field: __darwin_arm_debug_state64::__bvr"]
-        [::std::mem::offset_of!(__darwin_arm_debug_state64, __bvr) - 0usize];
-    ["Offset of field: __darwin_arm_debug_state64::__bcr"]
-        [::std::mem::offset_of!(__darwin_arm_debug_state64, __bcr) - 128usize];
-    ["Offset of field: __darwin_arm_debug_state64::__wvr"]
-        [::std::mem::offset_of!(__darwin_arm_debug_state64, __wvr) - 256usize];
-    ["Offset of field: __darwin_arm_debug_state64::__wcr"]
-        [::std::mem::offset_of!(__darwin_arm_debug_state64, __wcr) - 384usize];
-    ["Offset of field: __darwin_arm_debug_state64::__mdscr_el1"]
-        [::std::mem::offset_of!(__darwin_arm_debug_state64, __mdscr_el1) - 512usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_arm_cpmu_state64 {
-    pub __ctrs: [__uint64_t; 16usize],
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __darwin_arm_cpmu_state64"]
-        [::std::mem::size_of::<__darwin_arm_cpmu_state64>() - 128usize];
-    ["Alignment of __darwin_arm_cpmu_state64"]
-        [::std::mem::align_of::<__darwin_arm_cpmu_state64>() - 8usize];
-    ["Offset of field: __darwin_arm_cpmu_state64::__ctrs"]
-        [::std::mem::offset_of!(__darwin_arm_cpmu_state64, __ctrs) - 0usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_mcontext32 {
-    pub __es: __darwin_arm_exception_state,
-    pub __ss: __darwin_arm_thread_state,
-    pub __fs: __darwin_arm_vfp_state,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __darwin_mcontext32"][::std::mem::size_of::<__darwin_mcontext32>() - 340usize];
-    ["Alignment of __darwin_mcontext32"][::std::mem::align_of::<__darwin_mcontext32>() - 4usize];
-    ["Offset of field: __darwin_mcontext32::__es"]
-        [::std::mem::offset_of!(__darwin_mcontext32, __es) - 0usize];
-    ["Offset of field: __darwin_mcontext32::__ss"]
-        [::std::mem::offset_of!(__darwin_mcontext32, __ss) - 12usize];
-    ["Offset of field: __darwin_mcontext32::__fs"]
-        [::std::mem::offset_of!(__darwin_mcontext32, __fs) - 80usize];
-};
-#[repr(C)]
-#[repr(align(16))]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_mcontext64 {
-    pub __es: __darwin_arm_exception_state64,
-    pub __ss: __darwin_arm_thread_state64,
-    pub __ns: __darwin_arm_neon_state64,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __darwin_mcontext64"][::std::mem::size_of::<__darwin_mcontext64>() - 816usize];
-    ["Alignment of __darwin_mcontext64"][::std::mem::align_of::<__darwin_mcontext64>() - 16usize];
-    ["Offset of field: __darwin_mcontext64::__es"]
-        [::std::mem::offset_of!(__darwin_mcontext64, __es) - 0usize];
-    ["Offset of field: __darwin_mcontext64::__ss"]
-        [::std::mem::offset_of!(__darwin_mcontext64, __ss) - 16usize];
-    ["Offset of field: __darwin_mcontext64::__ns"]
-        [::std::mem::offset_of!(__darwin_mcontext64, __ns) - 288usize];
-};
-pub type mcontext_t = *mut __darwin_mcontext64;
-pub type pthread_attr_t = __darwin_pthread_attr_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_sigaltstack {
-    pub ss_sp: *mut ::std::os::raw::c_void,
-    pub ss_size: __darwin_size_t,
-    pub ss_flags: ::std::os::raw::c_int,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __darwin_sigaltstack"][::std::mem::size_of::<__darwin_sigaltstack>() - 24usize];
-    ["Alignment of __darwin_sigaltstack"][::std::mem::align_of::<__darwin_sigaltstack>() - 8usize];
-    ["Offset of field: __darwin_sigaltstack::ss_sp"]
-        [::std::mem::offset_of!(__darwin_sigaltstack, ss_sp) - 0usize];
-    ["Offset of field: __darwin_sigaltstack::ss_size"]
-        [::std::mem::offset_of!(__darwin_sigaltstack, ss_size) - 8usize];
-    ["Offset of field: __darwin_sigaltstack::ss_flags"]
-        [::std::mem::offset_of!(__darwin_sigaltstack, ss_flags) - 16usize];
-};
-pub type stack_t = __darwin_sigaltstack;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_ucontext {
-    pub uc_onstack: ::std::os::raw::c_int,
-    pub uc_sigmask: __darwin_sigset_t,
-    pub uc_stack: __darwin_sigaltstack,
-    pub uc_link: *mut __darwin_ucontext,
-    pub uc_mcsize: __darwin_size_t,
-    pub uc_mcontext: *mut __darwin_mcontext64,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __darwin_ucontext"][::std::mem::size_of::<__darwin_ucontext>() - 56usize];
-    ["Alignment of __darwin_ucontext"][::std::mem::align_of::<__darwin_ucontext>() - 8usize];
-    ["Offset of field: __darwin_ucontext::uc_onstack"]
-        [::std::mem::offset_of!(__darwin_ucontext, uc_onstack) - 0usize];
-    ["Offset of field: __darwin_ucontext::uc_sigmask"]
-        [::std::mem::offset_of!(__darwin_ucontext, uc_sigmask) - 4usize];
-    ["Offset of field: __darwin_ucontext::uc_stack"]
-        [::std::mem::offset_of!(__darwin_ucontext, uc_stack) - 8usize];
-    ["Offset of field: __darwin_ucontext::uc_link"]
-        [::std::mem::offset_of!(__darwin_ucontext, uc_link) - 32usize];
-    ["Offset of field: __darwin_ucontext::uc_mcsize"]
-        [::std::mem::offset_of!(__darwin_ucontext, uc_mcsize) - 40usize];
-    ["Offset of field: __darwin_ucontext::uc_mcontext"]
-        [::std::mem::offset_of!(__darwin_ucontext, uc_mcontext) - 48usize];
-};
-pub type ucontext_t = __darwin_ucontext;
-pub type sigset_t = __darwin_sigset_t;
-pub type uid_t = __darwin_uid_t;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union sigval {
-    pub sival_int: ::std::os::raw::c_int,
-    pub sival_ptr: *mut ::std::os::raw::c_void,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of sigval"][::std::mem::size_of::<sigval>() - 8usize];
-    ["Alignment of sigval"][::std::mem::align_of::<sigval>() - 8usize];
-    ["Offset of field: sigval::sival_int"][::std::mem::offset_of!(sigval, sival_int) - 0usize];
-    ["Offset of field: sigval::sival_ptr"][::std::mem::offset_of!(sigval, sival_ptr) - 0usize];
-};
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct sigevent {
-    pub sigev_notify: ::std::os::raw::c_int,
-    pub sigev_signo: ::std::os::raw::c_int,
-    pub sigev_value: sigval,
-    pub sigev_notify_function: ::std::option::Option<unsafe extern "C" fn(arg1: sigval)>,
-    pub sigev_notify_attributes: *mut pthread_attr_t,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of sigevent"][::std::mem::size_of::<sigevent>() - 32usize];
-    ["Alignment of sigevent"][::std::mem::align_of::<sigevent>() - 8usize];
-    ["Offset of field: sigevent::sigev_notify"]
-        [::std::mem::offset_of!(sigevent, sigev_notify) - 0usize];
-    ["Offset of field: sigevent::sigev_signo"]
-        [::std::mem::offset_of!(sigevent, sigev_signo) - 4usize];
-    ["Offset of field: sigevent::sigev_value"]
-        [::std::mem::offset_of!(sigevent, sigev_value) - 8usize];
-    ["Offset of field: sigevent::sigev_notify_function"]
-        [::std::mem::offset_of!(sigevent, sigev_notify_function) - 16usize];
-    ["Offset of field: sigevent::sigev_notify_attributes"]
-        [::std::mem::offset_of!(sigevent, sigev_notify_attributes) - 24usize];
-};
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __siginfo {
-    pub si_signo: ::std::os::raw::c_int,
-    pub si_errno: ::std::os::raw::c_int,
-    pub si_code: ::std::os::raw::c_int,
-    pub si_pid: pid_t,
-    pub si_uid: uid_t,
-    pub si_status: ::std::os::raw::c_int,
-    pub si_addr: *mut ::std::os::raw::c_void,
-    pub si_value: sigval,
-    pub si_band: ::std::os::raw::c_long,
-    pub __pad: [::std::os::raw::c_ulong; 7usize],
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __siginfo"][::std::mem::size_of::<__siginfo>() - 104usize];
-    ["Alignment of __siginfo"][::std::mem::align_of::<__siginfo>() - 8usize];
-    ["Offset of field: __siginfo::si_signo"][::std::mem::offset_of!(__siginfo, si_signo) - 0usize];
-    ["Offset of field: __siginfo::si_errno"][::std::mem::offset_of!(__siginfo, si_errno) - 4usize];
-    ["Offset of field: __siginfo::si_code"][::std::mem::offset_of!(__siginfo, si_code) - 8usize];
-    ["Offset of field: __siginfo::si_pid"][::std::mem::offset_of!(__siginfo, si_pid) - 12usize];
-    ["Offset of field: __siginfo::si_uid"][::std::mem::offset_of!(__siginfo, si_uid) - 16usize];
-    ["Offset of field: __siginfo::si_status"]
-        [::std::mem::offset_of!(__siginfo, si_status) - 20usize];
-    ["Offset of field: __siginfo::si_addr"][::std::mem::offset_of!(__siginfo, si_addr) - 24usize];
-    ["Offset of field: __siginfo::si_value"][::std::mem::offset_of!(__siginfo, si_value) - 32usize];
-    ["Offset of field: __siginfo::si_band"][::std::mem::offset_of!(__siginfo, si_band) - 40usize];
-    ["Offset of field: __siginfo::__pad"][::std::mem::offset_of!(__siginfo, __pad) - 48usize];
-};
-pub type siginfo_t = __siginfo;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union __sigaction_u {
-    pub __sa_handler: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    pub __sa_sigaction: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: ::std::os::raw::c_int,
-            arg2: *mut __siginfo,
-            arg3: *mut ::std::os::raw::c_void,
-        ),
-    >,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __sigaction_u"][::std::mem::size_of::<__sigaction_u>() - 8usize];
-    ["Alignment of __sigaction_u"][::std::mem::align_of::<__sigaction_u>() - 8usize];
-    ["Offset of field: __sigaction_u::__sa_handler"]
-        [::std::mem::offset_of!(__sigaction_u, __sa_handler) - 0usize];
-    ["Offset of field: __sigaction_u::__sa_sigaction"]
-        [::std::mem::offset_of!(__sigaction_u, __sa_sigaction) - 0usize];
-};
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __sigaction {
-    pub __sigaction_u: __sigaction_u,
-    pub sa_tramp: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: ::std::os::raw::c_int,
-            arg3: ::std::os::raw::c_int,
-            arg4: *mut siginfo_t,
-            arg5: *mut ::std::os::raw::c_void,
-        ),
-    >,
-    pub sa_mask: sigset_t,
-    pub sa_flags: ::std::os::raw::c_int,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __sigaction"][::std::mem::size_of::<__sigaction>() - 24usize];
-    ["Alignment of __sigaction"][::std::mem::align_of::<__sigaction>() - 8usize];
-    ["Offset of field: __sigaction::__sigaction_u"]
-        [::std::mem::offset_of!(__sigaction, __sigaction_u) - 0usize];
-    ["Offset of field: __sigaction::sa_tramp"]
-        [::std::mem::offset_of!(__sigaction, sa_tramp) - 8usize];
-    ["Offset of field: __sigaction::sa_mask"]
-        [::std::mem::offset_of!(__sigaction, sa_mask) - 16usize];
-    ["Offset of field: __sigaction::sa_flags"]
-        [::std::mem::offset_of!(__sigaction, sa_flags) - 20usize];
-};
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct sigaction {
-    pub __sigaction_u: __sigaction_u,
-    pub sa_mask: sigset_t,
-    pub sa_flags: ::std::os::raw::c_int,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of sigaction"][::std::mem::size_of::<sigaction>() - 16usize];
-    ["Alignment of sigaction"][::std::mem::align_of::<sigaction>() - 8usize];
-    ["Offset of field: sigaction::__sigaction_u"]
-        [::std::mem::offset_of!(sigaction, __sigaction_u) - 0usize];
-    ["Offset of field: sigaction::sa_mask"][::std::mem::offset_of!(sigaction, sa_mask) - 8usize];
-    ["Offset of field: sigaction::sa_flags"][::std::mem::offset_of!(sigaction, sa_flags) - 12usize];
-};
-pub type sig_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sigvec {
-    pub sv_handler: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    pub sv_mask: ::std::os::raw::c_int,
-    pub sv_flags: ::std::os::raw::c_int,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of sigvec"][::std::mem::size_of::<sigvec>() - 16usize];
-    ["Alignment of sigvec"][::std::mem::align_of::<sigvec>() - 8usize];
-    ["Offset of field: sigvec::sv_handler"][::std::mem::offset_of!(sigvec, sv_handler) - 0usize];
-    ["Offset of field: sigvec::sv_mask"][::std::mem::offset_of!(sigvec, sv_mask) - 8usize];
-    ["Offset of field: sigvec::sv_flags"][::std::mem::offset_of!(sigvec, sv_flags) - 12usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sigstack {
-    pub ss_sp: *mut ::std::os::raw::c_char,
-    pub ss_onstack: ::std::os::raw::c_int,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of sigstack"][::std::mem::size_of::<sigstack>() - 16usize];
-    ["Alignment of sigstack"][::std::mem::align_of::<sigstack>() - 8usize];
-    ["Offset of field: sigstack::ss_sp"][::std::mem::offset_of!(sigstack, ss_sp) - 0usize];
-    ["Offset of field: sigstack::ss_onstack"]
-        [::std::mem::offset_of!(sigstack, ss_onstack) - 8usize];
-};
 unsafe extern "C" {
-    pub fn signal(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    ) -> ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: ::std::os::raw::c_int,
-            arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-        ),
-    >;
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timeval {
-    pub tv_sec: __darwin_time_t,
-    pub tv_usec: __darwin_suseconds_t,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of timeval"][::std::mem::size_of::<timeval>() - 16usize];
-    ["Alignment of timeval"][::std::mem::align_of::<timeval>() - 8usize];
-    ["Offset of field: timeval::tv_sec"][::std::mem::offset_of!(timeval, tv_sec) - 0usize];
-    ["Offset of field: timeval::tv_usec"][::std::mem::offset_of!(timeval, tv_usec) - 8usize];
-};
-pub type rlim_t = __uint64_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct rusage {
-    pub ru_utime: timeval,
-    pub ru_stime: timeval,
-    pub ru_maxrss: ::std::os::raw::c_long,
-    pub ru_ixrss: ::std::os::raw::c_long,
-    pub ru_idrss: ::std::os::raw::c_long,
-    pub ru_isrss: ::std::os::raw::c_long,
-    pub ru_minflt: ::std::os::raw::c_long,
-    pub ru_majflt: ::std::os::raw::c_long,
-    pub ru_nswap: ::std::os::raw::c_long,
-    pub ru_inblock: ::std::os::raw::c_long,
-    pub ru_oublock: ::std::os::raw::c_long,
-    pub ru_msgsnd: ::std::os::raw::c_long,
-    pub ru_msgrcv: ::std::os::raw::c_long,
-    pub ru_nsignals: ::std::os::raw::c_long,
-    pub ru_nvcsw: ::std::os::raw::c_long,
-    pub ru_nivcsw: ::std::os::raw::c_long,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of rusage"][::std::mem::size_of::<rusage>() - 144usize];
-    ["Alignment of rusage"][::std::mem::align_of::<rusage>() - 8usize];
-    ["Offset of field: rusage::ru_utime"][::std::mem::offset_of!(rusage, ru_utime) - 0usize];
-    ["Offset of field: rusage::ru_stime"][::std::mem::offset_of!(rusage, ru_stime) - 16usize];
-    ["Offset of field: rusage::ru_maxrss"][::std::mem::offset_of!(rusage, ru_maxrss) - 32usize];
-    ["Offset of field: rusage::ru_ixrss"][::std::mem::offset_of!(rusage, ru_ixrss) - 40usize];
-    ["Offset of field: rusage::ru_idrss"][::std::mem::offset_of!(rusage, ru_idrss) - 48usize];
-    ["Offset of field: rusage::ru_isrss"][::std::mem::offset_of!(rusage, ru_isrss) - 56usize];
-    ["Offset of field: rusage::ru_minflt"][::std::mem::offset_of!(rusage, ru_minflt) - 64usize];
-    ["Offset of field: rusage::ru_majflt"][::std::mem::offset_of!(rusage, ru_majflt) - 72usize];
-    ["Offset of field: rusage::ru_nswap"][::std::mem::offset_of!(rusage, ru_nswap) - 80usize];
-    ["Offset of field: rusage::ru_inblock"][::std::mem::offset_of!(rusage, ru_inblock) - 88usize];
-    ["Offset of field: rusage::ru_oublock"][::std::mem::offset_of!(rusage, ru_oublock) - 96usize];
-    ["Offset of field: rusage::ru_msgsnd"][::std::mem::offset_of!(rusage, ru_msgsnd) - 104usize];
-    ["Offset of field: rusage::ru_msgrcv"][::std::mem::offset_of!(rusage, ru_msgrcv) - 112usize];
-    ["Offset of field: rusage::ru_nsignals"]
-        [::std::mem::offset_of!(rusage, ru_nsignals) - 120usize];
-    ["Offset of field: rusage::ru_nvcsw"][::std::mem::offset_of!(rusage, ru_nvcsw) - 128usize];
-    ["Offset of field: rusage::ru_nivcsw"][::std::mem::offset_of!(rusage, ru_nivcsw) - 136usize];
-};
-pub type rusage_info_t = *mut ::std::os::raw::c_void;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct rusage_info_v0 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of rusage_info_v0"][::std::mem::size_of::<rusage_info_v0>() - 96usize];
-    ["Alignment of rusage_info_v0"][::std::mem::align_of::<rusage_info_v0>() - 8usize];
-    ["Offset of field: rusage_info_v0::ri_uuid"]
-        [::std::mem::offset_of!(rusage_info_v0, ri_uuid) - 0usize];
-    ["Offset of field: rusage_info_v0::ri_user_time"]
-        [::std::mem::offset_of!(rusage_info_v0, ri_user_time) - 16usize];
-    ["Offset of field: rusage_info_v0::ri_system_time"]
-        [::std::mem::offset_of!(rusage_info_v0, ri_system_time) - 24usize];
-    ["Offset of field: rusage_info_v0::ri_pkg_idle_wkups"]
-        [::std::mem::offset_of!(rusage_info_v0, ri_pkg_idle_wkups) - 32usize];
-    ["Offset of field: rusage_info_v0::ri_interrupt_wkups"]
-        [::std::mem::offset_of!(rusage_info_v0, ri_interrupt_wkups) - 40usize];
-    ["Offset of field: rusage_info_v0::ri_pageins"]
-        [::std::mem::offset_of!(rusage_info_v0, ri_pageins) - 48usize];
-    ["Offset of field: rusage_info_v0::ri_wired_size"]
-        [::std::mem::offset_of!(rusage_info_v0, ri_wired_size) - 56usize];
-    ["Offset of field: rusage_info_v0::ri_resident_size"]
-        [::std::mem::offset_of!(rusage_info_v0, ri_resident_size) - 64usize];
-    ["Offset of field: rusage_info_v0::ri_phys_footprint"]
-        [::std::mem::offset_of!(rusage_info_v0, ri_phys_footprint) - 72usize];
-    ["Offset of field: rusage_info_v0::ri_proc_start_abstime"]
-        [::std::mem::offset_of!(rusage_info_v0, ri_proc_start_abstime) - 80usize];
-    ["Offset of field: rusage_info_v0::ri_proc_exit_abstime"]
-        [::std::mem::offset_of!(rusage_info_v0, ri_proc_exit_abstime) - 88usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct rusage_info_v1 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of rusage_info_v1"][::std::mem::size_of::<rusage_info_v1>() - 144usize];
-    ["Alignment of rusage_info_v1"][::std::mem::align_of::<rusage_info_v1>() - 8usize];
-    ["Offset of field: rusage_info_v1::ri_uuid"]
-        [::std::mem::offset_of!(rusage_info_v1, ri_uuid) - 0usize];
-    ["Offset of field: rusage_info_v1::ri_user_time"]
-        [::std::mem::offset_of!(rusage_info_v1, ri_user_time) - 16usize];
-    ["Offset of field: rusage_info_v1::ri_system_time"]
-        [::std::mem::offset_of!(rusage_info_v1, ri_system_time) - 24usize];
-    ["Offset of field: rusage_info_v1::ri_pkg_idle_wkups"]
-        [::std::mem::offset_of!(rusage_info_v1, ri_pkg_idle_wkups) - 32usize];
-    ["Offset of field: rusage_info_v1::ri_interrupt_wkups"]
-        [::std::mem::offset_of!(rusage_info_v1, ri_interrupt_wkups) - 40usize];
-    ["Offset of field: rusage_info_v1::ri_pageins"]
-        [::std::mem::offset_of!(rusage_info_v1, ri_pageins) - 48usize];
-    ["Offset of field: rusage_info_v1::ri_wired_size"]
-        [::std::mem::offset_of!(rusage_info_v1, ri_wired_size) - 56usize];
-    ["Offset of field: rusage_info_v1::ri_resident_size"]
-        [::std::mem::offset_of!(rusage_info_v1, ri_resident_size) - 64usize];
-    ["Offset of field: rusage_info_v1::ri_phys_footprint"]
-        [::std::mem::offset_of!(rusage_info_v1, ri_phys_footprint) - 72usize];
-    ["Offset of field: rusage_info_v1::ri_proc_start_abstime"]
-        [::std::mem::offset_of!(rusage_info_v1, ri_proc_start_abstime) - 80usize];
-    ["Offset of field: rusage_info_v1::ri_proc_exit_abstime"]
-        [::std::mem::offset_of!(rusage_info_v1, ri_proc_exit_abstime) - 88usize];
-    ["Offset of field: rusage_info_v1::ri_child_user_time"]
-        [::std::mem::offset_of!(rusage_info_v1, ri_child_user_time) - 96usize];
-    ["Offset of field: rusage_info_v1::ri_child_system_time"]
-        [::std::mem::offset_of!(rusage_info_v1, ri_child_system_time) - 104usize];
-    ["Offset of field: rusage_info_v1::ri_child_pkg_idle_wkups"]
-        [::std::mem::offset_of!(rusage_info_v1, ri_child_pkg_idle_wkups) - 112usize];
-    ["Offset of field: rusage_info_v1::ri_child_interrupt_wkups"]
-        [::std::mem::offset_of!(rusage_info_v1, ri_child_interrupt_wkups) - 120usize];
-    ["Offset of field: rusage_info_v1::ri_child_pageins"]
-        [::std::mem::offset_of!(rusage_info_v1, ri_child_pageins) - 128usize];
-    ["Offset of field: rusage_info_v1::ri_child_elapsed_abstime"]
-        [::std::mem::offset_of!(rusage_info_v1, ri_child_elapsed_abstime) - 136usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct rusage_info_v2 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of rusage_info_v2"][::std::mem::size_of::<rusage_info_v2>() - 160usize];
-    ["Alignment of rusage_info_v2"][::std::mem::align_of::<rusage_info_v2>() - 8usize];
-    ["Offset of field: rusage_info_v2::ri_uuid"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_uuid) - 0usize];
-    ["Offset of field: rusage_info_v2::ri_user_time"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_user_time) - 16usize];
-    ["Offset of field: rusage_info_v2::ri_system_time"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_system_time) - 24usize];
-    ["Offset of field: rusage_info_v2::ri_pkg_idle_wkups"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_pkg_idle_wkups) - 32usize];
-    ["Offset of field: rusage_info_v2::ri_interrupt_wkups"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_interrupt_wkups) - 40usize];
-    ["Offset of field: rusage_info_v2::ri_pageins"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_pageins) - 48usize];
-    ["Offset of field: rusage_info_v2::ri_wired_size"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_wired_size) - 56usize];
-    ["Offset of field: rusage_info_v2::ri_resident_size"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_resident_size) - 64usize];
-    ["Offset of field: rusage_info_v2::ri_phys_footprint"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_phys_footprint) - 72usize];
-    ["Offset of field: rusage_info_v2::ri_proc_start_abstime"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_proc_start_abstime) - 80usize];
-    ["Offset of field: rusage_info_v2::ri_proc_exit_abstime"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_proc_exit_abstime) - 88usize];
-    ["Offset of field: rusage_info_v2::ri_child_user_time"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_child_user_time) - 96usize];
-    ["Offset of field: rusage_info_v2::ri_child_system_time"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_child_system_time) - 104usize];
-    ["Offset of field: rusage_info_v2::ri_child_pkg_idle_wkups"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_child_pkg_idle_wkups) - 112usize];
-    ["Offset of field: rusage_info_v2::ri_child_interrupt_wkups"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_child_interrupt_wkups) - 120usize];
-    ["Offset of field: rusage_info_v2::ri_child_pageins"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_child_pageins) - 128usize];
-    ["Offset of field: rusage_info_v2::ri_child_elapsed_abstime"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_child_elapsed_abstime) - 136usize];
-    ["Offset of field: rusage_info_v2::ri_diskio_bytesread"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_diskio_bytesread) - 144usize];
-    ["Offset of field: rusage_info_v2::ri_diskio_byteswritten"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_diskio_byteswritten) - 152usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct rusage_info_v3 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-    pub ri_cpu_time_qos_default: u64,
-    pub ri_cpu_time_qos_maintenance: u64,
-    pub ri_cpu_time_qos_background: u64,
-    pub ri_cpu_time_qos_utility: u64,
-    pub ri_cpu_time_qos_legacy: u64,
-    pub ri_cpu_time_qos_user_initiated: u64,
-    pub ri_cpu_time_qos_user_interactive: u64,
-    pub ri_billed_system_time: u64,
-    pub ri_serviced_system_time: u64,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of rusage_info_v3"][::std::mem::size_of::<rusage_info_v3>() - 232usize];
-    ["Alignment of rusage_info_v3"][::std::mem::align_of::<rusage_info_v3>() - 8usize];
-    ["Offset of field: rusage_info_v3::ri_uuid"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_uuid) - 0usize];
-    ["Offset of field: rusage_info_v3::ri_user_time"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_user_time) - 16usize];
-    ["Offset of field: rusage_info_v3::ri_system_time"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_system_time) - 24usize];
-    ["Offset of field: rusage_info_v3::ri_pkg_idle_wkups"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_pkg_idle_wkups) - 32usize];
-    ["Offset of field: rusage_info_v3::ri_interrupt_wkups"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_interrupt_wkups) - 40usize];
-    ["Offset of field: rusage_info_v3::ri_pageins"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_pageins) - 48usize];
-    ["Offset of field: rusage_info_v3::ri_wired_size"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_wired_size) - 56usize];
-    ["Offset of field: rusage_info_v3::ri_resident_size"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_resident_size) - 64usize];
-    ["Offset of field: rusage_info_v3::ri_phys_footprint"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_phys_footprint) - 72usize];
-    ["Offset of field: rusage_info_v3::ri_proc_start_abstime"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_proc_start_abstime) - 80usize];
-    ["Offset of field: rusage_info_v3::ri_proc_exit_abstime"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_proc_exit_abstime) - 88usize];
-    ["Offset of field: rusage_info_v3::ri_child_user_time"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_child_user_time) - 96usize];
-    ["Offset of field: rusage_info_v3::ri_child_system_time"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_child_system_time) - 104usize];
-    ["Offset of field: rusage_info_v3::ri_child_pkg_idle_wkups"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_child_pkg_idle_wkups) - 112usize];
-    ["Offset of field: rusage_info_v3::ri_child_interrupt_wkups"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_child_interrupt_wkups) - 120usize];
-    ["Offset of field: rusage_info_v3::ri_child_pageins"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_child_pageins) - 128usize];
-    ["Offset of field: rusage_info_v3::ri_child_elapsed_abstime"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_child_elapsed_abstime) - 136usize];
-    ["Offset of field: rusage_info_v3::ri_diskio_bytesread"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_diskio_bytesread) - 144usize];
-    ["Offset of field: rusage_info_v3::ri_diskio_byteswritten"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_diskio_byteswritten) - 152usize];
-    ["Offset of field: rusage_info_v3::ri_cpu_time_qos_default"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_cpu_time_qos_default) - 160usize];
-    ["Offset of field: rusage_info_v3::ri_cpu_time_qos_maintenance"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_cpu_time_qos_maintenance) - 168usize];
-    ["Offset of field: rusage_info_v3::ri_cpu_time_qos_background"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_cpu_time_qos_background) - 176usize];
-    ["Offset of field: rusage_info_v3::ri_cpu_time_qos_utility"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_cpu_time_qos_utility) - 184usize];
-    ["Offset of field: rusage_info_v3::ri_cpu_time_qos_legacy"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_cpu_time_qos_legacy) - 192usize];
-    ["Offset of field: rusage_info_v3::ri_cpu_time_qos_user_initiated"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_cpu_time_qos_user_initiated) - 200usize];
-    ["Offset of field: rusage_info_v3::ri_cpu_time_qos_user_interactive"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_cpu_time_qos_user_interactive) - 208usize];
-    ["Offset of field: rusage_info_v3::ri_billed_system_time"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_billed_system_time) - 216usize];
-    ["Offset of field: rusage_info_v3::ri_serviced_system_time"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_serviced_system_time) - 224usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct rusage_info_v4 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-    pub ri_cpu_time_qos_default: u64,
-    pub ri_cpu_time_qos_maintenance: u64,
-    pub ri_cpu_time_qos_background: u64,
-    pub ri_cpu_time_qos_utility: u64,
-    pub ri_cpu_time_qos_legacy: u64,
-    pub ri_cpu_time_qos_user_initiated: u64,
-    pub ri_cpu_time_qos_user_interactive: u64,
-    pub ri_billed_system_time: u64,
-    pub ri_serviced_system_time: u64,
-    pub ri_logical_writes: u64,
-    pub ri_lifetime_max_phys_footprint: u64,
-    pub ri_instructions: u64,
-    pub ri_cycles: u64,
-    pub ri_billed_energy: u64,
-    pub ri_serviced_energy: u64,
-    pub ri_interval_max_phys_footprint: u64,
-    pub ri_runnable_time: u64,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of rusage_info_v4"][::std::mem::size_of::<rusage_info_v4>() - 296usize];
-    ["Alignment of rusage_info_v4"][::std::mem::align_of::<rusage_info_v4>() - 8usize];
-    ["Offset of field: rusage_info_v4::ri_uuid"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_uuid) - 0usize];
-    ["Offset of field: rusage_info_v4::ri_user_time"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_user_time) - 16usize];
-    ["Offset of field: rusage_info_v4::ri_system_time"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_system_time) - 24usize];
-    ["Offset of field: rusage_info_v4::ri_pkg_idle_wkups"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_pkg_idle_wkups) - 32usize];
-    ["Offset of field: rusage_info_v4::ri_interrupt_wkups"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_interrupt_wkups) - 40usize];
-    ["Offset of field: rusage_info_v4::ri_pageins"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_pageins) - 48usize];
-    ["Offset of field: rusage_info_v4::ri_wired_size"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_wired_size) - 56usize];
-    ["Offset of field: rusage_info_v4::ri_resident_size"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_resident_size) - 64usize];
-    ["Offset of field: rusage_info_v4::ri_phys_footprint"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_phys_footprint) - 72usize];
-    ["Offset of field: rusage_info_v4::ri_proc_start_abstime"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_proc_start_abstime) - 80usize];
-    ["Offset of field: rusage_info_v4::ri_proc_exit_abstime"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_proc_exit_abstime) - 88usize];
-    ["Offset of field: rusage_info_v4::ri_child_user_time"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_child_user_time) - 96usize];
-    ["Offset of field: rusage_info_v4::ri_child_system_time"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_child_system_time) - 104usize];
-    ["Offset of field: rusage_info_v4::ri_child_pkg_idle_wkups"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_child_pkg_idle_wkups) - 112usize];
-    ["Offset of field: rusage_info_v4::ri_child_interrupt_wkups"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_child_interrupt_wkups) - 120usize];
-    ["Offset of field: rusage_info_v4::ri_child_pageins"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_child_pageins) - 128usize];
-    ["Offset of field: rusage_info_v4::ri_child_elapsed_abstime"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_child_elapsed_abstime) - 136usize];
-    ["Offset of field: rusage_info_v4::ri_diskio_bytesread"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_diskio_bytesread) - 144usize];
-    ["Offset of field: rusage_info_v4::ri_diskio_byteswritten"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_diskio_byteswritten) - 152usize];
-    ["Offset of field: rusage_info_v4::ri_cpu_time_qos_default"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_cpu_time_qos_default) - 160usize];
-    ["Offset of field: rusage_info_v4::ri_cpu_time_qos_maintenance"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_cpu_time_qos_maintenance) - 168usize];
-    ["Offset of field: rusage_info_v4::ri_cpu_time_qos_background"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_cpu_time_qos_background) - 176usize];
-    ["Offset of field: rusage_info_v4::ri_cpu_time_qos_utility"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_cpu_time_qos_utility) - 184usize];
-    ["Offset of field: rusage_info_v4::ri_cpu_time_qos_legacy"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_cpu_time_qos_legacy) - 192usize];
-    ["Offset of field: rusage_info_v4::ri_cpu_time_qos_user_initiated"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_cpu_time_qos_user_initiated) - 200usize];
-    ["Offset of field: rusage_info_v4::ri_cpu_time_qos_user_interactive"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_cpu_time_qos_user_interactive) - 208usize];
-    ["Offset of field: rusage_info_v4::ri_billed_system_time"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_billed_system_time) - 216usize];
-    ["Offset of field: rusage_info_v4::ri_serviced_system_time"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_serviced_system_time) - 224usize];
-    ["Offset of field: rusage_info_v4::ri_logical_writes"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_logical_writes) - 232usize];
-    ["Offset of field: rusage_info_v4::ri_lifetime_max_phys_footprint"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_lifetime_max_phys_footprint) - 240usize];
-    ["Offset of field: rusage_info_v4::ri_instructions"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_instructions) - 248usize];
-    ["Offset of field: rusage_info_v4::ri_cycles"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_cycles) - 256usize];
-    ["Offset of field: rusage_info_v4::ri_billed_energy"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_billed_energy) - 264usize];
-    ["Offset of field: rusage_info_v4::ri_serviced_energy"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_serviced_energy) - 272usize];
-    ["Offset of field: rusage_info_v4::ri_interval_max_phys_footprint"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_interval_max_phys_footprint) - 280usize];
-    ["Offset of field: rusage_info_v4::ri_runnable_time"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_runnable_time) - 288usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct rusage_info_v5 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-    pub ri_cpu_time_qos_default: u64,
-    pub ri_cpu_time_qos_maintenance: u64,
-    pub ri_cpu_time_qos_background: u64,
-    pub ri_cpu_time_qos_utility: u64,
-    pub ri_cpu_time_qos_legacy: u64,
-    pub ri_cpu_time_qos_user_initiated: u64,
-    pub ri_cpu_time_qos_user_interactive: u64,
-    pub ri_billed_system_time: u64,
-    pub ri_serviced_system_time: u64,
-    pub ri_logical_writes: u64,
-    pub ri_lifetime_max_phys_footprint: u64,
-    pub ri_instructions: u64,
-    pub ri_cycles: u64,
-    pub ri_billed_energy: u64,
-    pub ri_serviced_energy: u64,
-    pub ri_interval_max_phys_footprint: u64,
-    pub ri_runnable_time: u64,
-    pub ri_flags: u64,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of rusage_info_v5"][::std::mem::size_of::<rusage_info_v5>() - 304usize];
-    ["Alignment of rusage_info_v5"][::std::mem::align_of::<rusage_info_v5>() - 8usize];
-    ["Offset of field: rusage_info_v5::ri_uuid"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_uuid) - 0usize];
-    ["Offset of field: rusage_info_v5::ri_user_time"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_user_time) - 16usize];
-    ["Offset of field: rusage_info_v5::ri_system_time"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_system_time) - 24usize];
-    ["Offset of field: rusage_info_v5::ri_pkg_idle_wkups"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_pkg_idle_wkups) - 32usize];
-    ["Offset of field: rusage_info_v5::ri_interrupt_wkups"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_interrupt_wkups) - 40usize];
-    ["Offset of field: rusage_info_v5::ri_pageins"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_pageins) - 48usize];
-    ["Offset of field: rusage_info_v5::ri_wired_size"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_wired_size) - 56usize];
-    ["Offset of field: rusage_info_v5::ri_resident_size"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_resident_size) - 64usize];
-    ["Offset of field: rusage_info_v5::ri_phys_footprint"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_phys_footprint) - 72usize];
-    ["Offset of field: rusage_info_v5::ri_proc_start_abstime"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_proc_start_abstime) - 80usize];
-    ["Offset of field: rusage_info_v5::ri_proc_exit_abstime"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_proc_exit_abstime) - 88usize];
-    ["Offset of field: rusage_info_v5::ri_child_user_time"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_child_user_time) - 96usize];
-    ["Offset of field: rusage_info_v5::ri_child_system_time"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_child_system_time) - 104usize];
-    ["Offset of field: rusage_info_v5::ri_child_pkg_idle_wkups"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_child_pkg_idle_wkups) - 112usize];
-    ["Offset of field: rusage_info_v5::ri_child_interrupt_wkups"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_child_interrupt_wkups) - 120usize];
-    ["Offset of field: rusage_info_v5::ri_child_pageins"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_child_pageins) - 128usize];
-    ["Offset of field: rusage_info_v5::ri_child_elapsed_abstime"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_child_elapsed_abstime) - 136usize];
-    ["Offset of field: rusage_info_v5::ri_diskio_bytesread"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_diskio_bytesread) - 144usize];
-    ["Offset of field: rusage_info_v5::ri_diskio_byteswritten"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_diskio_byteswritten) - 152usize];
-    ["Offset of field: rusage_info_v5::ri_cpu_time_qos_default"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_cpu_time_qos_default) - 160usize];
-    ["Offset of field: rusage_info_v5::ri_cpu_time_qos_maintenance"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_cpu_time_qos_maintenance) - 168usize];
-    ["Offset of field: rusage_info_v5::ri_cpu_time_qos_background"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_cpu_time_qos_background) - 176usize];
-    ["Offset of field: rusage_info_v5::ri_cpu_time_qos_utility"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_cpu_time_qos_utility) - 184usize];
-    ["Offset of field: rusage_info_v5::ri_cpu_time_qos_legacy"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_cpu_time_qos_legacy) - 192usize];
-    ["Offset of field: rusage_info_v5::ri_cpu_time_qos_user_initiated"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_cpu_time_qos_user_initiated) - 200usize];
-    ["Offset of field: rusage_info_v5::ri_cpu_time_qos_user_interactive"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_cpu_time_qos_user_interactive) - 208usize];
-    ["Offset of field: rusage_info_v5::ri_billed_system_time"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_billed_system_time) - 216usize];
-    ["Offset of field: rusage_info_v5::ri_serviced_system_time"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_serviced_system_time) - 224usize];
-    ["Offset of field: rusage_info_v5::ri_logical_writes"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_logical_writes) - 232usize];
-    ["Offset of field: rusage_info_v5::ri_lifetime_max_phys_footprint"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_lifetime_max_phys_footprint) - 240usize];
-    ["Offset of field: rusage_info_v5::ri_instructions"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_instructions) - 248usize];
-    ["Offset of field: rusage_info_v5::ri_cycles"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_cycles) - 256usize];
-    ["Offset of field: rusage_info_v5::ri_billed_energy"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_billed_energy) - 264usize];
-    ["Offset of field: rusage_info_v5::ri_serviced_energy"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_serviced_energy) - 272usize];
-    ["Offset of field: rusage_info_v5::ri_interval_max_phys_footprint"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_interval_max_phys_footprint) - 280usize];
-    ["Offset of field: rusage_info_v5::ri_runnable_time"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_runnable_time) - 288usize];
-    ["Offset of field: rusage_info_v5::ri_flags"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_flags) - 296usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct rusage_info_v6 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-    pub ri_cpu_time_qos_default: u64,
-    pub ri_cpu_time_qos_maintenance: u64,
-    pub ri_cpu_time_qos_background: u64,
-    pub ri_cpu_time_qos_utility: u64,
-    pub ri_cpu_time_qos_legacy: u64,
-    pub ri_cpu_time_qos_user_initiated: u64,
-    pub ri_cpu_time_qos_user_interactive: u64,
-    pub ri_billed_system_time: u64,
-    pub ri_serviced_system_time: u64,
-    pub ri_logical_writes: u64,
-    pub ri_lifetime_max_phys_footprint: u64,
-    pub ri_instructions: u64,
-    pub ri_cycles: u64,
-    pub ri_billed_energy: u64,
-    pub ri_serviced_energy: u64,
-    pub ri_interval_max_phys_footprint: u64,
-    pub ri_runnable_time: u64,
-    pub ri_flags: u64,
-    pub ri_user_ptime: u64,
-    pub ri_system_ptime: u64,
-    pub ri_pinstructions: u64,
-    pub ri_pcycles: u64,
-    pub ri_energy_nj: u64,
-    pub ri_penergy_nj: u64,
-    pub ri_secure_time_in_system: u64,
-    pub ri_secure_ptime_in_system: u64,
-    pub ri_reserved: [u64; 12usize],
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of rusage_info_v6"][::std::mem::size_of::<rusage_info_v6>() - 464usize];
-    ["Alignment of rusage_info_v6"][::std::mem::align_of::<rusage_info_v6>() - 8usize];
-    ["Offset of field: rusage_info_v6::ri_uuid"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_uuid) - 0usize];
-    ["Offset of field: rusage_info_v6::ri_user_time"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_user_time) - 16usize];
-    ["Offset of field: rusage_info_v6::ri_system_time"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_system_time) - 24usize];
-    ["Offset of field: rusage_info_v6::ri_pkg_idle_wkups"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_pkg_idle_wkups) - 32usize];
-    ["Offset of field: rusage_info_v6::ri_interrupt_wkups"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_interrupt_wkups) - 40usize];
-    ["Offset of field: rusage_info_v6::ri_pageins"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_pageins) - 48usize];
-    ["Offset of field: rusage_info_v6::ri_wired_size"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_wired_size) - 56usize];
-    ["Offset of field: rusage_info_v6::ri_resident_size"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_resident_size) - 64usize];
-    ["Offset of field: rusage_info_v6::ri_phys_footprint"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_phys_footprint) - 72usize];
-    ["Offset of field: rusage_info_v6::ri_proc_start_abstime"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_proc_start_abstime) - 80usize];
-    ["Offset of field: rusage_info_v6::ri_proc_exit_abstime"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_proc_exit_abstime) - 88usize];
-    ["Offset of field: rusage_info_v6::ri_child_user_time"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_child_user_time) - 96usize];
-    ["Offset of field: rusage_info_v6::ri_child_system_time"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_child_system_time) - 104usize];
-    ["Offset of field: rusage_info_v6::ri_child_pkg_idle_wkups"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_child_pkg_idle_wkups) - 112usize];
-    ["Offset of field: rusage_info_v6::ri_child_interrupt_wkups"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_child_interrupt_wkups) - 120usize];
-    ["Offset of field: rusage_info_v6::ri_child_pageins"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_child_pageins) - 128usize];
-    ["Offset of field: rusage_info_v6::ri_child_elapsed_abstime"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_child_elapsed_abstime) - 136usize];
-    ["Offset of field: rusage_info_v6::ri_diskio_bytesread"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_diskio_bytesread) - 144usize];
-    ["Offset of field: rusage_info_v6::ri_diskio_byteswritten"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_diskio_byteswritten) - 152usize];
-    ["Offset of field: rusage_info_v6::ri_cpu_time_qos_default"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_cpu_time_qos_default) - 160usize];
-    ["Offset of field: rusage_info_v6::ri_cpu_time_qos_maintenance"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_cpu_time_qos_maintenance) - 168usize];
-    ["Offset of field: rusage_info_v6::ri_cpu_time_qos_background"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_cpu_time_qos_background) - 176usize];
-    ["Offset of field: rusage_info_v6::ri_cpu_time_qos_utility"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_cpu_time_qos_utility) - 184usize];
-    ["Offset of field: rusage_info_v6::ri_cpu_time_qos_legacy"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_cpu_time_qos_legacy) - 192usize];
-    ["Offset of field: rusage_info_v6::ri_cpu_time_qos_user_initiated"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_cpu_time_qos_user_initiated) - 200usize];
-    ["Offset of field: rusage_info_v6::ri_cpu_time_qos_user_interactive"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_cpu_time_qos_user_interactive) - 208usize];
-    ["Offset of field: rusage_info_v6::ri_billed_system_time"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_billed_system_time) - 216usize];
-    ["Offset of field: rusage_info_v6::ri_serviced_system_time"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_serviced_system_time) - 224usize];
-    ["Offset of field: rusage_info_v6::ri_logical_writes"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_logical_writes) - 232usize];
-    ["Offset of field: rusage_info_v6::ri_lifetime_max_phys_footprint"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_lifetime_max_phys_footprint) - 240usize];
-    ["Offset of field: rusage_info_v6::ri_instructions"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_instructions) - 248usize];
-    ["Offset of field: rusage_info_v6::ri_cycles"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_cycles) - 256usize];
-    ["Offset of field: rusage_info_v6::ri_billed_energy"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_billed_energy) - 264usize];
-    ["Offset of field: rusage_info_v6::ri_serviced_energy"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_serviced_energy) - 272usize];
-    ["Offset of field: rusage_info_v6::ri_interval_max_phys_footprint"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_interval_max_phys_footprint) - 280usize];
-    ["Offset of field: rusage_info_v6::ri_runnable_time"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_runnable_time) - 288usize];
-    ["Offset of field: rusage_info_v6::ri_flags"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_flags) - 296usize];
-    ["Offset of field: rusage_info_v6::ri_user_ptime"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_user_ptime) - 304usize];
-    ["Offset of field: rusage_info_v6::ri_system_ptime"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_system_ptime) - 312usize];
-    ["Offset of field: rusage_info_v6::ri_pinstructions"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_pinstructions) - 320usize];
-    ["Offset of field: rusage_info_v6::ri_pcycles"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_pcycles) - 328usize];
-    ["Offset of field: rusage_info_v6::ri_energy_nj"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_energy_nj) - 336usize];
-    ["Offset of field: rusage_info_v6::ri_penergy_nj"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_penergy_nj) - 344usize];
-    ["Offset of field: rusage_info_v6::ri_secure_time_in_system"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_secure_time_in_system) - 352usize];
-    ["Offset of field: rusage_info_v6::ri_secure_ptime_in_system"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_secure_ptime_in_system) - 360usize];
-    ["Offset of field: rusage_info_v6::ri_reserved"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_reserved) - 368usize];
-};
-pub type rusage_info_current = rusage_info_v6;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct rlimit {
-    pub rlim_cur: rlim_t,
-    pub rlim_max: rlim_t,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of rlimit"][::std::mem::size_of::<rlimit>() - 16usize];
-    ["Alignment of rlimit"][::std::mem::align_of::<rlimit>() - 8usize];
-    ["Offset of field: rlimit::rlim_cur"][::std::mem::offset_of!(rlimit, rlim_cur) - 0usize];
-    ["Offset of field: rlimit::rlim_max"][::std::mem::offset_of!(rlimit, rlim_max) - 8usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct proc_rlimit_control_wakeupmon {
-    pub wm_flags: u32,
-    pub wm_rate: i32,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of proc_rlimit_control_wakeupmon"]
-        [::std::mem::size_of::<proc_rlimit_control_wakeupmon>() - 8usize];
-    ["Alignment of proc_rlimit_control_wakeupmon"]
-        [::std::mem::align_of::<proc_rlimit_control_wakeupmon>() - 4usize];
-    ["Offset of field: proc_rlimit_control_wakeupmon::wm_flags"]
-        [::std::mem::offset_of!(proc_rlimit_control_wakeupmon, wm_flags) - 0usize];
-    ["Offset of field: proc_rlimit_control_wakeupmon::wm_rate"]
-        [::std::mem::offset_of!(proc_rlimit_control_wakeupmon, wm_rate) - 4usize];
-};
-unsafe extern "C" {
-    pub fn getpriority(arg1: ::std::os::raw::c_int, arg2: id_t) -> ::std::os::raw::c_int;
+    pub fn __assert_perror_fail(
+        __errnum: ::std::os::raw::c_int,
+        __file: *const ::std::os::raw::c_char,
+        __line: ::std::os::raw::c_uint,
+        __function: *const ::std::os::raw::c_char,
+    ) -> !;
 }
 unsafe extern "C" {
-    pub fn getiopolicy_np(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
+    pub fn __assert(
+        __assertion: *const ::std::os::raw::c_char,
+        __file: *const ::std::os::raw::c_char,
+        __line: ::std::os::raw::c_int,
+    ) -> !;
 }
-unsafe extern "C" {
-    pub fn getrlimit(arg1: ::std::os::raw::c_int, arg2: *mut rlimit) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn getrusage(arg1: ::std::os::raw::c_int, arg2: *mut rusage) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn setpriority(
-        arg1: ::std::os::raw::c_int,
-        arg2: id_t,
-        arg3: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn setiopolicy_np(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-        arg3: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn setrlimit(arg1: ::std::os::raw::c_int, arg2: *const rlimit) -> ::std::os::raw::c_int;
-}
-#[repr(C, packed)]
-#[derive(Debug, Copy, Clone)]
-pub struct _OSUnalignedU16 {
-    pub __val: u16,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of _OSUnalignedU16"][::std::mem::size_of::<_OSUnalignedU16>() - 2usize];
-    ["Alignment of _OSUnalignedU16"][::std::mem::align_of::<_OSUnalignedU16>() - 1usize];
-    ["Offset of field: _OSUnalignedU16::__val"]
-        [::std::mem::offset_of!(_OSUnalignedU16, __val) - 0usize];
-};
-#[repr(C, packed)]
-#[derive(Debug, Copy, Clone)]
-pub struct _OSUnalignedU32 {
-    pub __val: u32,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of _OSUnalignedU32"][::std::mem::size_of::<_OSUnalignedU32>() - 4usize];
-    ["Alignment of _OSUnalignedU32"][::std::mem::align_of::<_OSUnalignedU32>() - 1usize];
-    ["Offset of field: _OSUnalignedU32::__val"]
-        [::std::mem::offset_of!(_OSUnalignedU32, __val) - 0usize];
-};
-#[repr(C, packed)]
-#[derive(Debug, Copy, Clone)]
-pub struct _OSUnalignedU64 {
-    pub __val: u64,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of _OSUnalignedU64"][::std::mem::size_of::<_OSUnalignedU64>() - 8usize];
-    ["Alignment of _OSUnalignedU64"][::std::mem::align_of::<_OSUnalignedU64>() - 1usize];
-    ["Offset of field: _OSUnalignedU64::__val"]
-        [::std::mem::offset_of!(_OSUnalignedU64, __val) - 0usize];
-};
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union wait {
-    pub w_status: ::std::os::raw::c_int,
-    pub w_T: wait__bindgen_ty_1,
-    pub w_S: wait__bindgen_ty_2,
-}
-#[repr(C)]
-#[repr(align(4))]
-#[derive(Debug, Copy, Clone)]
-pub struct wait__bindgen_ty_1 {
-    pub _bitfield_align_1: [u16; 0],
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of wait__bindgen_ty_1"][::std::mem::size_of::<wait__bindgen_ty_1>() - 4usize];
-    ["Alignment of wait__bindgen_ty_1"][::std::mem::align_of::<wait__bindgen_ty_1>() - 4usize];
-};
-impl wait__bindgen_ty_1 {
-    #[inline]
-    pub fn w_Termsig(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 7u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Termsig(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(0usize, 7u8, val as u64)
-        }
-    }
-    #[inline]
-    pub unsafe fn w_Termsig_raw(this: *const Self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 4usize]>>::raw_get(
-                ::std::ptr::addr_of!((*this)._bitfield_1),
-                0usize,
-                7u8,
-            ) as u32)
-        }
-    }
-    #[inline]
-    pub unsafe fn set_w_Termsig_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            <__BindgenBitfieldUnit<[u8; 4usize]>>::raw_set(
-                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
-                0usize,
-                7u8,
-                val as u64,
-            )
-        }
-    }
-    #[inline]
-    pub fn w_Coredump(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(7usize, 1u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Coredump(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(7usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub unsafe fn w_Coredump_raw(this: *const Self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 4usize]>>::raw_get(
-                ::std::ptr::addr_of!((*this)._bitfield_1),
-                7usize,
-                1u8,
-            ) as u32)
-        }
-    }
-    #[inline]
-    pub unsafe fn set_w_Coredump_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            <__BindgenBitfieldUnit<[u8; 4usize]>>::raw_set(
-                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
-                7usize,
-                1u8,
-                val as u64,
-            )
-        }
-    }
-    #[inline]
-    pub fn w_Retcode(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 8u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Retcode(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(8usize, 8u8, val as u64)
-        }
-    }
-    #[inline]
-    pub unsafe fn w_Retcode_raw(this: *const Self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 4usize]>>::raw_get(
-                ::std::ptr::addr_of!((*this)._bitfield_1),
-                8usize,
-                8u8,
-            ) as u32)
-        }
-    }
-    #[inline]
-    pub unsafe fn set_w_Retcode_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            <__BindgenBitfieldUnit<[u8; 4usize]>>::raw_set(
-                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
-                8usize,
-                8u8,
-                val as u64,
-            )
-        }
-    }
-    #[inline]
-    pub fn w_Filler(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(16usize, 16u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Filler(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(16usize, 16u8, val as u64)
-        }
-    }
-    #[inline]
-    pub unsafe fn w_Filler_raw(this: *const Self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 4usize]>>::raw_get(
-                ::std::ptr::addr_of!((*this)._bitfield_1),
-                16usize,
-                16u8,
-            ) as u32)
-        }
-    }
-    #[inline]
-    pub unsafe fn set_w_Filler_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            <__BindgenBitfieldUnit<[u8; 4usize]>>::raw_set(
-                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
-                16usize,
-                16u8,
-                val as u64,
-            )
-        }
-    }
-    #[inline]
-    pub fn new_bitfield_1(
-        w_Termsig: ::std::os::raw::c_uint,
-        w_Coredump: ::std::os::raw::c_uint,
-        w_Retcode: ::std::os::raw::c_uint,
-        w_Filler: ::std::os::raw::c_uint,
-    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
-        __bindgen_bitfield_unit.set(0usize, 7u8, {
-            let w_Termsig: u32 = unsafe { ::std::mem::transmute(w_Termsig) };
-            w_Termsig as u64
-        });
-        __bindgen_bitfield_unit.set(7usize, 1u8, {
-            let w_Coredump: u32 = unsafe { ::std::mem::transmute(w_Coredump) };
-            w_Coredump as u64
-        });
-        __bindgen_bitfield_unit.set(8usize, 8u8, {
-            let w_Retcode: u32 = unsafe { ::std::mem::transmute(w_Retcode) };
-            w_Retcode as u64
-        });
-        __bindgen_bitfield_unit.set(16usize, 16u8, {
-            let w_Filler: u32 = unsafe { ::std::mem::transmute(w_Filler) };
-            w_Filler as u64
-        });
-        __bindgen_bitfield_unit
-    }
-}
-#[repr(C)]
-#[repr(align(4))]
-#[derive(Debug, Copy, Clone)]
-pub struct wait__bindgen_ty_2 {
-    pub _bitfield_align_1: [u16; 0],
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of wait__bindgen_ty_2"][::std::mem::size_of::<wait__bindgen_ty_2>() - 4usize];
-    ["Alignment of wait__bindgen_ty_2"][::std::mem::align_of::<wait__bindgen_ty_2>() - 4usize];
-};
-impl wait__bindgen_ty_2 {
-    #[inline]
-    pub fn w_Stopval(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 8u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Stopval(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(0usize, 8u8, val as u64)
-        }
-    }
-    #[inline]
-    pub unsafe fn w_Stopval_raw(this: *const Self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 4usize]>>::raw_get(
-                ::std::ptr::addr_of!((*this)._bitfield_1),
-                0usize,
-                8u8,
-            ) as u32)
-        }
-    }
-    #[inline]
-    pub unsafe fn set_w_Stopval_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            <__BindgenBitfieldUnit<[u8; 4usize]>>::raw_set(
-                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
-                0usize,
-                8u8,
-                val as u64,
-            )
-        }
-    }
-    #[inline]
-    pub fn w_Stopsig(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 8u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Stopsig(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(8usize, 8u8, val as u64)
-        }
-    }
-    #[inline]
-    pub unsafe fn w_Stopsig_raw(this: *const Self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 4usize]>>::raw_get(
-                ::std::ptr::addr_of!((*this)._bitfield_1),
-                8usize,
-                8u8,
-            ) as u32)
-        }
-    }
-    #[inline]
-    pub unsafe fn set_w_Stopsig_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            <__BindgenBitfieldUnit<[u8; 4usize]>>::raw_set(
-                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
-                8usize,
-                8u8,
-                val as u64,
-            )
-        }
-    }
-    #[inline]
-    pub fn w_Filler(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(16usize, 16u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Filler(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(16usize, 16u8, val as u64)
-        }
-    }
-    #[inline]
-    pub unsafe fn w_Filler_raw(this: *const Self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 4usize]>>::raw_get(
-                ::std::ptr::addr_of!((*this)._bitfield_1),
-                16usize,
-                16u8,
-            ) as u32)
-        }
-    }
-    #[inline]
-    pub unsafe fn set_w_Filler_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            <__BindgenBitfieldUnit<[u8; 4usize]>>::raw_set(
-                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
-                16usize,
-                16u8,
-                val as u64,
-            )
-        }
-    }
-    #[inline]
-    pub fn new_bitfield_1(
-        w_Stopval: ::std::os::raw::c_uint,
-        w_Stopsig: ::std::os::raw::c_uint,
-        w_Filler: ::std::os::raw::c_uint,
-    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
-        __bindgen_bitfield_unit.set(0usize, 8u8, {
-            let w_Stopval: u32 = unsafe { ::std::mem::transmute(w_Stopval) };
-            w_Stopval as u64
-        });
-        __bindgen_bitfield_unit.set(8usize, 8u8, {
-            let w_Stopsig: u32 = unsafe { ::std::mem::transmute(w_Stopsig) };
-            w_Stopsig as u64
-        });
-        __bindgen_bitfield_unit.set(16usize, 16u8, {
-            let w_Filler: u32 = unsafe { ::std::mem::transmute(w_Filler) };
-            w_Filler as u64
-        });
-        __bindgen_bitfield_unit
-    }
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of wait"][::std::mem::size_of::<wait>() - 4usize];
-    ["Alignment of wait"][::std::mem::align_of::<wait>() - 4usize];
-    ["Offset of field: wait::w_status"][::std::mem::offset_of!(wait, w_status) - 0usize];
-    ["Offset of field: wait::w_T"][::std::mem::offset_of!(wait, w_T) - 0usize];
-    ["Offset of field: wait::w_S"][::std::mem::offset_of!(wait, w_S) - 0usize];
-};
-unsafe extern "C" {
-    pub fn wait(arg1: *mut ::std::os::raw::c_int) -> pid_t;
-}
-unsafe extern "C" {
-    pub fn waitpid(
-        arg1: pid_t,
-        arg2: *mut ::std::os::raw::c_int,
-        arg3: ::std::os::raw::c_int,
-    ) -> pid_t;
-}
-unsafe extern "C" {
-    pub fn waitid(
-        arg1: idtype_t,
-        arg2: id_t,
-        arg3: *mut siginfo_t,
-        arg4: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn wait3(
-        arg1: *mut ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-        arg3: *mut rusage,
-    ) -> pid_t;
-}
-unsafe extern "C" {
-    pub fn wait4(
-        arg1: pid_t,
-        arg2: *mut ::std::os::raw::c_int,
-        arg3: ::std::os::raw::c_int,
-        arg4: *mut rusage,
-    ) -> pid_t;
-}
-unsafe extern "C" {
-    pub fn alloca(arg1: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void;
-}
-pub type ct_rune_t = __darwin_ct_rune_t;
-pub type rune_t = __darwin_rune_t;
-pub type wchar_t = __darwin_wchar_t;
+pub type wchar_t = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct div_t {
@@ -4461,115 +3002,716 @@ const _: () = {
     ["Offset of field: lldiv_t::rem"][::std::mem::offset_of!(lldiv_t, rem) - 8usize];
 };
 unsafe extern "C" {
-    pub static mut __mb_cur_max: ::std::os::raw::c_int;
-}
-pub type malloc_type_id_t = ::std::os::raw::c_ulonglong;
-unsafe extern "C" {
-    pub fn malloc_type_malloc(
-        size: usize,
-        type_id: malloc_type_id_t,
-    ) -> *mut ::std::os::raw::c_void;
+    pub fn __ctype_get_mb_cur_max() -> usize;
 }
 unsafe extern "C" {
-    pub fn malloc_type_calloc(
-        count: usize,
-        size: usize,
-        type_id: malloc_type_id_t,
-    ) -> *mut ::std::os::raw::c_void;
+    pub fn atof(__nptr: *const ::std::os::raw::c_char) -> f64;
 }
 unsafe extern "C" {
-    pub fn malloc_type_free(ptr: *mut ::std::os::raw::c_void, type_id: malloc_type_id_t);
+    pub fn atoi(__nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn malloc_type_realloc(
-        ptr: *mut ::std::os::raw::c_void,
-        size: usize,
-        type_id: malloc_type_id_t,
-    ) -> *mut ::std::os::raw::c_void;
+    pub fn atol(__nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
 }
 unsafe extern "C" {
-    pub fn malloc_type_valloc(
-        size: usize,
-        type_id: malloc_type_id_t,
-    ) -> *mut ::std::os::raw::c_void;
+    pub fn atoll(__nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_longlong;
 }
 unsafe extern "C" {
-    pub fn malloc_type_aligned_alloc(
-        alignment: usize,
-        size: usize,
-        type_id: malloc_type_id_t,
-    ) -> *mut ::std::os::raw::c_void;
+    pub fn strtod(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+    ) -> f64;
 }
 unsafe extern "C" {
-    pub fn malloc_type_posix_memalign(
-        memptr: *mut *mut ::std::os::raw::c_void,
-        alignment: usize,
-        size: usize,
-        type_id: malloc_type_id_t,
+    pub fn strtof(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+    ) -> f32;
+}
+unsafe extern "C" {
+    pub fn strtold(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+    ) -> u128;
+}
+unsafe extern "C" {
+    pub fn strtol(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn strtoul(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_ulong;
+}
+unsafe extern "C" {
+    pub fn strtoq(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_longlong;
+}
+unsafe extern "C" {
+    pub fn strtouq(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_ulonglong;
+}
+unsafe extern "C" {
+    pub fn strtoll(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_longlong;
+}
+unsafe extern "C" {
+    pub fn strtoull(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_ulonglong;
+}
+unsafe extern "C" {
+    pub fn l64a(__n: ::std::os::raw::c_long) -> *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn a64l(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
+}
+pub type u_char = __u_char;
+pub type u_short = __u_short;
+pub type u_int = __u_int;
+pub type u_long = __u_long;
+pub type quad_t = __quad_t;
+pub type u_quad_t = __u_quad_t;
+pub type fsid_t = __fsid_t;
+pub type loff_t = __loff_t;
+pub type ino_t = __ino_t;
+pub type dev_t = __dev_t;
+pub type gid_t = __gid_t;
+pub type mode_t = __mode_t;
+pub type nlink_t = __nlink_t;
+pub type uid_t = __uid_t;
+pub type pid_t = __pid_t;
+pub type id_t = __id_t;
+pub type daddr_t = __daddr_t;
+pub type caddr_t = __caddr_t;
+pub type key_t = __key_t;
+pub type clock_t = __clock_t;
+pub type clockid_t = __clockid_t;
+pub type time_t = __time_t;
+pub type timer_t = __timer_t;
+pub type ulong = ::std::os::raw::c_ulong;
+pub type ushort = ::std::os::raw::c_ushort;
+pub type uint = ::std::os::raw::c_uint;
+pub type u_int8_t = __uint8_t;
+pub type u_int16_t = __uint16_t;
+pub type u_int32_t = __uint32_t;
+pub type u_int64_t = __uint64_t;
+pub type register_t = ::std::os::raw::c_long;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __sigset_t {
+    pub __val: [::std::os::raw::c_ulong; 16usize],
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of __sigset_t"][::std::mem::size_of::<__sigset_t>() - 128usize];
+    ["Alignment of __sigset_t"][::std::mem::align_of::<__sigset_t>() - 8usize];
+    ["Offset of field: __sigset_t::__val"][::std::mem::offset_of!(__sigset_t, __val) - 0usize];
+};
+pub type sigset_t = __sigset_t;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct timeval {
+    pub tv_sec: __time_t,
+    pub tv_usec: __suseconds_t,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of timeval"][::std::mem::size_of::<timeval>() - 16usize];
+    ["Alignment of timeval"][::std::mem::align_of::<timeval>() - 8usize];
+    ["Offset of field: timeval::tv_sec"][::std::mem::offset_of!(timeval, tv_sec) - 0usize];
+    ["Offset of field: timeval::tv_usec"][::std::mem::offset_of!(timeval, tv_usec) - 8usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct timespec {
+    pub tv_sec: __time_t,
+    pub tv_nsec: __syscall_slong_t,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of timespec"][::std::mem::size_of::<timespec>() - 16usize];
+    ["Alignment of timespec"][::std::mem::align_of::<timespec>() - 8usize];
+    ["Offset of field: timespec::tv_sec"][::std::mem::offset_of!(timespec, tv_sec) - 0usize];
+    ["Offset of field: timespec::tv_nsec"][::std::mem::offset_of!(timespec, tv_nsec) - 8usize];
+};
+pub type suseconds_t = __suseconds_t;
+pub type __fd_mask = ::std::os::raw::c_long;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fd_set {
+    pub __fds_bits: [__fd_mask; 16usize],
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of fd_set"][::std::mem::size_of::<fd_set>() - 128usize];
+    ["Alignment of fd_set"][::std::mem::align_of::<fd_set>() - 8usize];
+    ["Offset of field: fd_set::__fds_bits"][::std::mem::offset_of!(fd_set, __fds_bits) - 0usize];
+};
+pub type fd_mask = __fd_mask;
+unsafe extern "C" {
+    pub fn select(
+        __nfds: ::std::os::raw::c_int,
+        __readfds: *mut fd_set,
+        __writefds: *mut fd_set,
+        __exceptfds: *mut fd_set,
+        __timeout: *mut timeval,
     ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn pselect(
+        __nfds: ::std::os::raw::c_int,
+        __readfds: *mut fd_set,
+        __writefds: *mut fd_set,
+        __exceptfds: *mut fd_set,
+        __timeout: *const timespec,
+        __sigmask: *const __sigset_t,
+    ) -> ::std::os::raw::c_int;
+}
+pub type blksize_t = __blksize_t;
+pub type blkcnt_t = __blkcnt_t;
+pub type fsblkcnt_t = __fsblkcnt_t;
+pub type fsfilcnt_t = __fsfilcnt_t;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union __atomic_wide_counter {
+    pub __value64: ::std::os::raw::c_ulonglong,
+    pub __value32: __atomic_wide_counter__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct _malloc_zone_t {
-    _unused: [u8; 0],
+pub struct __atomic_wide_counter__bindgen_ty_1 {
+    pub __low: ::std::os::raw::c_uint,
+    pub __high: ::std::os::raw::c_uint,
 }
-pub type malloc_zone_t = _malloc_zone_t;
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of __atomic_wide_counter__bindgen_ty_1"]
+        [::std::mem::size_of::<__atomic_wide_counter__bindgen_ty_1>() - 8usize];
+    ["Alignment of __atomic_wide_counter__bindgen_ty_1"]
+        [::std::mem::align_of::<__atomic_wide_counter__bindgen_ty_1>() - 4usize];
+    ["Offset of field: __atomic_wide_counter__bindgen_ty_1::__low"]
+        [::std::mem::offset_of!(__atomic_wide_counter__bindgen_ty_1, __low) - 0usize];
+    ["Offset of field: __atomic_wide_counter__bindgen_ty_1::__high"]
+        [::std::mem::offset_of!(__atomic_wide_counter__bindgen_ty_1, __high) - 4usize];
+};
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of __atomic_wide_counter"][::std::mem::size_of::<__atomic_wide_counter>() - 8usize];
+    ["Alignment of __atomic_wide_counter"]
+        [::std::mem::align_of::<__atomic_wide_counter>() - 8usize];
+    ["Offset of field: __atomic_wide_counter::__value64"]
+        [::std::mem::offset_of!(__atomic_wide_counter, __value64) - 0usize];
+    ["Offset of field: __atomic_wide_counter::__value32"]
+        [::std::mem::offset_of!(__atomic_wide_counter, __value32) - 0usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __pthread_internal_list {
+    pub __prev: *mut __pthread_internal_list,
+    pub __next: *mut __pthread_internal_list,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of __pthread_internal_list"][::std::mem::size_of::<__pthread_internal_list>() - 16usize];
+    ["Alignment of __pthread_internal_list"]
+        [::std::mem::align_of::<__pthread_internal_list>() - 8usize];
+    ["Offset of field: __pthread_internal_list::__prev"]
+        [::std::mem::offset_of!(__pthread_internal_list, __prev) - 0usize];
+    ["Offset of field: __pthread_internal_list::__next"]
+        [::std::mem::offset_of!(__pthread_internal_list, __next) - 8usize];
+};
+pub type __pthread_list_t = __pthread_internal_list;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __pthread_internal_slist {
+    pub __next: *mut __pthread_internal_slist,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of __pthread_internal_slist"]
+        [::std::mem::size_of::<__pthread_internal_slist>() - 8usize];
+    ["Alignment of __pthread_internal_slist"]
+        [::std::mem::align_of::<__pthread_internal_slist>() - 8usize];
+    ["Offset of field: __pthread_internal_slist::__next"]
+        [::std::mem::offset_of!(__pthread_internal_slist, __next) - 0usize];
+};
+pub type __pthread_slist_t = __pthread_internal_slist;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __pthread_mutex_s {
+    pub __lock: ::std::os::raw::c_int,
+    pub __count: ::std::os::raw::c_uint,
+    pub __owner: ::std::os::raw::c_int,
+    pub __nusers: ::std::os::raw::c_uint,
+    pub __kind: ::std::os::raw::c_int,
+    pub __spins: ::std::os::raw::c_int,
+    pub __list: __pthread_list_t,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of __pthread_mutex_s"][::std::mem::size_of::<__pthread_mutex_s>() - 40usize];
+    ["Alignment of __pthread_mutex_s"][::std::mem::align_of::<__pthread_mutex_s>() - 8usize];
+    ["Offset of field: __pthread_mutex_s::__lock"]
+        [::std::mem::offset_of!(__pthread_mutex_s, __lock) - 0usize];
+    ["Offset of field: __pthread_mutex_s::__count"]
+        [::std::mem::offset_of!(__pthread_mutex_s, __count) - 4usize];
+    ["Offset of field: __pthread_mutex_s::__owner"]
+        [::std::mem::offset_of!(__pthread_mutex_s, __owner) - 8usize];
+    ["Offset of field: __pthread_mutex_s::__nusers"]
+        [::std::mem::offset_of!(__pthread_mutex_s, __nusers) - 12usize];
+    ["Offset of field: __pthread_mutex_s::__kind"]
+        [::std::mem::offset_of!(__pthread_mutex_s, __kind) - 16usize];
+    ["Offset of field: __pthread_mutex_s::__spins"]
+        [::std::mem::offset_of!(__pthread_mutex_s, __spins) - 20usize];
+    ["Offset of field: __pthread_mutex_s::__list"]
+        [::std::mem::offset_of!(__pthread_mutex_s, __list) - 24usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __pthread_rwlock_arch_t {
+    pub __readers: ::std::os::raw::c_uint,
+    pub __writers: ::std::os::raw::c_uint,
+    pub __wrphase_futex: ::std::os::raw::c_uint,
+    pub __writers_futex: ::std::os::raw::c_uint,
+    pub __pad3: ::std::os::raw::c_uint,
+    pub __pad4: ::std::os::raw::c_uint,
+    pub __cur_writer: ::std::os::raw::c_int,
+    pub __shared: ::std::os::raw::c_int,
+    pub __pad1: ::std::os::raw::c_ulong,
+    pub __pad2: ::std::os::raw::c_ulong,
+    pub __flags: ::std::os::raw::c_uint,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of __pthread_rwlock_arch_t"][::std::mem::size_of::<__pthread_rwlock_arch_t>() - 56usize];
+    ["Alignment of __pthread_rwlock_arch_t"]
+        [::std::mem::align_of::<__pthread_rwlock_arch_t>() - 8usize];
+    ["Offset of field: __pthread_rwlock_arch_t::__readers"]
+        [::std::mem::offset_of!(__pthread_rwlock_arch_t, __readers) - 0usize];
+    ["Offset of field: __pthread_rwlock_arch_t::__writers"]
+        [::std::mem::offset_of!(__pthread_rwlock_arch_t, __writers) - 4usize];
+    ["Offset of field: __pthread_rwlock_arch_t::__wrphase_futex"]
+        [::std::mem::offset_of!(__pthread_rwlock_arch_t, __wrphase_futex) - 8usize];
+    ["Offset of field: __pthread_rwlock_arch_t::__writers_futex"]
+        [::std::mem::offset_of!(__pthread_rwlock_arch_t, __writers_futex) - 12usize];
+    ["Offset of field: __pthread_rwlock_arch_t::__pad3"]
+        [::std::mem::offset_of!(__pthread_rwlock_arch_t, __pad3) - 16usize];
+    ["Offset of field: __pthread_rwlock_arch_t::__pad4"]
+        [::std::mem::offset_of!(__pthread_rwlock_arch_t, __pad4) - 20usize];
+    ["Offset of field: __pthread_rwlock_arch_t::__cur_writer"]
+        [::std::mem::offset_of!(__pthread_rwlock_arch_t, __cur_writer) - 24usize];
+    ["Offset of field: __pthread_rwlock_arch_t::__shared"]
+        [::std::mem::offset_of!(__pthread_rwlock_arch_t, __shared) - 28usize];
+    ["Offset of field: __pthread_rwlock_arch_t::__pad1"]
+        [::std::mem::offset_of!(__pthread_rwlock_arch_t, __pad1) - 32usize];
+    ["Offset of field: __pthread_rwlock_arch_t::__pad2"]
+        [::std::mem::offset_of!(__pthread_rwlock_arch_t, __pad2) - 40usize];
+    ["Offset of field: __pthread_rwlock_arch_t::__flags"]
+        [::std::mem::offset_of!(__pthread_rwlock_arch_t, __flags) - 48usize];
+};
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __pthread_cond_s {
+    pub __wseq: __atomic_wide_counter,
+    pub __g1_start: __atomic_wide_counter,
+    pub __g_refs: [::std::os::raw::c_uint; 2usize],
+    pub __g_size: [::std::os::raw::c_uint; 2usize],
+    pub __g1_orig_size: ::std::os::raw::c_uint,
+    pub __wrefs: ::std::os::raw::c_uint,
+    pub __g_signals: [::std::os::raw::c_uint; 2usize],
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of __pthread_cond_s"][::std::mem::size_of::<__pthread_cond_s>() - 48usize];
+    ["Alignment of __pthread_cond_s"][::std::mem::align_of::<__pthread_cond_s>() - 8usize];
+    ["Offset of field: __pthread_cond_s::__wseq"]
+        [::std::mem::offset_of!(__pthread_cond_s, __wseq) - 0usize];
+    ["Offset of field: __pthread_cond_s::__g1_start"]
+        [::std::mem::offset_of!(__pthread_cond_s, __g1_start) - 8usize];
+    ["Offset of field: __pthread_cond_s::__g_refs"]
+        [::std::mem::offset_of!(__pthread_cond_s, __g_refs) - 16usize];
+    ["Offset of field: __pthread_cond_s::__g_size"]
+        [::std::mem::offset_of!(__pthread_cond_s, __g_size) - 24usize];
+    ["Offset of field: __pthread_cond_s::__g1_orig_size"]
+        [::std::mem::offset_of!(__pthread_cond_s, __g1_orig_size) - 32usize];
+    ["Offset of field: __pthread_cond_s::__wrefs"]
+        [::std::mem::offset_of!(__pthread_cond_s, __wrefs) - 36usize];
+    ["Offset of field: __pthread_cond_s::__g_signals"]
+        [::std::mem::offset_of!(__pthread_cond_s, __g_signals) - 40usize];
+};
+pub type __tss_t = ::std::os::raw::c_uint;
+pub type __thrd_t = ::std::os::raw::c_ulong;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __once_flag {
+    pub __data: ::std::os::raw::c_int,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of __once_flag"][::std::mem::size_of::<__once_flag>() - 4usize];
+    ["Alignment of __once_flag"][::std::mem::align_of::<__once_flag>() - 4usize];
+    ["Offset of field: __once_flag::__data"][::std::mem::offset_of!(__once_flag, __data) - 0usize];
+};
+pub type pthread_t = ::std::os::raw::c_ulong;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_mutexattr_t {
+    pub __size: [::std::os::raw::c_char; 8usize],
+    pub __align: ::std::os::raw::c_int,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of pthread_mutexattr_t"][::std::mem::size_of::<pthread_mutexattr_t>() - 8usize];
+    ["Alignment of pthread_mutexattr_t"][::std::mem::align_of::<pthread_mutexattr_t>() - 4usize];
+    ["Offset of field: pthread_mutexattr_t::__size"]
+        [::std::mem::offset_of!(pthread_mutexattr_t, __size) - 0usize];
+    ["Offset of field: pthread_mutexattr_t::__align"]
+        [::std::mem::offset_of!(pthread_mutexattr_t, __align) - 0usize];
+};
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_condattr_t {
+    pub __size: [::std::os::raw::c_char; 8usize],
+    pub __align: ::std::os::raw::c_int,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of pthread_condattr_t"][::std::mem::size_of::<pthread_condattr_t>() - 8usize];
+    ["Alignment of pthread_condattr_t"][::std::mem::align_of::<pthread_condattr_t>() - 4usize];
+    ["Offset of field: pthread_condattr_t::__size"]
+        [::std::mem::offset_of!(pthread_condattr_t, __size) - 0usize];
+    ["Offset of field: pthread_condattr_t::__align"]
+        [::std::mem::offset_of!(pthread_condattr_t, __align) - 0usize];
+};
+pub type pthread_key_t = ::std::os::raw::c_uint;
+pub type pthread_once_t = ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_attr_t {
+    pub __size: [::std::os::raw::c_char; 64usize],
+    pub __align: ::std::os::raw::c_long,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of pthread_attr_t"][::std::mem::size_of::<pthread_attr_t>() - 64usize];
+    ["Alignment of pthread_attr_t"][::std::mem::align_of::<pthread_attr_t>() - 8usize];
+    ["Offset of field: pthread_attr_t::__size"]
+        [::std::mem::offset_of!(pthread_attr_t, __size) - 0usize];
+    ["Offset of field: pthread_attr_t::__align"]
+        [::std::mem::offset_of!(pthread_attr_t, __align) - 0usize];
+};
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_mutex_t {
+    pub __data: __pthread_mutex_s,
+    pub __size: [::std::os::raw::c_char; 48usize],
+    pub __align: ::std::os::raw::c_long,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of pthread_mutex_t"][::std::mem::size_of::<pthread_mutex_t>() - 48usize];
+    ["Alignment of pthread_mutex_t"][::std::mem::align_of::<pthread_mutex_t>() - 8usize];
+    ["Offset of field: pthread_mutex_t::__data"]
+        [::std::mem::offset_of!(pthread_mutex_t, __data) - 0usize];
+    ["Offset of field: pthread_mutex_t::__size"]
+        [::std::mem::offset_of!(pthread_mutex_t, __size) - 0usize];
+    ["Offset of field: pthread_mutex_t::__align"]
+        [::std::mem::offset_of!(pthread_mutex_t, __align) - 0usize];
+};
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_cond_t {
+    pub __data: __pthread_cond_s,
+    pub __size: [::std::os::raw::c_char; 48usize],
+    pub __align: ::std::os::raw::c_longlong,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of pthread_cond_t"][::std::mem::size_of::<pthread_cond_t>() - 48usize];
+    ["Alignment of pthread_cond_t"][::std::mem::align_of::<pthread_cond_t>() - 8usize];
+    ["Offset of field: pthread_cond_t::__data"]
+        [::std::mem::offset_of!(pthread_cond_t, __data) - 0usize];
+    ["Offset of field: pthread_cond_t::__size"]
+        [::std::mem::offset_of!(pthread_cond_t, __size) - 0usize];
+    ["Offset of field: pthread_cond_t::__align"]
+        [::std::mem::offset_of!(pthread_cond_t, __align) - 0usize];
+};
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_rwlock_t {
+    pub __data: __pthread_rwlock_arch_t,
+    pub __size: [::std::os::raw::c_char; 56usize],
+    pub __align: ::std::os::raw::c_long,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of pthread_rwlock_t"][::std::mem::size_of::<pthread_rwlock_t>() - 56usize];
+    ["Alignment of pthread_rwlock_t"][::std::mem::align_of::<pthread_rwlock_t>() - 8usize];
+    ["Offset of field: pthread_rwlock_t::__data"]
+        [::std::mem::offset_of!(pthread_rwlock_t, __data) - 0usize];
+    ["Offset of field: pthread_rwlock_t::__size"]
+        [::std::mem::offset_of!(pthread_rwlock_t, __size) - 0usize];
+    ["Offset of field: pthread_rwlock_t::__align"]
+        [::std::mem::offset_of!(pthread_rwlock_t, __align) - 0usize];
+};
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_rwlockattr_t {
+    pub __size: [::std::os::raw::c_char; 8usize],
+    pub __align: ::std::os::raw::c_long,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of pthread_rwlockattr_t"][::std::mem::size_of::<pthread_rwlockattr_t>() - 8usize];
+    ["Alignment of pthread_rwlockattr_t"][::std::mem::align_of::<pthread_rwlockattr_t>() - 8usize];
+    ["Offset of field: pthread_rwlockattr_t::__size"]
+        [::std::mem::offset_of!(pthread_rwlockattr_t, __size) - 0usize];
+    ["Offset of field: pthread_rwlockattr_t::__align"]
+        [::std::mem::offset_of!(pthread_rwlockattr_t, __align) - 0usize];
+};
+pub type pthread_spinlock_t = ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_barrier_t {
+    pub __size: [::std::os::raw::c_char; 32usize],
+    pub __align: ::std::os::raw::c_long,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of pthread_barrier_t"][::std::mem::size_of::<pthread_barrier_t>() - 32usize];
+    ["Alignment of pthread_barrier_t"][::std::mem::align_of::<pthread_barrier_t>() - 8usize];
+    ["Offset of field: pthread_barrier_t::__size"]
+        [::std::mem::offset_of!(pthread_barrier_t, __size) - 0usize];
+    ["Offset of field: pthread_barrier_t::__align"]
+        [::std::mem::offset_of!(pthread_barrier_t, __align) - 0usize];
+};
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_barrierattr_t {
+    pub __size: [::std::os::raw::c_char; 8usize],
+    pub __align: ::std::os::raw::c_int,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of pthread_barrierattr_t"][::std::mem::size_of::<pthread_barrierattr_t>() - 8usize];
+    ["Alignment of pthread_barrierattr_t"]
+        [::std::mem::align_of::<pthread_barrierattr_t>() - 4usize];
+    ["Offset of field: pthread_barrierattr_t::__size"]
+        [::std::mem::offset_of!(pthread_barrierattr_t, __size) - 0usize];
+    ["Offset of field: pthread_barrierattr_t::__align"]
+        [::std::mem::offset_of!(pthread_barrierattr_t, __align) - 0usize];
+};
 unsafe extern "C" {
-    pub fn malloc_type_zone_malloc(
-        zone: *mut malloc_zone_t,
-        size: usize,
-        type_id: malloc_type_id_t,
-    ) -> *mut ::std::os::raw::c_void;
+    pub fn random() -> ::std::os::raw::c_long;
 }
 unsafe extern "C" {
-    pub fn malloc_type_zone_calloc(
-        zone: *mut malloc_zone_t,
-        count: usize,
-        size: usize,
-        type_id: malloc_type_id_t,
-    ) -> *mut ::std::os::raw::c_void;
+    pub fn srandom(__seed: ::std::os::raw::c_uint);
 }
 unsafe extern "C" {
-    pub fn malloc_type_zone_free(
-        zone: *mut malloc_zone_t,
-        ptr: *mut ::std::os::raw::c_void,
-        type_id: malloc_type_id_t,
-    );
+    pub fn initstate(
+        __seed: ::std::os::raw::c_uint,
+        __statebuf: *mut ::std::os::raw::c_char,
+        __statelen: usize,
+    ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn malloc_type_zone_realloc(
-        zone: *mut malloc_zone_t,
-        ptr: *mut ::std::os::raw::c_void,
-        size: usize,
-        type_id: malloc_type_id_t,
-    ) -> *mut ::std::os::raw::c_void;
+    pub fn setstate(__statebuf: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct random_data {
+    pub fptr: *mut i32,
+    pub rptr: *mut i32,
+    pub state: *mut i32,
+    pub rand_type: ::std::os::raw::c_int,
+    pub rand_deg: ::std::os::raw::c_int,
+    pub rand_sep: ::std::os::raw::c_int,
+    pub end_ptr: *mut i32,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of random_data"][::std::mem::size_of::<random_data>() - 48usize];
+    ["Alignment of random_data"][::std::mem::align_of::<random_data>() - 8usize];
+    ["Offset of field: random_data::fptr"][::std::mem::offset_of!(random_data, fptr) - 0usize];
+    ["Offset of field: random_data::rptr"][::std::mem::offset_of!(random_data, rptr) - 8usize];
+    ["Offset of field: random_data::state"][::std::mem::offset_of!(random_data, state) - 16usize];
+    ["Offset of field: random_data::rand_type"]
+        [::std::mem::offset_of!(random_data, rand_type) - 24usize];
+    ["Offset of field: random_data::rand_deg"]
+        [::std::mem::offset_of!(random_data, rand_deg) - 28usize];
+    ["Offset of field: random_data::rand_sep"]
+        [::std::mem::offset_of!(random_data, rand_sep) - 32usize];
+    ["Offset of field: random_data::end_ptr"]
+        [::std::mem::offset_of!(random_data, end_ptr) - 40usize];
+};
+unsafe extern "C" {
+    pub fn random_r(__buf: *mut random_data, __result: *mut i32) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn malloc_type_zone_valloc(
-        zone: *mut malloc_zone_t,
-        size: usize,
-        type_id: malloc_type_id_t,
-    ) -> *mut ::std::os::raw::c_void;
+    pub fn srandom_r(
+        __seed: ::std::os::raw::c_uint,
+        __buf: *mut random_data,
+    ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn malloc_type_zone_memalign(
-        zone: *mut malloc_zone_t,
-        alignment: usize,
-        size: usize,
-        type_id: malloc_type_id_t,
-    ) -> *mut ::std::os::raw::c_void;
+    pub fn initstate_r(
+        __seed: ::std::os::raw::c_uint,
+        __statebuf: *mut ::std::os::raw::c_char,
+        __statelen: usize,
+        __buf: *mut random_data,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn setstate_r(
+        __statebuf: *mut ::std::os::raw::c_char,
+        __buf: *mut random_data,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn rand() -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn srand(__seed: ::std::os::raw::c_uint);
+}
+unsafe extern "C" {
+    pub fn rand_r(__seed: *mut ::std::os::raw::c_uint) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn drand48() -> f64;
+}
+unsafe extern "C" {
+    pub fn erand48(__xsubi: *mut ::std::os::raw::c_ushort) -> f64;
+}
+unsafe extern "C" {
+    pub fn lrand48() -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn nrand48(__xsubi: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn mrand48() -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn jrand48(__xsubi: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn srand48(__seedval: ::std::os::raw::c_long);
+}
+unsafe extern "C" {
+    pub fn seed48(__seed16v: *mut ::std::os::raw::c_ushort) -> *mut ::std::os::raw::c_ushort;
+}
+unsafe extern "C" {
+    pub fn lcong48(__param: *mut ::std::os::raw::c_ushort);
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct drand48_data {
+    pub __x: [::std::os::raw::c_ushort; 3usize],
+    pub __old_x: [::std::os::raw::c_ushort; 3usize],
+    pub __c: ::std::os::raw::c_ushort,
+    pub __init: ::std::os::raw::c_ushort,
+    pub __a: ::std::os::raw::c_ulonglong,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of drand48_data"][::std::mem::size_of::<drand48_data>() - 24usize];
+    ["Alignment of drand48_data"][::std::mem::align_of::<drand48_data>() - 8usize];
+    ["Offset of field: drand48_data::__x"][::std::mem::offset_of!(drand48_data, __x) - 0usize];
+    ["Offset of field: drand48_data::__old_x"]
+        [::std::mem::offset_of!(drand48_data, __old_x) - 6usize];
+    ["Offset of field: drand48_data::__c"][::std::mem::offset_of!(drand48_data, __c) - 12usize];
+    ["Offset of field: drand48_data::__init"]
+        [::std::mem::offset_of!(drand48_data, __init) - 14usize];
+    ["Offset of field: drand48_data::__a"][::std::mem::offset_of!(drand48_data, __a) - 16usize];
+};
+unsafe extern "C" {
+    pub fn drand48_r(__buffer: *mut drand48_data, __result: *mut f64) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn erand48_r(
+        __xsubi: *mut ::std::os::raw::c_ushort,
+        __buffer: *mut drand48_data,
+        __result: *mut f64,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn lrand48_r(
+        __buffer: *mut drand48_data,
+        __result: *mut ::std::os::raw::c_long,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn nrand48_r(
+        __xsubi: *mut ::std::os::raw::c_ushort,
+        __buffer: *mut drand48_data,
+        __result: *mut ::std::os::raw::c_long,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn mrand48_r(
+        __buffer: *mut drand48_data,
+        __result: *mut ::std::os::raw::c_long,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn jrand48_r(
+        __xsubi: *mut ::std::os::raw::c_ushort,
+        __buffer: *mut drand48_data,
+        __result: *mut ::std::os::raw::c_long,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn srand48_r(
+        __seedval: ::std::os::raw::c_long,
+        __buffer: *mut drand48_data,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn seed48_r(
+        __seed16v: *mut ::std::os::raw::c_ushort,
+        __buffer: *mut drand48_data,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn lcong48_r(
+        __param: *mut ::std::os::raw::c_ushort,
+        __buffer: *mut drand48_data,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn arc4random() -> __uint32_t;
+}
+unsafe extern "C" {
+    pub fn arc4random_buf(__buf: *mut ::std::os::raw::c_void, __size: usize);
+}
+unsafe extern "C" {
+    pub fn arc4random_uniform(__upper_bound: __uint32_t) -> __uint32_t;
 }
 unsafe extern "C" {
     pub fn malloc(__size: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void;
 }
 unsafe extern "C" {
     pub fn calloc(
-        __count: ::std::os::raw::c_ulong,
+        __nmemb: ::std::os::raw::c_ulong,
         __size: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_void;
-}
-unsafe extern "C" {
-    pub fn free(arg1: *mut ::std::os::raw::c_void);
 }
 unsafe extern "C" {
     pub fn realloc(
@@ -4578,19 +3720,20 @@ unsafe extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 unsafe extern "C" {
-    pub fn reallocf(
+    pub fn free(__ptr: *mut ::std::os::raw::c_void);
+}
+unsafe extern "C" {
+    pub fn reallocarray(
         __ptr: *mut ::std::os::raw::c_void,
+        __nmemb: usize,
         __size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 unsafe extern "C" {
-    pub fn valloc(arg1: usize) -> *mut ::std::os::raw::c_void;
+    pub fn alloca(__size: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void;
 }
 unsafe extern "C" {
-    pub fn aligned_alloc(
-        __alignment: ::std::os::raw::c_ulong,
-        __size: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_void;
+    pub fn valloc(__size: usize) -> *mut ::std::os::raw::c_void;
 }
 unsafe extern "C" {
     pub fn posix_memalign(
@@ -4600,554 +3743,265 @@ unsafe extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn abort() -> !;
-}
-unsafe extern "C" {
-    pub fn abs(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn atexit(arg1: ::std::option::Option<unsafe extern "C" fn()>) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn atof(arg1: *const ::std::os::raw::c_char) -> f64;
-}
-unsafe extern "C" {
-    pub fn atoi(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn atol(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
-}
-unsafe extern "C" {
-    pub fn atoll(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_longlong;
-}
-unsafe extern "C" {
-    pub fn bsearch(
-        __key: *const ::std::os::raw::c_void,
-        __base: *const ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
+    pub fn aligned_alloc(
+        __alignment: ::std::os::raw::c_ulong,
+        __size: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_void;
 }
 unsafe extern "C" {
-    pub fn div(arg1: ::std::os::raw::c_int, arg2: ::std::os::raw::c_int) -> div_t;
+    pub fn abort() -> !;
 }
 unsafe extern "C" {
-    pub fn exit(arg1: ::std::os::raw::c_int) -> !;
+    pub fn atexit(__func: ::std::option::Option<unsafe extern "C" fn()>) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn getenv(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn labs(arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
-}
-unsafe extern "C" {
-    pub fn ldiv(arg1: ::std::os::raw::c_long, arg2: ::std::os::raw::c_long) -> ldiv_t;
-}
-unsafe extern "C" {
-    pub fn llabs(arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_longlong;
-}
-unsafe extern "C" {
-    pub fn lldiv(arg1: ::std::os::raw::c_longlong, arg2: ::std::os::raw::c_longlong) -> lldiv_t;
-}
-unsafe extern "C" {
-    pub fn mblen(__s: *const ::std::os::raw::c_char, __n: usize) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn mbstowcs(arg1: *mut wchar_t, arg2: *const ::std::os::raw::c_char, arg3: usize) -> usize;
-}
-unsafe extern "C" {
-    pub fn mbtowc(
-        arg1: *mut wchar_t,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: usize,
+    pub fn at_quick_exit(
+        __func: ::std::option::Option<unsafe extern "C" fn()>,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn qsort(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: ::std::option::Option<
+    pub fn on_exit(
+        __func: ::std::option::Option<
             unsafe extern "C" fn(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
+                __status: ::std::os::raw::c_int,
+                __arg: *mut ::std::os::raw::c_void,
+            ),
         >,
-    );
-}
-unsafe extern "C" {
-    pub fn rand() -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn srand(arg1: ::std::os::raw::c_uint);
-}
-unsafe extern "C" {
-    pub fn strtod(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *mut *mut ::std::os::raw::c_char,
-    ) -> f64;
-}
-unsafe extern "C" {
-    pub fn strtof(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *mut *mut ::std::os::raw::c_char,
-    ) -> f32;
-}
-unsafe extern "C" {
-    pub fn strtol(
-        __str: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_long;
-}
-unsafe extern "C" {
-    pub fn strtold(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *mut *mut ::std::os::raw::c_char,
-    ) -> f64;
-}
-unsafe extern "C" {
-    pub fn strtoll(
-        __str: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_longlong;
-}
-unsafe extern "C" {
-    pub fn strtoul(
-        __str: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_ulong;
-}
-unsafe extern "C" {
-    pub fn strtoull(
-        __str: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_ulonglong;
-}
-unsafe extern "C" {
-    pub fn system(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn wcstombs(arg1: *mut ::std::os::raw::c_char, arg2: *const wchar_t, arg3: usize) -> usize;
-}
-unsafe extern "C" {
-    pub fn wctomb(arg1: *mut ::std::os::raw::c_char, arg2: wchar_t) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn _Exit(arg1: ::std::os::raw::c_int) -> !;
-}
-unsafe extern "C" {
-    pub fn a64l(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
-}
-unsafe extern "C" {
-    pub fn drand48() -> f64;
-}
-unsafe extern "C" {
-    pub fn ecvt(
-        arg1: f64,
-        arg2: ::std::os::raw::c_int,
-        arg3: *mut ::std::os::raw::c_int,
-        arg4: *mut ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn erand48(arg1: *mut ::std::os::raw::c_ushort) -> f64;
-}
-unsafe extern "C" {
-    pub fn fcvt(
-        arg1: f64,
-        arg2: ::std::os::raw::c_int,
-        arg3: *mut ::std::os::raw::c_int,
-        arg4: *mut ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn gcvt(
-        arg1: f64,
-        arg2: ::std::os::raw::c_int,
-        arg3: *mut ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn getsubopt(
-        arg1: *mut *mut ::std::os::raw::c_char,
-        arg2: *const *mut ::std::os::raw::c_char,
-        arg3: *mut *mut ::std::os::raw::c_char,
+        __arg: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn grantpt(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn exit(__status: ::std::os::raw::c_int) -> !;
 }
 unsafe extern "C" {
-    pub fn initstate(
-        arg1: ::std::os::raw::c_uint,
-        arg2: *mut ::std::os::raw::c_char,
-        arg3: usize,
-    ) -> *mut ::std::os::raw::c_char;
+    pub fn quick_exit(__status: ::std::os::raw::c_int) -> !;
 }
 unsafe extern "C" {
-    pub fn jrand48(arg1: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
+    pub fn _Exit(__status: ::std::os::raw::c_int) -> !;
 }
 unsafe extern "C" {
-    pub fn l64a(arg1: ::std::os::raw::c_long) -> *mut ::std::os::raw::c_char;
+    pub fn getenv(__name: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn lcong48(arg1: *mut ::std::os::raw::c_ushort);
-}
-unsafe extern "C" {
-    pub fn lrand48() -> ::std::os::raw::c_long;
-}
-unsafe extern "C" {
-    pub fn mktemp(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn mkstemp(arg1: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn mrand48() -> ::std::os::raw::c_long;
-}
-unsafe extern "C" {
-    pub fn nrand48(arg1: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
-}
-unsafe extern "C" {
-    pub fn posix_openpt(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn ptsname(arg1: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn ptsname_r(
-        fildes: ::std::os::raw::c_int,
-        buffer: *mut ::std::os::raw::c_char,
-        buflen: usize,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn putenv(arg1: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn random() -> ::std::os::raw::c_long;
-}
-unsafe extern "C" {
-    pub fn rand_r(arg1: *mut ::std::os::raw::c_uint) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    #[link_name = "\u{1}_realpath$DARWIN_EXTSN"]
-    pub fn realpath(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *mut ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn seed48(arg1: *mut ::std::os::raw::c_ushort) -> *mut ::std::os::raw::c_ushort;
+    pub fn putenv(__string: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
     pub fn setenv(
         __name: *const ::std::os::raw::c_char,
         __value: *const ::std::os::raw::c_char,
-        __overwrite: ::std::os::raw::c_int,
+        __replace: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn setkey(arg1: *const ::std::os::raw::c_char);
+    pub fn unsetenv(__name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn setstate(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+    pub fn clearenv() -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn srand48(arg1: ::std::os::raw::c_long);
+    pub fn mktemp(__template: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn srandom(arg1: ::std::os::raw::c_uint);
+    pub fn mkstemp(__template: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn unlockpt(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn mkstemps(
+        __template: *mut ::std::os::raw::c_char,
+        __suffixlen: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn unsetenv(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-pub type dev_t = __darwin_dev_t;
-pub type mode_t = __darwin_mode_t;
-unsafe extern "C" {
-    pub fn arc4random() -> u32;
+    pub fn mkdtemp(__template: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn arc4random_addrandom(arg1: *mut ::std::os::raw::c_uchar, arg2: ::std::os::raw::c_int);
+    pub fn system(__command: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn arc4random_buf(__buf: *mut ::std::os::raw::c_void, __nbytes: usize);
+    pub fn realpath(
+        __name: *const ::std::os::raw::c_char,
+        __resolved: *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
 }
+pub type __compar_fn_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        arg1: *const ::std::os::raw::c_void,
+        arg2: *const ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int,
+>;
 unsafe extern "C" {
-    pub fn arc4random_stir();
-}
-unsafe extern "C" {
-    pub fn arc4random_uniform(__upper_bound: u32) -> u32;
-}
-unsafe extern "C" {
-    pub fn atexit_b(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn bsearch_b(
+    pub fn bsearch(
         __key: *const ::std::os::raw::c_void,
         __base: *const ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: *mut ::std::os::raw::c_void,
+        __nmemb: usize,
+        __size: usize,
+        __compar: __compar_fn_t,
     ) -> *mut ::std::os::raw::c_void;
 }
 unsafe extern "C" {
-    pub fn cgetcap(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
+    pub fn qsort(
+        __base: *mut ::std::os::raw::c_void,
+        __nmemb: usize,
+        __size: usize,
+        __compar: __compar_fn_t,
+    );
+}
+unsafe extern "C" {
+    pub fn abs(__x: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn labs(__x: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn llabs(__x: ::std::os::raw::c_longlong) -> ::std::os::raw::c_longlong;
+}
+unsafe extern "C" {
+    pub fn div(__numer: ::std::os::raw::c_int, __denom: ::std::os::raw::c_int) -> div_t;
+}
+unsafe extern "C" {
+    pub fn ldiv(__numer: ::std::os::raw::c_long, __denom: ::std::os::raw::c_long) -> ldiv_t;
+}
+unsafe extern "C" {
+    pub fn lldiv(
+        __numer: ::std::os::raw::c_longlong,
+        __denom: ::std::os::raw::c_longlong,
+    ) -> lldiv_t;
+}
+unsafe extern "C" {
+    pub fn ecvt(
+        __value: f64,
+        __ndigit: ::std::os::raw::c_int,
+        __decpt: *mut ::std::os::raw::c_int,
+        __sign: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn cgetclose() -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn cgetent(
-        arg1: *mut *mut ::std::os::raw::c_char,
-        arg2: *mut *mut ::std::os::raw::c_char,
-        arg3: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn cgetfirst(
-        arg1: *mut *mut ::std::os::raw::c_char,
-        arg2: *mut *mut ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn cgetmatch(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn cgetnext(
-        arg1: *mut *mut ::std::os::raw::c_char,
-        arg2: *mut *mut ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn cgetnum(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut ::std::os::raw::c_long,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn cgetset(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn cgetstr(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut *mut ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn cgetustr(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut *mut ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn daemon(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn devname(arg1: dev_t, arg2: mode_t) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn devname_r(
-        arg1: dev_t,
-        arg2: mode_t,
-        buf: *mut ::std::os::raw::c_char,
-        len: ::std::os::raw::c_int,
+    pub fn fcvt(
+        __value: f64,
+        __ndigit: ::std::os::raw::c_int,
+        __decpt: *mut ::std::os::raw::c_int,
+        __sign: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn getbsize(
-        arg1: *mut ::std::os::raw::c_int,
-        arg2: *mut ::std::os::raw::c_long,
+    pub fn gcvt(
+        __value: f64,
+        __ndigit: ::std::os::raw::c_int,
+        __buf: *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn getloadavg(arg1: *mut f64, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn qecvt(
+        __value: u128,
+        __ndigit: ::std::os::raw::c_int,
+        __decpt: *mut ::std::os::raw::c_int,
+        __sign: *mut ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn getprogname() -> *const ::std::os::raw::c_char;
+    pub fn qfcvt(
+        __value: u128,
+        __ndigit: ::std::os::raw::c_int,
+        __decpt: *mut ::std::os::raw::c_int,
+        __sign: *mut ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn setprogname(arg1: *const ::std::os::raw::c_char);
+    pub fn qgcvt(
+        __value: u128,
+        __ndigit: ::std::os::raw::c_int,
+        __buf: *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn heapsort(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
+    pub fn ecvt_r(
+        __value: f64,
+        __ndigit: ::std::os::raw::c_int,
+        __decpt: *mut ::std::os::raw::c_int,
+        __sign: *mut ::std::os::raw::c_int,
+        __buf: *mut ::std::os::raw::c_char,
+        __len: usize,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn heapsort_b(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: *mut ::std::os::raw::c_void,
+    pub fn fcvt_r(
+        __value: f64,
+        __ndigit: ::std::os::raw::c_int,
+        __decpt: *mut ::std::os::raw::c_int,
+        __sign: *mut ::std::os::raw::c_int,
+        __buf: *mut ::std::os::raw::c_char,
+        __len: usize,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn mergesort(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
+    pub fn qecvt_r(
+        __value: u128,
+        __ndigit: ::std::os::raw::c_int,
+        __decpt: *mut ::std::os::raw::c_int,
+        __sign: *mut ::std::os::raw::c_int,
+        __buf: *mut ::std::os::raw::c_char,
+        __len: usize,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn mergesort_b(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: *mut ::std::os::raw::c_void,
+    pub fn qfcvt_r(
+        __value: u128,
+        __ndigit: ::std::os::raw::c_int,
+        __decpt: *mut ::std::os::raw::c_int,
+        __sign: *mut ::std::os::raw::c_int,
+        __buf: *mut ::std::os::raw::c_char,
+        __len: usize,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn psort(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
-    );
+    pub fn mblen(__s: *const ::std::os::raw::c_char, __n: usize) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn psort_b(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: *mut ::std::os::raw::c_void,
-    );
-}
-unsafe extern "C" {
-    pub fn psort_r(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        arg1: *mut ::std::os::raw::c_void,
-        __compar: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-                arg3: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
-    );
-}
-unsafe extern "C" {
-    pub fn qsort_b(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: *mut ::std::os::raw::c_void,
-    );
-}
-unsafe extern "C" {
-    pub fn qsort_r(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        arg1: *mut ::std::os::raw::c_void,
-        __compar: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-                arg3: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
-    );
-}
-unsafe extern "C" {
-    pub fn radixsort(
-        __base: *mut *const ::std::os::raw::c_uchar,
-        __nel: ::std::os::raw::c_int,
-        __table: *const ::std::os::raw::c_uchar,
-        __endbyte: ::std::os::raw::c_uint,
+    pub fn mbtowc(
+        __pwc: *mut wchar_t,
+        __s: *const ::std::os::raw::c_char,
+        __n: usize,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn rpmatch(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+    pub fn wctomb(__s: *mut ::std::os::raw::c_char, __wchar: wchar_t) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn sradixsort(
-        __base: *mut *const ::std::os::raw::c_uchar,
-        __nel: ::std::os::raw::c_int,
-        __table: *const ::std::os::raw::c_uchar,
-        __endbyte: ::std::os::raw::c_uint,
+    pub fn mbstowcs(__pwcs: *mut wchar_t, __s: *const ::std::os::raw::c_char, __n: usize) -> usize;
+}
+unsafe extern "C" {
+    pub fn wcstombs(__s: *mut ::std::os::raw::c_char, __pwcs: *const wchar_t, __n: usize) -> usize;
+}
+unsafe extern "C" {
+    pub fn rpmatch(__response: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn getsubopt(
+        __optionp: *mut *mut ::std::os::raw::c_char,
+        __tokens: *const *mut ::std::os::raw::c_char,
+        __valuep: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn sranddev();
+    pub fn getloadavg(__loadavg: *mut f64, __nelem: ::std::os::raw::c_int)
+    -> ::std::os::raw::c_int;
 }
-unsafe extern "C" {
-    pub fn srandomdev();
+#[repr(C)]
+#[repr(align(16))]
+#[derive(Debug, Copy, Clone)]
+pub struct max_align_t {
+    pub __clang_max_align_nonce1: ::std::os::raw::c_longlong,
+    pub __bindgen_padding_0: u64,
+    pub __clang_max_align_nonce2: u128,
 }
-unsafe extern "C" {
-    pub fn strtonum(
-        __numstr: *const ::std::os::raw::c_char,
-        __minval: ::std::os::raw::c_longlong,
-        __maxval: ::std::os::raw::c_longlong,
-        __errstrp: *mut *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_longlong;
-}
-unsafe extern "C" {
-    pub fn strtoq(
-        __str: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_longlong;
-}
-unsafe extern "C" {
-    pub fn strtouq(
-        __str: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_ulonglong;
-}
-unsafe extern "C" {
-    pub static mut suboptarg: *mut ::std::os::raw::c_char;
-}
-pub type rsize_t = ::std::os::raw::c_ulong;
-pub type max_align_t = f64;
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of max_align_t"][::std::mem::size_of::<max_align_t>() - 32usize];
+    ["Alignment of max_align_t"][::std::mem::align_of::<max_align_t>() - 16usize];
+    ["Offset of field: max_align_t::__clang_max_align_nonce1"]
+        [::std::mem::offset_of!(max_align_t, __clang_max_align_nonce1) - 0usize];
+    ["Offset of field: max_align_t::__clang_max_align_nonce2"]
+        [::std::mem::offset_of!(max_align_t, __clang_max_align_nonce2) - 16usize];
+};
 unsafe extern "C" {
     #[doc = " allocates array and initializes it with 0; returns NULL if memory allocation failed"]
     pub fn BMSallocClearMemory_call(
@@ -6045,14 +4899,12 @@ pub struct SCIP_ParamSet {
     _unused: [u8; 0],
 }
 pub type SCIP_PARAMSET = SCIP_ParamSet;
-unsafe extern "C" {
-    pub fn imaxabs(j: intmax_t) -> intmax_t;
-}
+pub type __gwchar_t = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct imaxdiv_t {
-    pub quot: intmax_t,
-    pub rem: intmax_t,
+    pub quot: ::std::os::raw::c_long,
+    pub rem: ::std::os::raw::c_long,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
@@ -6061,6 +4913,9 @@ const _: () = {
     ["Offset of field: imaxdiv_t::quot"][::std::mem::offset_of!(imaxdiv_t, quot) - 0usize];
     ["Offset of field: imaxdiv_t::rem"][::std::mem::offset_of!(imaxdiv_t, rem) - 8usize];
 };
+unsafe extern "C" {
+    pub fn imaxabs(__n: intmax_t) -> intmax_t;
+}
 unsafe extern "C" {
     pub fn imaxdiv(__numer: intmax_t, __denom: intmax_t) -> imaxdiv_t;
 }
@@ -6080,15 +4935,15 @@ unsafe extern "C" {
 }
 unsafe extern "C" {
     pub fn wcstoimax(
-        __nptr: *const wchar_t,
-        __endptr: *mut *mut wchar_t,
+        __nptr: *const __gwchar_t,
+        __endptr: *mut *mut __gwchar_t,
         __base: ::std::os::raw::c_int,
     ) -> intmax_t;
 }
 unsafe extern "C" {
     pub fn wcstoumax(
-        __nptr: *const wchar_t,
-        __endptr: *mut *mut wchar_t,
+        __nptr: *const __gwchar_t,
+        __endptr: *mut *mut __gwchar_t,
         __base: ::std::os::raw::c_int,
     ) -> uintmax_t;
 }
@@ -8364,12 +7219,14 @@ unsafe extern "C" {
     pub fn SCIPbanditGetNActions(bandit: *mut SCIP_BANDIT) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " compares two benderss w. r. to their priority"]
     pub fn SCIPbendersComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting benderss w.r.t. to their name"]
     pub fn SCIPbendersCompName(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -8739,12 +7596,14 @@ unsafe extern "C" {
     ) -> ::std::os::raw::c_uint;
 }
 unsafe extern "C" {
+    #[doc = " compares two Benders' decomposition cuts w. r. to their priority"]
     pub fn SCIPbenderscutComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting Benders' decomposition cuts w.r.t. to their name"]
     pub fn SCIPbenderscutCompName(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -8807,12 +7666,14 @@ unsafe extern "C" {
     );
 }
 unsafe extern "C" {
+    #[doc = " compares two branching rules w. r. to their priority"]
     pub fn SCIPbranchruleComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting branching rules w.r.t. to their name"]
     pub fn SCIPbranchruleCompName(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -8916,12 +7777,14 @@ unsafe extern "C" {
     pub fn SCIPbranchruleIsInitialized(branchrule: *mut SCIP_BRANCHRULE) -> ::std::os::raw::c_uint;
 }
 unsafe extern "C" {
+    #[doc = " compares two conflict handlers w. r. to their priority"]
     pub fn SCIPconflicthdlrComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting conflict handler w.r.t. to their name"]
     pub fn SCIPconflicthdlrCompName(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -8973,24 +7836,28 @@ unsafe extern "C" {
     pub fn SCIPconflicthdlrGetTime(conflicthdlr: *mut SCIP_CONFLICTHDLR) -> f64;
 }
 unsafe extern "C" {
+    #[doc = " compares two constraint handlers w.r.t. their separation priority"]
     pub fn SCIPconshdlrCompSepa(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " compares two constraint handlers w.r.t. their enforcing priority"]
     pub fn SCIPconshdlrCompEnfo(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " compares two constraint handlers w.r.t. their feasibility check priority"]
     pub fn SCIPconshdlrCompCheck(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " compares two constraints w.r.t. their feasibility check priority"]
     pub fn SCIPconsCompCheck(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -10566,6 +9433,7 @@ unsafe extern "C" {
     pub fn SCIPexprhdlrHasGetSymData(exprhdlr: *mut SCIP_EXPRHDLR) -> ::std::os::raw::c_uint;
 }
 unsafe extern "C" {
+    #[doc = " compares two expression handler w.r.t. their name"]
     pub fn SCIPexprhdlrComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -11028,18 +9896,21 @@ unsafe extern "C" {
     pub fn SCIPfclose(fp: *mut SCIP_FILE) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " compares two heuristics w.r.t. to their delay positions and priorities"]
     pub fn SCIPheurComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " compares two heuristics w.r.t. to their priority values"]
     pub fn SCIPheurCompPriority(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting heuristics w.r.t. to their name"]
     pub fn SCIPheurCompName(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -11336,12 +10207,14 @@ unsafe extern "C" {
     pub fn SCIPvariableGraphFree(scip: *mut SCIP, vargraph: *mut *mut SCIP_VGRAPH);
 }
 unsafe extern "C" {
+    #[doc = " compares two compressions w. r. to their priority"]
     pub fn SCIPcomprComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting compressions w.r.t. to their name"]
     pub fn SCIPcomprCompName(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -11491,6 +10364,7 @@ unsafe extern "C" {
     pub fn SCIPiisGetSubscip(iis: *mut SCIP_IIS) -> *mut SCIP;
 }
 unsafe extern "C" {
+    #[doc = " compares two IIS finders w. r. to their priority"]
     pub fn SCIPiisfinderComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -11837,6 +10711,7 @@ unsafe extern "C" {
     pub fn SCIPboundtypeOpposite(boundtype: SCIP_BOUNDTYPE) -> SCIP_BOUNDTYPE;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting rows by non-decreasing index"]
     pub fn SCIProwComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -12009,6 +10884,7 @@ pub struct SCIP_LPiExact {
 }
 pub type SCIP_LPIEXACT = SCIP_LPiExact;
 unsafe extern "C" {
+    #[doc = " comparison method for sorting rows by non-decreasing index"]
     pub fn SCIProwExactComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -12420,10 +11296,31 @@ unsafe extern "C" {
         varineq: *mut ::std::os::raw::c_uint,
     ) -> SCIP_RETCODE;
 }
-pub type __gnuc_va_list = __builtin_va_list;
 unsafe extern "C" {
-    pub fn memchr(
-        __s: *const ::std::os::raw::c_void,
+    pub fn memcpy(
+        __dest: *mut ::std::os::raw::c_void,
+        __src: *const ::std::os::raw::c_void,
+        __n: ::std::os::raw::c_ulong,
+    ) -> *mut ::std::os::raw::c_void;
+}
+unsafe extern "C" {
+    pub fn memmove(
+        __dest: *mut ::std::os::raw::c_void,
+        __src: *const ::std::os::raw::c_void,
+        __n: ::std::os::raw::c_ulong,
+    ) -> *mut ::std::os::raw::c_void;
+}
+unsafe extern "C" {
+    pub fn memccpy(
+        __dest: *mut ::std::os::raw::c_void,
+        __src: *const ::std::os::raw::c_void,
+        __c: ::std::os::raw::c_int,
+        __n: ::std::os::raw::c_ulong,
+    ) -> *mut ::std::os::raw::c_void;
+}
+unsafe extern "C" {
+    pub fn memset(
+        __s: *mut ::std::os::raw::c_void,
         __c: ::std::os::raw::c_int,
         __n: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_void;
@@ -12436,36 +11333,43 @@ unsafe extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn memcpy(
-        __dst: *mut ::std::os::raw::c_void,
-        __src: *const ::std::os::raw::c_void,
+    pub fn __memcmpeq(
+        __s1: *const ::std::os::raw::c_void,
+        __s2: *const ::std::os::raw::c_void,
+        __n: usize,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn memchr(
+        __s: *const ::std::os::raw::c_void,
+        __c: ::std::os::raw::c_int,
         __n: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_void;
 }
 unsafe extern "C" {
-    pub fn memmove(
-        __dst: *mut ::std::os::raw::c_void,
-        __src: *const ::std::os::raw::c_void,
-        __len: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_void;
-}
-unsafe extern "C" {
-    pub fn memset(
-        __b: *mut ::std::os::raw::c_void,
-        __c: ::std::os::raw::c_int,
-        __len: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_void;
-}
-unsafe extern "C" {
-    pub fn strcat(
-        __s1: *mut ::std::os::raw::c_char,
-        __s2: *const ::std::os::raw::c_char,
+    pub fn strcpy(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn strchr(
-        __s: *const ::std::os::raw::c_char,
-        __c: ::std::os::raw::c_int,
+    pub fn strncpy(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_ulong,
+    ) -> *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn strcat(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn strncat(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
@@ -12475,37 +11379,6 @@ unsafe extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn strcoll(
-        __s1: *const ::std::os::raw::c_char,
-        __s2: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn strcpy(
-        __dst: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn strcspn(
-        __s: *const ::std::os::raw::c_char,
-        __charset: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_ulong;
-}
-unsafe extern "C" {
-    pub fn strerror(__errnum: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn strlen(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_ulong;
-}
-unsafe extern "C" {
-    pub fn strncat(
-        __s1: *mut ::std::os::raw::c_char,
-        __s2: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
     pub fn strncmp(
         __s1: *const ::std::os::raw::c_char,
         __s2: *const ::std::os::raw::c_char,
@@ -12513,16 +11386,72 @@ unsafe extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn strncpy(
-        __dst: *mut ::std::os::raw::c_char,
+    pub fn strcoll(
+        __s1: *const ::std::os::raw::c_char,
+        __s2: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn strxfrm(
+        __dest: *mut ::std::os::raw::c_char,
         __src: *const ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __locale_struct {
+    pub __locales: [*mut __locale_data; 13usize],
+    pub __ctype_b: *const ::std::os::raw::c_ushort,
+    pub __ctype_tolower: *const ::std::os::raw::c_int,
+    pub __ctype_toupper: *const ::std::os::raw::c_int,
+    pub __names: [*const ::std::os::raw::c_char; 13usize],
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of __locale_struct"][::std::mem::size_of::<__locale_struct>() - 232usize];
+    ["Alignment of __locale_struct"][::std::mem::align_of::<__locale_struct>() - 8usize];
+    ["Offset of field: __locale_struct::__locales"]
+        [::std::mem::offset_of!(__locale_struct, __locales) - 0usize];
+    ["Offset of field: __locale_struct::__ctype_b"]
+        [::std::mem::offset_of!(__locale_struct, __ctype_b) - 104usize];
+    ["Offset of field: __locale_struct::__ctype_tolower"]
+        [::std::mem::offset_of!(__locale_struct, __ctype_tolower) - 112usize];
+    ["Offset of field: __locale_struct::__ctype_toupper"]
+        [::std::mem::offset_of!(__locale_struct, __ctype_toupper) - 120usize];
+    ["Offset of field: __locale_struct::__names"]
+        [::std::mem::offset_of!(__locale_struct, __names) - 128usize];
+};
+pub type __locale_t = *mut __locale_struct;
+pub type locale_t = __locale_t;
+unsafe extern "C" {
+    pub fn strcoll_l(
+        __s1: *const ::std::os::raw::c_char,
+        __s2: *const ::std::os::raw::c_char,
+        __l: locale_t,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn strxfrm_l(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: usize,
+        __l: locale_t,
+    ) -> usize;
+}
+unsafe extern "C" {
+    pub fn strdup(__s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn strndup(
+        __string: *const ::std::os::raw::c_char,
         __n: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn strpbrk(
+    pub fn strchr(
         __s: *const ::std::os::raw::c_char,
-        __charset: *const ::std::os::raw::c_char,
+        __c: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
@@ -12532,147 +11461,174 @@ unsafe extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn strspn(
+    pub fn strchrnul(
         __s: *const ::std::os::raw::c_char,
-        __charset: *const ::std::os::raw::c_char,
+        __c: ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn strcspn(
+        __s: *const ::std::os::raw::c_char,
+        __reject: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_ulong;
 }
 unsafe extern "C" {
+    pub fn strspn(
+        __s: *const ::std::os::raw::c_char,
+        __accept: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_ulong;
+}
+unsafe extern "C" {
+    pub fn strpbrk(
+        __s: *const ::std::os::raw::c_char,
+        __accept: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
     pub fn strstr(
-        __big: *const ::std::os::raw::c_char,
-        __little: *const ::std::os::raw::c_char,
+        __haystack: *const ::std::os::raw::c_char,
+        __needle: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     pub fn strtok(
-        __str: *mut ::std::os::raw::c_char,
-        __sep: *const ::std::os::raw::c_char,
+        __s: *mut ::std::os::raw::c_char,
+        __delim: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn strxfrm(
-        __s1: *mut ::std::os::raw::c_char,
-        __s2: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_ulong;
+    pub fn __strtok_r(
+        __s: *mut ::std::os::raw::c_char,
+        __delim: *const ::std::os::raw::c_char,
+        __save_ptr: *mut *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     pub fn strtok_r(
-        __str: *mut ::std::os::raw::c_char,
-        __sep: *const ::std::os::raw::c_char,
-        __lasts: *mut *mut ::std::os::raw::c_char,
+        __s: *mut ::std::os::raw::c_char,
+        __delim: *const ::std::os::raw::c_char,
+        __save_ptr: *mut *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
+    pub fn strcasestr(
+        __haystack: *const ::std::os::raw::c_char,
+        __needle: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn memmem(
+        __haystack: *const ::std::os::raw::c_void,
+        __haystacklen: usize,
+        __needle: *const ::std::os::raw::c_void,
+        __needlelen: usize,
+    ) -> *mut ::std::os::raw::c_void;
+}
+unsafe extern "C" {
+    pub fn __mempcpy(
+        __dest: *mut ::std::os::raw::c_void,
+        __src: *const ::std::os::raw::c_void,
+        __n: usize,
+    ) -> *mut ::std::os::raw::c_void;
+}
+unsafe extern "C" {
+    pub fn mempcpy(
+        __dest: *mut ::std::os::raw::c_void,
+        __src: *const ::std::os::raw::c_void,
+        __n: ::std::os::raw::c_ulong,
+    ) -> *mut ::std::os::raw::c_void;
+}
+unsafe extern "C" {
+    pub fn strlen(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_ulong;
+}
+unsafe extern "C" {
+    pub fn strnlen(__string: *const ::std::os::raw::c_char, __maxlen: usize) -> usize;
+}
+unsafe extern "C" {
+    pub fn strerror(__errnum: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    #[link_name = "\u{1}__xpg_strerror_r"]
     pub fn strerror_r(
         __errnum: ::std::os::raw::c_int,
-        __strerrbuf: *mut ::std::os::raw::c_char,
+        __buf: *mut ::std::os::raw::c_char,
         __buflen: usize,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn strdup(__s1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+    pub fn strerror_l(
+        __errnum: ::std::os::raw::c_int,
+        __l: locale_t,
+    ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn memccpy(
-        __dst: *mut ::std::os::raw::c_void,
+    pub fn bcmp(
+        __s1: *const ::std::os::raw::c_void,
+        __s2: *const ::std::os::raw::c_void,
+        __n: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn bcopy(
         __src: *const ::std::os::raw::c_void,
+        __dest: *mut ::std::os::raw::c_void,
+        __n: ::std::os::raw::c_ulong,
+    );
+}
+unsafe extern "C" {
+    pub fn bzero(__s: *mut ::std::os::raw::c_void, __n: ::std::os::raw::c_ulong);
+}
+unsafe extern "C" {
+    pub fn index(
+        __s: *const ::std::os::raw::c_char,
         __c: ::std::os::raw::c_int,
-        __n: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_void;
-}
-unsafe extern "C" {
-    pub fn stpcpy(
-        __dst: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn stpncpy(
-        __dst: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
+    pub fn rindex(
+        __s: *const ::std::os::raw::c_char,
+        __c: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn strndup(
+    pub fn ffs(__i: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn ffsl(__l: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn ffsll(__ll: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn strcasecmp(
         __s1: *const ::std::os::raw::c_char,
+        __s2: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn strncasecmp(
+        __s1: *const ::std::os::raw::c_char,
+        __s2: *const ::std::os::raw::c_char,
         __n: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_char;
+    ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn strnlen(__s1: *const ::std::os::raw::c_char, __n: usize) -> usize;
+    pub fn strcasecmp_l(
+        __s1: *const ::std::os::raw::c_char,
+        __s2: *const ::std::os::raw::c_char,
+        __loc: locale_t,
+    ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn strsignal(__sig: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
-}
-pub type errno_t = ::std::os::raw::c_int;
-unsafe extern "C" {
-    pub fn memset_s(
-        __s: *mut ::std::os::raw::c_void,
-        __smax: rsize_t,
-        __c: ::std::os::raw::c_int,
-        __n: rsize_t,
-    ) -> errno_t;
+    pub fn strncasecmp_l(
+        __s1: *const ::std::os::raw::c_char,
+        __s2: *const ::std::os::raw::c_char,
+        __n: usize,
+        __loc: locale_t,
+    ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn memmem(
-        __big: *const ::std::os::raw::c_void,
-        __big_len: usize,
-        __little: *const ::std::os::raw::c_void,
-        __little_len: usize,
-    ) -> *mut ::std::os::raw::c_void;
-}
-unsafe extern "C" {
-    pub fn memset_pattern4(
-        __b: *mut ::std::os::raw::c_void,
-        __pattern4: *const ::std::os::raw::c_void,
-        __len: usize,
-    );
-}
-unsafe extern "C" {
-    pub fn memset_pattern8(
-        __b: *mut ::std::os::raw::c_void,
-        __pattern8: *const ::std::os::raw::c_void,
-        __len: usize,
-    );
-}
-unsafe extern "C" {
-    pub fn memset_pattern16(
-        __b: *mut ::std::os::raw::c_void,
-        __pattern16: *const ::std::os::raw::c_void,
-        __len: usize,
-    );
-}
-unsafe extern "C" {
-    pub fn strcasestr(
-        __big: *const ::std::os::raw::c_char,
-        __little: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn strnstr(
-        __big: *const ::std::os::raw::c_char,
-        __little: *const ::std::os::raw::c_char,
-        __len: usize,
-    ) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn strlcat(
-        __dst: *mut ::std::os::raw::c_char,
-        __source: *const ::std::os::raw::c_char,
-        __size: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_ulong;
-}
-unsafe extern "C" {
-    pub fn strlcpy(
-        __dst: *mut ::std::os::raw::c_char,
-        __source: *const ::std::os::raw::c_char,
-        __size: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_ulong;
-}
-unsafe extern "C" {
-    pub fn strmode(__mode: ::std::os::raw::c_int, __bp: *mut ::std::os::raw::c_char);
+    pub fn explicit_bzero(__s: *mut ::std::os::raw::c_void, __n: usize);
 }
 unsafe extern "C" {
     pub fn strsep(
@@ -12681,85 +11637,47 @@ unsafe extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn swab(
-        arg1: *const ::std::os::raw::c_void,
-        arg2: *mut ::std::os::raw::c_void,
-        arg3: isize,
-    );
+    pub fn strsignal(__sig: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn timingsafe_bcmp(
-        __b1: *const ::std::os::raw::c_void,
-        __b2: *const ::std::os::raw::c_void,
-        __len: usize,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn strsignal_r(
-        __sig: ::std::os::raw::c_int,
-        __strsignalbuf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn bcmp(
-        arg1: *const ::std::os::raw::c_void,
-        arg2: *const ::std::os::raw::c_void,
-        arg3: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn bcopy(
-        arg1: *const ::std::os::raw::c_void,
-        arg2: *mut ::std::os::raw::c_void,
-        arg3: usize,
-    );
-}
-unsafe extern "C" {
-    pub fn bzero(arg1: *mut ::std::os::raw::c_void, arg2: ::std::os::raw::c_ulong);
-}
-unsafe extern "C" {
-    pub fn index(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
+    pub fn __stpcpy(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn rindex(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
+    pub fn stpcpy(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn ffs(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn __stpncpy(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: usize,
+    ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn strcasecmp(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
+    pub fn stpncpy(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_ulong,
+    ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn strncasecmp(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_int;
+    pub fn strlcpy(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: usize,
+    ) -> usize;
 }
 unsafe extern "C" {
-    pub fn ffsl(arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn ffsll(arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn fls(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn flsl(arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn flsll(arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int;
+    pub fn strlcat(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: usize,
+    ) -> usize;
 }
 unsafe extern "C" {
     #[doc = " Creates and captures a message handler which deals with warning, information, and dialog (interactive shell) methods.\n\n  Use SCIPsetMessagehdlr() to make SCIP aware of the created message handler.\n  @note The message handler does not handle error messages. For that see SCIPmessageSetErrorPrinting()\n  @note Creating a message handler automatically captures it."]
@@ -16230,12 +15148,14 @@ unsafe extern "C" {
     );
 }
 unsafe extern "C" {
+    #[doc = " default comparer for integers"]
     pub fn SCIPsortCompInt(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " implements argsort\n\n The data pointer is a lookup array of integers."]
     pub fn SCIPsortArgsortInt(
         dataptr: *mut ::std::os::raw::c_void,
         ind1: ::std::os::raw::c_int,
@@ -16243,6 +15163,7 @@ unsafe extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " implements argsort\n\n The data pointer is a lookup array, which are pointer arrays."]
     pub fn SCIPsortArgsortPtr(
         dataptr: *mut ::std::os::raw::c_void,
         ind1: ::std::os::raw::c_int,
@@ -21944,6 +20865,7 @@ unsafe extern "C" {
     );
 }
 unsafe extern "C" {
+    #[doc = " standard hash key comparator for string keys"]
     pub fn SCIPhashKeyEqString(
         userptr: *mut ::std::os::raw::c_void,
         key1: *mut ::std::os::raw::c_void,
@@ -21951,18 +20873,21 @@ unsafe extern "C" {
     ) -> ::std::os::raw::c_uint;
 }
 unsafe extern "C" {
+    #[doc = " standard hashing function for string keys"]
     pub fn SCIPhashKeyValString(
         userptr: *mut ::std::os::raw::c_void,
         key: *mut ::std::os::raw::c_void,
     ) -> u64;
 }
 unsafe extern "C" {
+    #[doc = " gets the element as the key"]
     pub fn SCIPhashGetKeyStandard(
         userptr: *mut ::std::os::raw::c_void,
         elem: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 unsafe extern "C" {
+    #[doc = " returns TRUE iff both keys(pointer) are equal"]
     pub fn SCIPhashKeyEqPtr(
         userptr: *mut ::std::os::raw::c_void,
         key1: *mut ::std::os::raw::c_void,
@@ -21970,6 +20895,7 @@ unsafe extern "C" {
     ) -> ::std::os::raw::c_uint;
 }
 unsafe extern "C" {
+    #[doc = " returns the hash value of the key"]
     pub fn SCIPhashKeyValPtr(
         userptr: *mut ::std::os::raw::c_void,
         key: *mut ::std::os::raw::c_void,
@@ -23082,12 +22008,14 @@ unsafe extern "C" {
     pub fn SCIPparamIsDefault(param: *mut SCIP_PARAM) -> ::std::os::raw::c_uint;
 }
 unsafe extern "C" {
+    #[doc = " compares two presolvers w. r. to their priority"]
     pub fn SCIPpresolComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting presolvers w.r.t. to their name"]
     pub fn SCIPpresolCompName(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -23186,12 +22114,14 @@ unsafe extern "C" {
     pub fn SCIPpresolGetNCalls(presol: *mut SCIP_PRESOL) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " compares two pricers w. r. to their priority"]
     pub fn SCIPpricerComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting pricers w.r.t. to their name"]
     pub fn SCIPpricerCompName(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -23282,12 +22212,14 @@ unsafe extern "C" {
     pub fn SCIPreaderCanWrite(reader: *mut SCIP_READER) -> ::std::os::raw::c_uint;
 }
 unsafe extern "C" {
+    #[doc = " compares two relaxation handlers w. r. to their priority"]
     pub fn SCIPrelaxComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting relaxators w.r.t. to their name"]
     pub fn SCIPrelaxCompName(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -23460,12 +22392,14 @@ unsafe extern "C" {
     pub fn SCIPreoptGetNTotalInfNodes(reopt: *mut SCIP_REOPT) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " compares two separators w. r. to their priority"]
     pub fn SCIPsepaComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting separators w.r.t. to their name"]
     pub fn SCIPsepaCompName(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -23664,24 +22598,28 @@ unsafe extern "C" {
     pub fn SCIPcutselGetNLocalCutsFiltered(cutsel: *mut SCIP_CUTSEL) -> ::std::os::raw::c_longlong;
 }
 unsafe extern "C" {
+    #[doc = " compares two cut selectors w. r. to their priority"]
     pub fn SCIPcutselComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " compares two propagators w. r. to their priority"]
     pub fn SCIPpropComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " compares two propagators w. r. to their presolving priority"]
     pub fn SCIPpropCompPresol(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting propagators w.r.t. to their name"]
     pub fn SCIPpropCompName(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -23940,6 +22878,7 @@ unsafe extern "C" {
     pub fn SCIPsolGetRelConsViolation(sol: *mut SCIP_SOL) -> f64;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting solution by decreasing objective value (best solution will be sorted to the end)"]
     pub fn SCIPsolComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -23978,6 +22917,7 @@ unsafe extern "C" {
     pub fn SCIPtableIsInitialized(table: *mut SCIP_TABLE) -> ::std::os::raw::c_uint;
 }
 unsafe extern "C" {
+    #[doc = " node comparator for best lower bound"]
     pub fn SCIPnodeCompLowerbound(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -24168,6 +23108,7 @@ unsafe extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting active and negated variables by non-decreasing index, active and negated\n  variables are handled as the same variables"]
     pub fn SCIPvarCompActiveAndNegated(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -24178,24 +23119,28 @@ unsafe extern "C" {
     pub fn SCIPvarCompare(var1: *mut SCIP_VAR, var2: *mut SCIP_VAR) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting variables by non-decreasing index"]
     pub fn SCIPvarComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting variables by non-decreasing objective coefficient"]
     pub fn SCIPvarCompObj(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " hash key retrieval function for variables"]
     pub fn SCIPvarGetHashkey(
         userptr: *mut ::std::os::raw::c_void,
         elem: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 unsafe extern "C" {
+    #[doc = " returns TRUE iff the indices of both variables are equal"]
     pub fn SCIPvarIsHashkeyEq(
         userptr: *mut ::std::os::raw::c_void,
         key1: *mut ::std::os::raw::c_void,
@@ -24203,6 +23148,7 @@ unsafe extern "C" {
     ) -> ::std::os::raw::c_uint;
 }
 unsafe extern "C" {
+    #[doc = " returns the hash value of the key"]
     pub fn SCIPvarGetHashkeyVal(
         userptr: *mut ::std::os::raw::c_void,
         key: *mut ::std::os::raw::c_void,
@@ -25937,7 +24883,9 @@ pub struct SCIP_AggrRow {
     pub slacksign: *mut ::std::os::raw::c_int,
     #[doc = "< weights of rows that have been added to the cutrow"]
     pub rowweights: *mut f64,
+    #[doc = "< right hand side of the cut row"]
     pub rhshi: f64,
+    #[doc = "< right hand side of the cut row"]
     pub rhslo: f64,
     #[doc = "< number of non-zeros in the cut row"]
     pub nnz: ::std::os::raw::c_int,
@@ -31471,6 +30419,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " calls the print callback for an expression\n\n @see SCIP_DECL_EXPRPRINT"]
     pub fn SCIPcallExprPrint(
         scip: *mut SCIP,
         expr: *mut SCIP_EXPR,
@@ -31481,6 +30430,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " calls the curvature callback for an expression\n\n @see SCIP_DECL_EXPRCURVATURE\n\n Returns unknown curvature if callback not implemented."]
     pub fn SCIPcallExprCurvature(
         scip: *mut SCIP,
         expr: *mut SCIP_EXPR,
@@ -31490,6 +30440,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " calls the monotonicity callback for an expression\n\n @see SCIP_DECL_EXPRMONOTONICITY\n\n Returns unknown monotonicity if callback not implemented."]
     pub fn SCIPcallExprMonotonicity(
         scip: *mut SCIP,
         expr: *mut SCIP_EXPR,
@@ -31518,6 +30469,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " calls the interval evaluation callback for an expression\n\n @see SCIP_DECL_EXPRINTEVAL\n\n Returns entire interval if callback not implemented."]
     pub fn SCIPcallExprInteval(
         scip: *mut SCIP,
         expr: *mut SCIP_EXPR,
@@ -31533,6 +30485,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " calls the estimate callback for an expression\n\n @see SCIP_DECL_EXPRESTIMATE\n\n Returns without success if callback not implemented."]
     pub fn SCIPcallExprEstimate(
         scip: *mut SCIP,
         expr: *mut SCIP_EXPR,
@@ -31549,6 +30502,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " calls the initial estimators callback for an expression\n\n @see SCIP_DECL_EXPRINITESTIMATES\n\n Returns no estimators if callback not implemented."]
     pub fn SCIPcallExprInitestimates(
         scip: *mut SCIP,
         expr: *mut SCIP_EXPR,
@@ -31560,6 +30514,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " calls the simplify callback for an expression\n\n @see SCIP_DECL_EXPRSIMPLIFY\n\n Returns unmodified expression if simplify callback not implemented.\n\n Does not simplify descendants (children, etc). Use SCIPsimplifyExpr() for that."]
     pub fn SCIPcallExprSimplify(
         scip: *mut SCIP,
         expr: *mut SCIP_EXPR,
@@ -31598,6 +30553,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " calls the reverse propagation callback for an expression\n\n @see SCIP_DECL_EXPRREVERSEPROP\n\n Returns unmodified `childrenbounds` if reverseprop callback not implemented."]
     pub fn SCIPcallExprReverseprop(
         scip: *mut SCIP,
         expr: *mut SCIP_EXPR,
@@ -31607,6 +30563,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " calls the symmetry information callback for an expression\n\n Returns NULL pointer if not implemented."]
     pub fn SCIPcallExprGetSymData(
         scip: *mut SCIP,
         expr: *mut SCIP_EXPR,
@@ -33122,6 +32079,7 @@ unsafe extern "C" {
     -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " compares two NLPIs w.r.t. their priority"]
     pub fn SCIPnlpiComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -33418,6 +32376,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " gets internal pointer to NLP solver\n\n Depending on the solver interface, a solver pointer may exist for every NLP problem instance.\n For this case, a NLPI problem can be passed in as well."]
     pub fn SCIPgetNlpiSolverPointer(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33425,6 +32384,7 @@ unsafe extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 unsafe extern "C" {
+    #[doc = " creates an empty problem instance"]
     pub fn SCIPcreateNlpiProblem(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33433,6 +32393,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " frees a problem instance"]
     pub fn SCIPfreeNlpiProblem(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33440,6 +32401,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " gets internal pointer to solver-internal problem instance"]
     pub fn SCIPgetNlpiProblemPointer(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33447,6 +32409,7 @@ unsafe extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 unsafe extern "C" {
+    #[doc = " add variables to nlpi"]
     pub fn SCIPaddNlpiVars(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33458,6 +32421,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " add constraints to nlpi"]
     pub fn SCIPaddNlpiConstraints(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33473,6 +32437,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " sets or overwrites objective, a minimization problem is expected"]
     pub fn SCIPsetNlpiObjective(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33485,6 +32450,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " change variable bounds"]
     pub fn SCIPchgNlpiVarBounds(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33496,6 +32462,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " change constraint sides"]
     pub fn SCIPchgNlpiConsSides(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33507,6 +32474,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " delete a set of variables"]
     pub fn SCIPdelNlpiVarSet(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33516,6 +32484,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " delete a set of constraints"]
     pub fn SCIPdelNlpiConsSet(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33525,6 +32494,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " changes or adds linear coefficients in a constraint or objective"]
     pub fn SCIPchgNlpiLinearCoefs(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33536,6 +32506,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " change the expression in the nonlinear part"]
     pub fn SCIPchgNlpiExpr(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33545,6 +32516,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " change the constant offset in the objective"]
     pub fn SCIPchgNlpiObjConstant(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33553,6 +32525,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " sets initial guess"]
     pub fn SCIPsetNlpiInitialGuess(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33564,6 +32537,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " try to solve NLP with all parameters given as SCIP_NLPPARAM struct\n\n Typical use is\n\n     SCIP_NLPPARAM nlparam = { SCIP_NLPPARAM_DEFAULT(scip); }\n     nlpparam.iterlimit = 42;\n     SCIP_CALL( SCIPsolveNlpiParam(scip, nlpi, nlpiproblem, nlpparam) );\n\n or, in \"one\" line:\n\n     SCIP_CALL( SCIPsolveNlpiParam(scip, nlpi, nlpiproblem,\n        (SCIP_NLPPARAM){ SCIP_NLPPARAM_DEFAULT(scip), .iterlimit = 42 }) );\n\n To get the latter, also \\ref SCIPsolveNlpi can be used."]
     pub fn SCIPsolveNlpiParam(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33572,6 +32546,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " gives solution status"]
     pub fn SCIPgetNlpiSolstat(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33579,6 +32554,7 @@ unsafe extern "C" {
     ) -> SCIP_NLPSOLSTAT;
 }
 unsafe extern "C" {
+    #[doc = " gives termination reason"]
     pub fn SCIPgetNlpiTermstat(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33586,6 +32562,7 @@ unsafe extern "C" {
     ) -> SCIP_NLPTERMSTAT;
 }
 unsafe extern "C" {
+    #[doc = " gives primal and dual solution\n for a ranged constraint, the dual variable is positive if the right hand side is active and negative if the left hand side is active"]
     pub fn SCIPgetNlpiSolution(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33598,6 +32575,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " gives solve statistics"]
     pub fn SCIPgetNlpiStatistics(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -40782,6 +39760,7 @@ unsafe extern "C" {
     pub fn SCIPincludeConshdlrCountsols(scip: *mut SCIP) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the count command"]
     pub fn SCIPdialogExecCountPresolve(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -40790,6 +39769,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the count command"]
     pub fn SCIPdialogExecCount(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -40798,6 +39778,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " execution method of dialog for writing all solutions"]
     pub fn SCIPdialogExecWriteAllsolutions(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55019,6 +54000,7 @@ unsafe extern "C" {
     pub fn SCIPgetSlackConsSuperindicator(cons: *mut SCIP_CONS) -> *mut SCIP_CONS;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the SCIPtransformMinUC() command"]
     pub fn SCIPdialogExecChangeMinUC(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55241,6 +54223,7 @@ unsafe extern "C" {
     pub fn SCIPincludeDispDefault(scip: *mut SCIP) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " standard menu dialog execution method, that displays it's help screen if the remaining command line is empty"]
     pub fn SCIPdialogExecMenu(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55249,6 +54232,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " standard menu dialog execution method, that doesn't display it's help screen"]
     pub fn SCIPdialogExecMenuLazy(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55257,6 +54241,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the change add constraint"]
     pub fn SCIPdialogExecChangeAddCons(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55265,6 +54250,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the change bounds command"]
     pub fn SCIPdialogExecChangeBounds(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55273,6 +54259,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the freetransproblem command"]
     pub fn SCIPdialogExecChangeFreetransproblem(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55281,6 +54268,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the changing the objective sense"]
     pub fn SCIPdialogExecChangeObjSense(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55289,6 +54277,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the checksol command"]
     pub fn SCIPdialogExecChecksol(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55297,6 +54286,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the cliquegraph command"]
     pub fn SCIPdialogExecCliquegraph(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55305,6 +54295,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display benders command"]
     pub fn SCIPdialogExecDisplayBenders(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55313,6 +54304,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display branching command"]
     pub fn SCIPdialogExecDisplayBranching(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55321,6 +54313,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display compression command"]
     pub fn SCIPdialogExecDisplayCompression(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55329,6 +54322,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display conflict command"]
     pub fn SCIPdialogExecDisplayConflict(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55337,6 +54331,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display conshdlrs command"]
     pub fn SCIPdialogExecDisplayConshdlrs(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55345,6 +54340,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display displaycols command"]
     pub fn SCIPdialogExecDisplayDisplaycols(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55353,6 +54349,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display exprhdlrs command"]
     pub fn SCIPdialogExecDisplayExprhdlrs(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55361,6 +54358,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display cutselectors command"]
     pub fn SCIPdialogExecDisplayCutselectors(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55369,6 +54367,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display heuristics command"]
     pub fn SCIPdialogExecDisplayHeuristics(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55377,6 +54376,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display IIS command"]
     pub fn SCIPdialogExecDisplayIIS(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55385,6 +54385,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display memory command"]
     pub fn SCIPdialogExecDisplayMemory(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55393,6 +54394,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display nodeselectors command"]
     pub fn SCIPdialogExecDisplayNodeselectors(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55401,6 +54403,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display nlpi command"]
     pub fn SCIPdialogExecDisplayNlpi(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55409,6 +54412,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display parameters command"]
     pub fn SCIPdialogExecDisplayParameters(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55417,6 +54421,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display presolvers command"]
     pub fn SCIPdialogExecDisplayPresolvers(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55425,6 +54430,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display pricer command"]
     pub fn SCIPdialogExecDisplayPricers(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55433,6 +54439,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display problem command"]
     pub fn SCIPdialogExecDisplayProblem(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55441,6 +54448,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display propagators command"]
     pub fn SCIPdialogExecDisplayPropagators(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55449,6 +54457,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display readers command"]
     pub fn SCIPdialogExecDisplayReaders(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55457,6 +54466,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display relaxators command"]
     pub fn SCIPdialogExecDisplayRelaxators(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55465,6 +54475,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display separators command"]
     pub fn SCIPdialogExecDisplaySeparators(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55473,6 +54484,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display solution command"]
     pub fn SCIPdialogExecDisplaySolution(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55481,6 +54493,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display finitesolution command"]
     pub fn SCIPdialogExecDisplayFiniteSolution(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55489,6 +54502,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display dual solution command"]
     pub fn SCIPdialogExecDisplayDualSolution(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55497,6 +54511,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display of solutions in the pool command"]
     pub fn SCIPdialogExecDisplaySolutionPool(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55505,6 +54520,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display subproblem command"]
     pub fn SCIPdialogExecDisplaySubproblem(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55513,6 +54529,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display subsolution command"]
     pub fn SCIPdialogExecDisplaySubSolution(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55521,6 +54538,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display statistics command"]
     pub fn SCIPdialogExecDisplayStatistics(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55529,6 +54547,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display symmetry command"]
     pub fn SCIPdialogExecDisplaySymmetry(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55537,6 +54556,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display reoptstatistics command"]
     pub fn SCIPdialogExecDisplayReoptStatistics(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55545,6 +54565,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display transproblem command"]
     pub fn SCIPdialogExecDisplayTransproblem(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55553,6 +54574,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display value command"]
     pub fn SCIPdialogExecDisplayValue(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55561,6 +54583,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display varbranchstatistics command"]
     pub fn SCIPdialogExecDisplayVarbranchstatistics(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55569,6 +54592,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display LP solution quality command"]
     pub fn SCIPdialogExecDisplayLPSolutionQuality(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55577,6 +54601,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display transsolution command"]
     pub fn SCIPdialogExecDisplayTranssolution(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55585,6 +54610,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the help command"]
     pub fn SCIPdialogExecHelp(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55593,6 +54619,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the free command"]
     pub fn SCIPdialogExecFree(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55601,6 +54628,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the newstart command"]
     pub fn SCIPdialogExecNewstart(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55609,6 +54637,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the transform command"]
     pub fn SCIPdialogExecTransform(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55617,6 +54646,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the optimize command"]
     pub fn SCIPdialogExecOptimize(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55625,6 +54655,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the parallelopt command"]
     pub fn SCIPdialogExecConcurrentOpt(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55633,6 +54664,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the presolve command"]
     pub fn SCIPdialogExecPresolve(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55641,6 +54673,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the iis command"]
     pub fn SCIPdialogExecIIS(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55649,6 +54682,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the quit command"]
     pub fn SCIPdialogExecQuit(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55657,6 +54691,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the read command"]
     pub fn SCIPdialogExecRead(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55665,6 +54700,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set default command"]
     pub fn SCIPdialogExecSetDefault(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55673,6 +54709,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set load command"]
     pub fn SCIPdialogExecSetLoad(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55681,6 +54718,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set save command"]
     pub fn SCIPdialogExecSetSave(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55689,6 +54727,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set diffsave command"]
     pub fn SCIPdialogExecSetDiffsave(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55697,6 +54736,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set parameter command"]
     pub fn SCIPdialogExecSetParam(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55705,9 +54745,11 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog description method for the set parameter command"]
     pub fn SCIPdialogDescSetParam(scip: *mut SCIP, dialog: *mut SCIP_DIALOG) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the fix parameter command"]
     pub fn SCIPdialogExecFixParam(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55716,9 +54758,11 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog description method for the fix parameter command"]
     pub fn SCIPdialogDescFixParam(scip: *mut SCIP, dialog: *mut SCIP_DIALOG) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set branching direction command"]
     pub fn SCIPdialogExecSetBranchingDirection(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55727,6 +54771,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set branching priority command"]
     pub fn SCIPdialogExecSetBranchingPriority(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55735,6 +54780,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set heuristics aggressive command"]
     pub fn SCIPdialogExecSetHeuristicsAggressive(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55743,6 +54789,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set heuristics default command"]
     pub fn SCIPdialogExecSetHeuristicsDefault(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55751,6 +54798,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set heuristics fast command"]
     pub fn SCIPdialogExecSetHeuristicsFast(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55759,6 +54807,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set heuristics off command"]
     pub fn SCIPdialogExecSetHeuristicsOff(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55767,6 +54816,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set presolving aggressive command"]
     pub fn SCIPdialogExecSetPresolvingAggressive(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55775,6 +54825,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set presolving default command"]
     pub fn SCIPdialogExecSetPresolvingDefault(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55783,6 +54834,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set presolving fast command"]
     pub fn SCIPdialogExecSetPresolvingFast(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55791,6 +54843,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set presolving off command"]
     pub fn SCIPdialogExecSetPresolvingOff(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55799,6 +54852,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set separating aggressive command"]
     pub fn SCIPdialogExecSetSeparatingAggressive(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55807,6 +54861,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set separating default command"]
     pub fn SCIPdialogExecSetSeparatingDefault(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55815,6 +54870,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set separating fast command"]
     pub fn SCIPdialogExecSetSeparatingFast(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55823,6 +54879,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set separating off command"]
     pub fn SCIPdialogExecSetSeparatingOff(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55831,6 +54888,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set emphasis counter command"]
     pub fn SCIPdialogExecSetEmphasisCounter(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55839,6 +54897,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set emphasis cpsolver command"]
     pub fn SCIPdialogExecSetEmphasisCpsolver(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55847,6 +54906,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set emphasis easy CIP command"]
     pub fn SCIPdialogExecSetEmphasisEasycip(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55855,6 +54915,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set emphasis feasibility command"]
     pub fn SCIPdialogExecSetEmphasisFeasibility(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55863,6 +54924,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set emphasis hard LP command"]
     pub fn SCIPdialogExecSetEmphasisHardlp(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55871,6 +54933,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set emphasis optimality command"]
     pub fn SCIPdialogExecSetEmphasisOptimality(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55879,6 +54942,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set emphasis numerics command"]
     pub fn SCIPdialogExecSetEmphasisNumerics(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55887,6 +54951,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set emphasis benchmark command"]
     pub fn SCIPdialogExecSetEmphasisBenchmark(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55895,6 +54960,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set limits objective command"]
     pub fn SCIPdialogExecSetLimitsObjective(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55903,6 +54969,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for linear constraint type classification"]
     pub fn SCIPdialogExecDisplayLinearConsClassification(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -57242,6 +56309,7 @@ unsafe extern "C" {
     pub fn SCIPnlhdlrHasSollinearize(nlhdlr: *mut SCIP_NLHDLR) -> ::std::os::raw::c_uint;
 }
 unsafe extern "C" {
+    #[doc = " compares two nonlinear handlers by detection priority\n\n if handlers have same detection priority, then compare by name"]
     pub fn SCIPnlhdlrComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -58682,5 +57750,8 @@ unsafe extern "C" {
     #[doc = " includes default plugins into SCIP with respect to priorities"]
     pub fn SCIPincludeDefaultPlugins(scip: *mut SCIP) -> SCIP_RETCODE;
 }
-pub type __builtin_va_list = *mut ::std::os::raw::c_char;
-pub type __uint128_t = u128;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __locale_data {
+    pub _address: u8,
+}

--- a/src/bindings/linux.rs
+++ b/src/bindings/linux.rs
@@ -136,477 +136,157 @@ where
         }
     }
 }
-pub const __has_safe_buffers: u32 = 1;
-pub const __DARWIN_ONLY_64_BIT_INO_T: u32 = 1;
-pub const __DARWIN_ONLY_UNIX_CONFORMANCE: u32 = 1;
-pub const __DARWIN_ONLY_VERS_1050: u32 = 1;
-pub const __DARWIN_UNIX03: u32 = 1;
-pub const __DARWIN_64_BIT_INO_T: u32 = 1;
-pub const __DARWIN_VERS_1050: u32 = 1;
-pub const __DARWIN_NON_CANCELABLE: u32 = 0;
-pub const __DARWIN_SUF_EXTSN: &[u8; 14] = b"$DARWIN_EXTSN\0";
-pub const __DARWIN_C_ANSI: u32 = 4096;
-pub const __DARWIN_C_FULL: u32 = 900000;
-pub const __DARWIN_C_LEVEL: u32 = 900000;
-pub const __STDC_WANT_LIB_EXT1__: u32 = 1;
-pub const __DARWIN_NO_LONG_LONG: u32 = 0;
-pub const _DARWIN_FEATURE_64_BIT_INODE: u32 = 1;
-pub const _DARWIN_FEATURE_ONLY_64_BIT_INODE: u32 = 1;
-pub const _DARWIN_FEATURE_ONLY_VERS_1050: u32 = 1;
-pub const _DARWIN_FEATURE_ONLY_UNIX_CONFORMANCE: u32 = 1;
-pub const _DARWIN_FEATURE_UNIX_CONFORMANCE: u32 = 3;
-pub const __has_ptrcheck: u32 = 0;
-pub const __API_TO_BE_DEPRECATED: u32 = 100000;
-pub const __API_TO_BE_DEPRECATED_MACOS: u32 = 100000;
-pub const __API_TO_BE_DEPRECATED_IOS: u32 = 100000;
-pub const __API_TO_BE_DEPRECATED_MACCATALYST: u32 = 100000;
-pub const __API_TO_BE_DEPRECATED_WATCHOS: u32 = 100000;
-pub const __API_TO_BE_DEPRECATED_TVOS: u32 = 100000;
-pub const __API_TO_BE_DEPRECATED_DRIVERKIT: u32 = 100000;
-pub const __API_TO_BE_DEPRECATED_VISIONOS: u32 = 100000;
-pub const __MAC_10_0: u32 = 1000;
-pub const __MAC_10_1: u32 = 1010;
-pub const __MAC_10_2: u32 = 1020;
-pub const __MAC_10_3: u32 = 1030;
-pub const __MAC_10_4: u32 = 1040;
-pub const __MAC_10_5: u32 = 1050;
-pub const __MAC_10_6: u32 = 1060;
-pub const __MAC_10_7: u32 = 1070;
-pub const __MAC_10_8: u32 = 1080;
-pub const __MAC_10_9: u32 = 1090;
-pub const __MAC_10_10: u32 = 101000;
-pub const __MAC_10_10_2: u32 = 101002;
-pub const __MAC_10_10_3: u32 = 101003;
-pub const __MAC_10_11: u32 = 101100;
-pub const __MAC_10_11_2: u32 = 101102;
-pub const __MAC_10_11_3: u32 = 101103;
-pub const __MAC_10_11_4: u32 = 101104;
-pub const __MAC_10_12: u32 = 101200;
-pub const __MAC_10_12_1: u32 = 101201;
-pub const __MAC_10_12_2: u32 = 101202;
-pub const __MAC_10_12_4: u32 = 101204;
-pub const __MAC_10_13: u32 = 101300;
-pub const __MAC_10_13_1: u32 = 101301;
-pub const __MAC_10_13_2: u32 = 101302;
-pub const __MAC_10_13_4: u32 = 101304;
-pub const __MAC_10_14: u32 = 101400;
-pub const __MAC_10_14_1: u32 = 101401;
-pub const __MAC_10_14_4: u32 = 101404;
-pub const __MAC_10_14_5: u32 = 101405;
-pub const __MAC_10_14_6: u32 = 101406;
-pub const __MAC_10_15: u32 = 101500;
-pub const __MAC_10_15_1: u32 = 101501;
-pub const __MAC_10_15_4: u32 = 101504;
-pub const __MAC_10_16: u32 = 101600;
-pub const __MAC_11_0: u32 = 110000;
-pub const __MAC_11_1: u32 = 110100;
-pub const __MAC_11_3: u32 = 110300;
-pub const __MAC_11_4: u32 = 110400;
-pub const __MAC_11_5: u32 = 110500;
-pub const __MAC_11_6: u32 = 110600;
-pub const __MAC_12_0: u32 = 120000;
-pub const __MAC_12_1: u32 = 120100;
-pub const __MAC_12_2: u32 = 120200;
-pub const __MAC_12_3: u32 = 120300;
-pub const __MAC_12_4: u32 = 120400;
-pub const __MAC_12_5: u32 = 120500;
-pub const __MAC_12_6: u32 = 120600;
-pub const __MAC_12_7: u32 = 120700;
-pub const __MAC_13_0: u32 = 130000;
-pub const __MAC_13_1: u32 = 130100;
-pub const __MAC_13_2: u32 = 130200;
-pub const __MAC_13_3: u32 = 130300;
-pub const __MAC_13_4: u32 = 130400;
-pub const __MAC_13_5: u32 = 130500;
-pub const __MAC_13_6: u32 = 130600;
-pub const __MAC_14_0: u32 = 140000;
-pub const __MAC_14_1: u32 = 140100;
-pub const __MAC_14_2: u32 = 140200;
-pub const __MAC_14_3: u32 = 140300;
-pub const __MAC_14_4: u32 = 140400;
-pub const __MAC_14_5: u32 = 140500;
-pub const __IPHONE_2_0: u32 = 20000;
-pub const __IPHONE_2_1: u32 = 20100;
-pub const __IPHONE_2_2: u32 = 20200;
-pub const __IPHONE_3_0: u32 = 30000;
-pub const __IPHONE_3_1: u32 = 30100;
-pub const __IPHONE_3_2: u32 = 30200;
-pub const __IPHONE_4_0: u32 = 40000;
-pub const __IPHONE_4_1: u32 = 40100;
-pub const __IPHONE_4_2: u32 = 40200;
-pub const __IPHONE_4_3: u32 = 40300;
-pub const __IPHONE_5_0: u32 = 50000;
-pub const __IPHONE_5_1: u32 = 50100;
-pub const __IPHONE_6_0: u32 = 60000;
-pub const __IPHONE_6_1: u32 = 60100;
-pub const __IPHONE_7_0: u32 = 70000;
-pub const __IPHONE_7_1: u32 = 70100;
-pub const __IPHONE_8_0: u32 = 80000;
-pub const __IPHONE_8_1: u32 = 80100;
-pub const __IPHONE_8_2: u32 = 80200;
-pub const __IPHONE_8_3: u32 = 80300;
-pub const __IPHONE_8_4: u32 = 80400;
-pub const __IPHONE_9_0: u32 = 90000;
-pub const __IPHONE_9_1: u32 = 90100;
-pub const __IPHONE_9_2: u32 = 90200;
-pub const __IPHONE_9_3: u32 = 90300;
-pub const __IPHONE_10_0: u32 = 100000;
-pub const __IPHONE_10_1: u32 = 100100;
-pub const __IPHONE_10_2: u32 = 100200;
-pub const __IPHONE_10_3: u32 = 100300;
-pub const __IPHONE_11_0: u32 = 110000;
-pub const __IPHONE_11_1: u32 = 110100;
-pub const __IPHONE_11_2: u32 = 110200;
-pub const __IPHONE_11_3: u32 = 110300;
-pub const __IPHONE_11_4: u32 = 110400;
-pub const __IPHONE_12_0: u32 = 120000;
-pub const __IPHONE_12_1: u32 = 120100;
-pub const __IPHONE_12_2: u32 = 120200;
-pub const __IPHONE_12_3: u32 = 120300;
-pub const __IPHONE_12_4: u32 = 120400;
-pub const __IPHONE_13_0: u32 = 130000;
-pub const __IPHONE_13_1: u32 = 130100;
-pub const __IPHONE_13_2: u32 = 130200;
-pub const __IPHONE_13_3: u32 = 130300;
-pub const __IPHONE_13_4: u32 = 130400;
-pub const __IPHONE_13_5: u32 = 130500;
-pub const __IPHONE_13_6: u32 = 130600;
-pub const __IPHONE_13_7: u32 = 130700;
-pub const __IPHONE_14_0: u32 = 140000;
-pub const __IPHONE_14_1: u32 = 140100;
-pub const __IPHONE_14_2: u32 = 140200;
-pub const __IPHONE_14_3: u32 = 140300;
-pub const __IPHONE_14_5: u32 = 140500;
-pub const __IPHONE_14_4: u32 = 140400;
-pub const __IPHONE_14_6: u32 = 140600;
-pub const __IPHONE_14_7: u32 = 140700;
-pub const __IPHONE_14_8: u32 = 140800;
-pub const __IPHONE_15_0: u32 = 150000;
-pub const __IPHONE_15_1: u32 = 150100;
-pub const __IPHONE_15_2: u32 = 150200;
-pub const __IPHONE_15_3: u32 = 150300;
-pub const __IPHONE_15_4: u32 = 150400;
-pub const __IPHONE_15_5: u32 = 150500;
-pub const __IPHONE_15_6: u32 = 150600;
-pub const __IPHONE_15_7: u32 = 150700;
-pub const __IPHONE_15_8: u32 = 150800;
-pub const __IPHONE_16_0: u32 = 160000;
-pub const __IPHONE_16_1: u32 = 160100;
-pub const __IPHONE_16_2: u32 = 160200;
-pub const __IPHONE_16_3: u32 = 160300;
-pub const __IPHONE_16_4: u32 = 160400;
-pub const __IPHONE_16_5: u32 = 160500;
-pub const __IPHONE_16_6: u32 = 160600;
-pub const __IPHONE_16_7: u32 = 160700;
-pub const __IPHONE_17_0: u32 = 170000;
-pub const __IPHONE_17_1: u32 = 170100;
-pub const __IPHONE_17_2: u32 = 170200;
-pub const __IPHONE_17_3: u32 = 170300;
-pub const __IPHONE_17_4: u32 = 170400;
-pub const __IPHONE_17_5: u32 = 170500;
-pub const __WATCHOS_1_0: u32 = 10000;
-pub const __WATCHOS_2_0: u32 = 20000;
-pub const __WATCHOS_2_1: u32 = 20100;
-pub const __WATCHOS_2_2: u32 = 20200;
-pub const __WATCHOS_3_0: u32 = 30000;
-pub const __WATCHOS_3_1: u32 = 30100;
-pub const __WATCHOS_3_1_1: u32 = 30101;
-pub const __WATCHOS_3_2: u32 = 30200;
-pub const __WATCHOS_4_0: u32 = 40000;
-pub const __WATCHOS_4_1: u32 = 40100;
-pub const __WATCHOS_4_2: u32 = 40200;
-pub const __WATCHOS_4_3: u32 = 40300;
-pub const __WATCHOS_5_0: u32 = 50000;
-pub const __WATCHOS_5_1: u32 = 50100;
-pub const __WATCHOS_5_2: u32 = 50200;
-pub const __WATCHOS_5_3: u32 = 50300;
-pub const __WATCHOS_6_0: u32 = 60000;
-pub const __WATCHOS_6_1: u32 = 60100;
-pub const __WATCHOS_6_2: u32 = 60200;
-pub const __WATCHOS_7_0: u32 = 70000;
-pub const __WATCHOS_7_1: u32 = 70100;
-pub const __WATCHOS_7_2: u32 = 70200;
-pub const __WATCHOS_7_3: u32 = 70300;
-pub const __WATCHOS_7_4: u32 = 70400;
-pub const __WATCHOS_7_5: u32 = 70500;
-pub const __WATCHOS_7_6: u32 = 70600;
-pub const __WATCHOS_8_0: u32 = 80000;
-pub const __WATCHOS_8_1: u32 = 80100;
-pub const __WATCHOS_8_3: u32 = 80300;
-pub const __WATCHOS_8_4: u32 = 80400;
-pub const __WATCHOS_8_5: u32 = 80500;
-pub const __WATCHOS_8_6: u32 = 80600;
-pub const __WATCHOS_8_7: u32 = 80700;
-pub const __WATCHOS_8_8: u32 = 80800;
-pub const __WATCHOS_9_0: u32 = 90000;
-pub const __WATCHOS_9_1: u32 = 90100;
-pub const __WATCHOS_9_2: u32 = 90200;
-pub const __WATCHOS_9_3: u32 = 90300;
-pub const __WATCHOS_9_4: u32 = 90400;
-pub const __WATCHOS_9_5: u32 = 90500;
-pub const __WATCHOS_9_6: u32 = 90600;
-pub const __WATCHOS_10_0: u32 = 100000;
-pub const __WATCHOS_10_1: u32 = 100100;
-pub const __WATCHOS_10_2: u32 = 100200;
-pub const __WATCHOS_10_3: u32 = 100300;
-pub const __WATCHOS_10_4: u32 = 100400;
-pub const __WATCHOS_10_5: u32 = 100500;
-pub const __TVOS_9_0: u32 = 90000;
-pub const __TVOS_9_1: u32 = 90100;
-pub const __TVOS_9_2: u32 = 90200;
-pub const __TVOS_10_0: u32 = 100000;
-pub const __TVOS_10_0_1: u32 = 100001;
-pub const __TVOS_10_1: u32 = 100100;
-pub const __TVOS_10_2: u32 = 100200;
-pub const __TVOS_11_0: u32 = 110000;
-pub const __TVOS_11_1: u32 = 110100;
-pub const __TVOS_11_2: u32 = 110200;
-pub const __TVOS_11_3: u32 = 110300;
-pub const __TVOS_11_4: u32 = 110400;
-pub const __TVOS_12_0: u32 = 120000;
-pub const __TVOS_12_1: u32 = 120100;
-pub const __TVOS_12_2: u32 = 120200;
-pub const __TVOS_12_3: u32 = 120300;
-pub const __TVOS_12_4: u32 = 120400;
-pub const __TVOS_13_0: u32 = 130000;
-pub const __TVOS_13_2: u32 = 130200;
-pub const __TVOS_13_3: u32 = 130300;
-pub const __TVOS_13_4: u32 = 130400;
-pub const __TVOS_14_0: u32 = 140000;
-pub const __TVOS_14_1: u32 = 140100;
-pub const __TVOS_14_2: u32 = 140200;
-pub const __TVOS_14_3: u32 = 140300;
-pub const __TVOS_14_5: u32 = 140500;
-pub const __TVOS_14_6: u32 = 140600;
-pub const __TVOS_14_7: u32 = 140700;
-pub const __TVOS_15_0: u32 = 150000;
-pub const __TVOS_15_1: u32 = 150100;
-pub const __TVOS_15_2: u32 = 150200;
-pub const __TVOS_15_3: u32 = 150300;
-pub const __TVOS_15_4: u32 = 150400;
-pub const __TVOS_15_5: u32 = 150500;
-pub const __TVOS_15_6: u32 = 150600;
-pub const __TVOS_16_0: u32 = 160000;
-pub const __TVOS_16_1: u32 = 160100;
-pub const __TVOS_16_2: u32 = 160200;
-pub const __TVOS_16_3: u32 = 160300;
-pub const __TVOS_16_4: u32 = 160400;
-pub const __TVOS_16_5: u32 = 160500;
-pub const __TVOS_16_6: u32 = 160600;
-pub const __TVOS_17_0: u32 = 170000;
-pub const __TVOS_17_1: u32 = 170100;
-pub const __TVOS_17_2: u32 = 170200;
-pub const __TVOS_17_3: u32 = 170300;
-pub const __TVOS_17_4: u32 = 170400;
-pub const __TVOS_17_5: u32 = 170500;
-pub const __BRIDGEOS_2_0: u32 = 20000;
-pub const __BRIDGEOS_3_0: u32 = 30000;
-pub const __BRIDGEOS_3_1: u32 = 30100;
-pub const __BRIDGEOS_3_4: u32 = 30400;
-pub const __BRIDGEOS_4_0: u32 = 40000;
-pub const __BRIDGEOS_4_1: u32 = 40100;
-pub const __BRIDGEOS_5_0: u32 = 50000;
-pub const __BRIDGEOS_5_1: u32 = 50100;
-pub const __BRIDGEOS_5_3: u32 = 50300;
-pub const __BRIDGEOS_6_0: u32 = 60000;
-pub const __BRIDGEOS_6_2: u32 = 60200;
-pub const __BRIDGEOS_6_4: u32 = 60400;
-pub const __BRIDGEOS_6_5: u32 = 60500;
-pub const __BRIDGEOS_6_6: u32 = 60600;
-pub const __BRIDGEOS_7_0: u32 = 70000;
-pub const __BRIDGEOS_7_1: u32 = 70100;
-pub const __BRIDGEOS_7_2: u32 = 70200;
-pub const __BRIDGEOS_7_3: u32 = 70300;
-pub const __BRIDGEOS_7_4: u32 = 70400;
-pub const __BRIDGEOS_7_6: u32 = 70600;
-pub const __BRIDGEOS_8_0: u32 = 80000;
-pub const __BRIDGEOS_8_1: u32 = 80100;
-pub const __BRIDGEOS_8_2: u32 = 80200;
-pub const __BRIDGEOS_8_3: u32 = 80300;
-pub const __BRIDGEOS_8_4: u32 = 80400;
-pub const __BRIDGEOS_8_5: u32 = 80500;
-pub const __DRIVERKIT_19_0: u32 = 190000;
-pub const __DRIVERKIT_20_0: u32 = 200000;
-pub const __DRIVERKIT_21_0: u32 = 210000;
-pub const __DRIVERKIT_22_0: u32 = 220000;
-pub const __DRIVERKIT_22_4: u32 = 220400;
-pub const __DRIVERKIT_22_5: u32 = 220500;
-pub const __DRIVERKIT_22_6: u32 = 220600;
-pub const __DRIVERKIT_23_0: u32 = 230000;
-pub const __DRIVERKIT_23_1: u32 = 230100;
-pub const __DRIVERKIT_23_2: u32 = 230200;
-pub const __DRIVERKIT_23_3: u32 = 230300;
-pub const __DRIVERKIT_23_4: u32 = 230400;
-pub const __DRIVERKIT_23_5: u32 = 230500;
-pub const __VISIONOS_1_0: u32 = 10000;
-pub const __VISIONOS_1_1: u32 = 10100;
-pub const __VISIONOS_1_2: u32 = 10200;
-pub const MAC_OS_X_VERSION_10_0: u32 = 1000;
-pub const MAC_OS_X_VERSION_10_1: u32 = 1010;
-pub const MAC_OS_X_VERSION_10_2: u32 = 1020;
-pub const MAC_OS_X_VERSION_10_3: u32 = 1030;
-pub const MAC_OS_X_VERSION_10_4: u32 = 1040;
-pub const MAC_OS_X_VERSION_10_5: u32 = 1050;
-pub const MAC_OS_X_VERSION_10_6: u32 = 1060;
-pub const MAC_OS_X_VERSION_10_7: u32 = 1070;
-pub const MAC_OS_X_VERSION_10_8: u32 = 1080;
-pub const MAC_OS_X_VERSION_10_9: u32 = 1090;
-pub const MAC_OS_X_VERSION_10_10: u32 = 101000;
-pub const MAC_OS_X_VERSION_10_10_2: u32 = 101002;
-pub const MAC_OS_X_VERSION_10_10_3: u32 = 101003;
-pub const MAC_OS_X_VERSION_10_11: u32 = 101100;
-pub const MAC_OS_X_VERSION_10_11_2: u32 = 101102;
-pub const MAC_OS_X_VERSION_10_11_3: u32 = 101103;
-pub const MAC_OS_X_VERSION_10_11_4: u32 = 101104;
-pub const MAC_OS_X_VERSION_10_12: u32 = 101200;
-pub const MAC_OS_X_VERSION_10_12_1: u32 = 101201;
-pub const MAC_OS_X_VERSION_10_12_2: u32 = 101202;
-pub const MAC_OS_X_VERSION_10_12_4: u32 = 101204;
-pub const MAC_OS_X_VERSION_10_13: u32 = 101300;
-pub const MAC_OS_X_VERSION_10_13_1: u32 = 101301;
-pub const MAC_OS_X_VERSION_10_13_2: u32 = 101302;
-pub const MAC_OS_X_VERSION_10_13_4: u32 = 101304;
-pub const MAC_OS_X_VERSION_10_14: u32 = 101400;
-pub const MAC_OS_X_VERSION_10_14_1: u32 = 101401;
-pub const MAC_OS_X_VERSION_10_14_4: u32 = 101404;
-pub const MAC_OS_X_VERSION_10_14_5: u32 = 101405;
-pub const MAC_OS_X_VERSION_10_14_6: u32 = 101406;
-pub const MAC_OS_X_VERSION_10_15: u32 = 101500;
-pub const MAC_OS_X_VERSION_10_15_1: u32 = 101501;
-pub const MAC_OS_X_VERSION_10_15_4: u32 = 101504;
-pub const MAC_OS_X_VERSION_10_16: u32 = 101600;
-pub const MAC_OS_VERSION_11_0: u32 = 110000;
-pub const MAC_OS_VERSION_11_1: u32 = 110100;
-pub const MAC_OS_VERSION_11_3: u32 = 110300;
-pub const MAC_OS_VERSION_11_4: u32 = 110400;
-pub const MAC_OS_VERSION_11_5: u32 = 110500;
-pub const MAC_OS_VERSION_11_6: u32 = 110600;
-pub const MAC_OS_VERSION_12_0: u32 = 120000;
-pub const MAC_OS_VERSION_12_1: u32 = 120100;
-pub const MAC_OS_VERSION_12_2: u32 = 120200;
-pub const MAC_OS_VERSION_12_3: u32 = 120300;
-pub const MAC_OS_VERSION_12_4: u32 = 120400;
-pub const MAC_OS_VERSION_12_5: u32 = 120500;
-pub const MAC_OS_VERSION_12_6: u32 = 120600;
-pub const MAC_OS_VERSION_12_7: u32 = 120700;
-pub const MAC_OS_VERSION_13_0: u32 = 130000;
-pub const MAC_OS_VERSION_13_1: u32 = 130100;
-pub const MAC_OS_VERSION_13_2: u32 = 130200;
-pub const MAC_OS_VERSION_13_3: u32 = 130300;
-pub const MAC_OS_VERSION_13_4: u32 = 130400;
-pub const MAC_OS_VERSION_13_5: u32 = 130500;
-pub const MAC_OS_VERSION_13_6: u32 = 130600;
-pub const MAC_OS_VERSION_14_0: u32 = 140000;
-pub const MAC_OS_VERSION_14_1: u32 = 140100;
-pub const MAC_OS_VERSION_14_2: u32 = 140200;
-pub const MAC_OS_VERSION_14_3: u32 = 140300;
-pub const MAC_OS_VERSION_14_4: u32 = 140400;
-pub const MAC_OS_VERSION_14_5: u32 = 140500;
-pub const __MAC_OS_X_VERSION_MAX_ALLOWED: u32 = 140500;
-pub const __ENABLE_LEGACY_MAC_AVAILABILITY: u32 = 1;
-pub const __PTHREAD_SIZE__: u32 = 8176;
-pub const __PTHREAD_ATTR_SIZE__: u32 = 56;
-pub const __PTHREAD_MUTEXATTR_SIZE__: u32 = 8;
-pub const __PTHREAD_MUTEX_SIZE__: u32 = 56;
-pub const __PTHREAD_CONDATTR_SIZE__: u32 = 8;
-pub const __PTHREAD_COND_SIZE__: u32 = 40;
-pub const __PTHREAD_ONCE_SIZE__: u32 = 8;
-pub const __PTHREAD_RWLOCK_SIZE__: u32 = 192;
-pub const __PTHREAD_RWLOCKATTR_SIZE__: u32 = 16;
-pub const __DARWIN_WCHAR_MIN: i32 = -2147483648;
-pub const _FORTIFY_SOURCE: u32 = 2;
-pub const RENAME_SECLUDE: u32 = 1;
-pub const RENAME_SWAP: u32 = 2;
-pub const RENAME_EXCL: u32 = 4;
-pub const RENAME_RESERVED1: u32 = 8;
-pub const RENAME_NOFOLLOW_ANY: u32 = 16;
-pub const SEEK_SET: u32 = 0;
-pub const SEEK_CUR: u32 = 1;
-pub const SEEK_END: u32 = 2;
-pub const SEEK_HOLE: u32 = 3;
-pub const SEEK_DATA: u32 = 4;
-pub const __SLBF: u32 = 1;
-pub const __SNBF: u32 = 2;
-pub const __SRD: u32 = 4;
-pub const __SWR: u32 = 8;
-pub const __SRW: u32 = 16;
-pub const __SEOF: u32 = 32;
-pub const __SERR: u32 = 64;
-pub const __SMBF: u32 = 128;
-pub const __SAPP: u32 = 256;
-pub const __SSTR: u32 = 512;
-pub const __SOPT: u32 = 1024;
-pub const __SNPT: u32 = 2048;
-pub const __SOFF: u32 = 4096;
-pub const __SMOD: u32 = 8192;
-pub const __SALC: u32 = 16384;
-pub const __SIGN: u32 = 32768;
+pub const _STDIO_H: u32 = 1;
+pub const _FEATURES_H: u32 = 1;
+pub const _DEFAULT_SOURCE: u32 = 1;
+pub const __GLIBC_USE_ISOC2X: u32 = 0;
+pub const __USE_ISOC11: u32 = 1;
+pub const __USE_ISOC99: u32 = 1;
+pub const __USE_ISOC95: u32 = 1;
+pub const __USE_POSIX_IMPLICITLY: u32 = 1;
+pub const _POSIX_SOURCE: u32 = 1;
+pub const _POSIX_C_SOURCE: u32 = 200809;
+pub const __USE_POSIX: u32 = 1;
+pub const __USE_POSIX2: u32 = 1;
+pub const __USE_POSIX199309: u32 = 1;
+pub const __USE_POSIX199506: u32 = 1;
+pub const __USE_XOPEN2K: u32 = 1;
+pub const __USE_XOPEN2K8: u32 = 1;
+pub const _ATFILE_SOURCE: u32 = 1;
+pub const __WORDSIZE: u32 = 64;
+pub const __WORDSIZE_TIME64_COMPAT32: u32 = 1;
+pub const __SYSCALL_WORDSIZE: u32 = 64;
+pub const __TIMESIZE: u32 = 64;
+pub const __USE_MISC: u32 = 1;
+pub const __USE_ATFILE: u32 = 1;
+pub const __USE_FORTIFY_LEVEL: u32 = 0;
+pub const __GLIBC_USE_DEPRECATED_GETS: u32 = 0;
+pub const __GLIBC_USE_DEPRECATED_SCANF: u32 = 0;
+pub const __GLIBC_USE_C2X_STRTOL: u32 = 0;
+pub const _STDC_PREDEF_H: u32 = 1;
+pub const __STDC_IEC_559__: u32 = 1;
+pub const __STDC_IEC_60559_BFP__: u32 = 201404;
+pub const __STDC_IEC_559_COMPLEX__: u32 = 1;
+pub const __STDC_IEC_60559_COMPLEX__: u32 = 201404;
+pub const __STDC_ISO_10646__: u32 = 201706;
+pub const __GNU_LIBRARY__: u32 = 6;
+pub const __GLIBC__: u32 = 2;
+pub const __GLIBC_MINOR__: u32 = 39;
+pub const _SYS_CDEFS_H: u32 = 1;
+pub const __glibc_c99_flexarr_available: u32 = 1;
+pub const __LDOUBLE_REDIRECTS_TO_FLOAT128_ABI: u32 = 0;
+pub const __HAVE_GENERIC_SELECTION: u32 = 1;
+pub const __GLIBC_USE_LIB_EXT2: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_BFP_EXT: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_BFP_EXT_C2X: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_EXT: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_FUNCS_EXT: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_FUNCS_EXT_C2X: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_TYPES_EXT: u32 = 0;
+pub const _BITS_TYPES_H: u32 = 1;
+pub const _BITS_TYPESIZES_H: u32 = 1;
+pub const __OFF_T_MATCHES_OFF64_T: u32 = 1;
+pub const __INO_T_MATCHES_INO64_T: u32 = 1;
+pub const __RLIM_T_MATCHES_RLIM64_T: u32 = 1;
+pub const __STATFS_MATCHES_STATFS64: u32 = 1;
+pub const __KERNEL_OLD_TIMEVAL_MATCHES_TIMEVAL64: u32 = 1;
+pub const __FD_SETSIZE: u32 = 1024;
+pub const _BITS_TIME64_H: u32 = 1;
+pub const _____fpos_t_defined: u32 = 1;
+pub const ____mbstate_t_defined: u32 = 1;
+pub const _____fpos64_t_defined: u32 = 1;
+pub const ____FILE_defined: u32 = 1;
+pub const __FILE_defined: u32 = 1;
+pub const __struct_FILE_defined: u32 = 1;
+pub const _IO_EOF_SEEN: u32 = 16;
+pub const _IO_ERR_SEEN: u32 = 32;
+pub const _IO_USER_LOCK: u32 = 32768;
+pub const __cookie_io_functions_t_defined: u32 = 1;
 pub const _IOFBF: u32 = 0;
 pub const _IOLBF: u32 = 1;
 pub const _IONBF: u32 = 2;
-pub const BUFSIZ: u32 = 1024;
+pub const BUFSIZ: u32 = 8192;
 pub const EOF: i32 = -1;
-pub const FOPEN_MAX: u32 = 20;
-pub const FILENAME_MAX: u32 = 1024;
-pub const P_tmpdir: &[u8; 10] = b"/var/tmp/\0";
-pub const L_tmpnam: u32 = 1024;
-pub const TMP_MAX: u32 = 308915776;
-pub const L_ctermid: u32 = 1024;
-pub const _USE_FORTIFY_LEVEL: u32 = 2;
-pub const __WORDSIZE: u32 = 64;
-pub const INT8_MAX: u32 = 127;
-pub const INT16_MAX: u32 = 32767;
-pub const INT32_MAX: u32 = 2147483647;
-pub const INT64_MAX: u64 = 9223372036854775807;
+pub const SEEK_SET: u32 = 0;
+pub const SEEK_CUR: u32 = 1;
+pub const SEEK_END: u32 = 2;
+pub const P_tmpdir: &[u8; 5] = b"/tmp\0";
+pub const L_tmpnam: u32 = 20;
+pub const TMP_MAX: u32 = 238328;
+pub const _BITS_STDIO_LIM_H: u32 = 1;
+pub const FILENAME_MAX: u32 = 4096;
+pub const L_ctermid: u32 = 9;
+pub const FOPEN_MAX: u32 = 16;
+pub const __HAVE_FLOAT128: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT128: u32 = 0;
+pub const __HAVE_FLOAT64X: u32 = 1;
+pub const __HAVE_FLOAT64X_LONG_DOUBLE: u32 = 1;
+pub const __HAVE_FLOAT16: u32 = 0;
+pub const __HAVE_FLOAT32: u32 = 1;
+pub const __HAVE_FLOAT64: u32 = 1;
+pub const __HAVE_FLOAT32X: u32 = 1;
+pub const __HAVE_FLOAT128X: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT16: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT32: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT64: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT32X: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT64X: u32 = 0;
+pub const __HAVE_DISTINCT_FLOAT128X: u32 = 0;
+pub const __HAVE_FLOATN_NOT_TYPEDEF: u32 = 0;
+pub const _STDINT_H: u32 = 1;
+pub const _BITS_WCHAR_H: u32 = 1;
+pub const _BITS_STDINT_INTN_H: u32 = 1;
+pub const _BITS_STDINT_UINTN_H: u32 = 1;
+pub const _BITS_STDINT_LEAST_H: u32 = 1;
 pub const INT8_MIN: i32 = -128;
 pub const INT16_MIN: i32 = -32768;
 pub const INT32_MIN: i32 = -2147483648;
-pub const INT64_MIN: i64 = -9223372036854775808;
+pub const INT8_MAX: u32 = 127;
+pub const INT16_MAX: u32 = 32767;
+pub const INT32_MAX: u32 = 2147483647;
 pub const UINT8_MAX: u32 = 255;
 pub const UINT16_MAX: u32 = 65535;
 pub const UINT32_MAX: u32 = 4294967295;
-pub const UINT64_MAX: i32 = -1;
 pub const INT_LEAST8_MIN: i32 = -128;
 pub const INT_LEAST16_MIN: i32 = -32768;
 pub const INT_LEAST32_MIN: i32 = -2147483648;
-pub const INT_LEAST64_MIN: i64 = -9223372036854775808;
 pub const INT_LEAST8_MAX: u32 = 127;
 pub const INT_LEAST16_MAX: u32 = 32767;
 pub const INT_LEAST32_MAX: u32 = 2147483647;
-pub const INT_LEAST64_MAX: u64 = 9223372036854775807;
 pub const UINT_LEAST8_MAX: u32 = 255;
 pub const UINT_LEAST16_MAX: u32 = 65535;
 pub const UINT_LEAST32_MAX: u32 = 4294967295;
-pub const UINT_LEAST64_MAX: i32 = -1;
 pub const INT_FAST8_MIN: i32 = -128;
-pub const INT_FAST16_MIN: i32 = -32768;
-pub const INT_FAST32_MIN: i32 = -2147483648;
-pub const INT_FAST64_MIN: i64 = -9223372036854775808;
+pub const INT_FAST16_MIN: i64 = -9223372036854775808;
+pub const INT_FAST32_MIN: i64 = -9223372036854775808;
 pub const INT_FAST8_MAX: u32 = 127;
-pub const INT_FAST16_MAX: u32 = 32767;
-pub const INT_FAST32_MAX: u32 = 2147483647;
-pub const INT_FAST64_MAX: u64 = 9223372036854775807;
+pub const INT_FAST16_MAX: u64 = 9223372036854775807;
+pub const INT_FAST32_MAX: u64 = 9223372036854775807;
 pub const UINT_FAST8_MAX: u32 = 255;
-pub const UINT_FAST16_MAX: u32 = 65535;
-pub const UINT_FAST32_MAX: u32 = 4294967295;
-pub const UINT_FAST64_MAX: i32 = -1;
-pub const INTPTR_MAX: u64 = 9223372036854775807;
+pub const UINT_FAST16_MAX: i32 = -1;
+pub const UINT_FAST32_MAX: i32 = -1;
 pub const INTPTR_MIN: i64 = -9223372036854775808;
+pub const INTPTR_MAX: u64 = 9223372036854775807;
 pub const UINTPTR_MAX: i32 = -1;
-pub const SIZE_MAX: i32 = -1;
-pub const RSIZE_MAX: i32 = -1;
-pub const WINT_MIN: i32 = -2147483648;
-pub const WINT_MAX: u32 = 2147483647;
+pub const PTRDIFF_MIN: i64 = -9223372036854775808;
+pub const PTRDIFF_MAX: u64 = 9223372036854775807;
 pub const SIG_ATOMIC_MIN: i32 = -2147483648;
 pub const SIG_ATOMIC_MAX: u32 = 2147483647;
-pub const FP_SUPERNORMAL: u32 = 6;
-pub const FP_FAST_FMA: u32 = 1;
-pub const FP_FAST_FMAF: u32 = 1;
-pub const FP_FAST_FMAL: u32 = 1;
+pub const SIZE_MAX: i32 = -1;
+pub const WINT_MIN: u32 = 0;
+pub const WINT_MAX: u32 = 4294967295;
+pub const _MATH_H: u32 = 1;
+pub const _BITS_LIBM_SIMD_DECL_STUBS_H: u32 = 1;
+pub const __FP_LOGB0_IS_MIN: u32 = 1;
+pub const __FP_LOGBNAN_IS_MIN: u32 = 1;
 pub const FP_ILOGB0: i32 = -2147483648;
 pub const FP_ILOGBNAN: i32 = -2147483648;
+pub const __MATH_DECLARING_DOUBLE: u32 = 1;
+pub const __MATH_DECLARING_FLOATN: u32 = 0;
+pub const __MATH_DECLARE_LDOUBLE: u32 = 1;
 pub const MATH_ERRNO: u32 = 1;
 pub const MATH_ERREXCEPT: u32 = 2;
+pub const math_errhandling: u32 = 3;
 pub const M_E: f64 = 2.718281828459045;
 pub const M_LOG2E: f64 = 1.4426950408889634;
 pub const M_LOG10E: f64 = 0.4342944819032518;
@@ -620,132 +300,85 @@ pub const M_2_PI: f64 = 0.6366197723675814;
 pub const M_2_SQRTPI: f64 = 1.1283791670955126;
 pub const M_SQRT2: f64 = 1.4142135623730951;
 pub const M_SQRT1_2: f64 = 0.7071067811865476;
-pub const FP_SNAN: u32 = 1;
-pub const FP_QNAN: u32 = 1;
-pub const DOMAIN: u32 = 1;
-pub const SING: u32 = 2;
-pub const OVERFLOW: u32 = 3;
-pub const UNDERFLOW: u32 = 4;
-pub const TLOSS: u32 = 5;
-pub const PLOSS: u32 = 6;
-pub const __DARWIN_CLK_TCK: u32 = 100;
-pub const MB_LEN_MAX: u32 = 6;
-pub const CLK_TCK: u32 = 100;
-pub const CHAR_BIT: u32 = 8;
-pub const SCHAR_MAX: u32 = 127;
-pub const SCHAR_MIN: i32 = -128;
-pub const UCHAR_MAX: u32 = 255;
-pub const CHAR_MAX: u32 = 127;
-pub const CHAR_MIN: i32 = -128;
-pub const USHRT_MAX: u32 = 65535;
-pub const SHRT_MAX: u32 = 32767;
-pub const SHRT_MIN: i32 = -32768;
-pub const UINT_MAX: u32 = 4294967295;
-pub const INT_MAX: u32 = 2147483647;
-pub const INT_MIN: i32 = -2147483648;
-pub const ULONG_MAX: i32 = -1;
-pub const LONG_MAX: u64 = 9223372036854775807;
-pub const LONG_MIN: i64 = -9223372036854775808;
-pub const ULLONG_MAX: i32 = -1;
-pub const LLONG_MAX: u64 = 9223372036854775807;
-pub const LLONG_MIN: i64 = -9223372036854775808;
-pub const LONG_BIT: u32 = 64;
-pub const SSIZE_MAX: u64 = 9223372036854775807;
-pub const WORD_BIT: u32 = 32;
-pub const SIZE_T_MAX: i32 = -1;
-pub const UQUAD_MAX: i32 = -1;
-pub const QUAD_MAX: u64 = 9223372036854775807;
-pub const QUAD_MIN: i64 = -9223372036854775808;
-pub const ARG_MAX: u32 = 1048576;
-pub const CHILD_MAX: u32 = 266;
-pub const GID_MAX: u32 = 2147483647;
-pub const LINK_MAX: u32 = 32767;
-pub const MAX_CANON: u32 = 1024;
-pub const MAX_INPUT: u32 = 1024;
-pub const NAME_MAX: u32 = 255;
-pub const NGROUPS_MAX: u32 = 16;
-pub const UID_MAX: u32 = 2147483647;
-pub const OPEN_MAX: u32 = 10240;
-pub const PATH_MAX: u32 = 1024;
-pub const PIPE_BUF: u32 = 512;
-pub const BC_BASE_MAX: u32 = 99;
-pub const BC_DIM_MAX: u32 = 2048;
-pub const BC_SCALE_MAX: u32 = 99;
-pub const BC_STRING_MAX: u32 = 1000;
-pub const CHARCLASS_NAME_MAX: u32 = 14;
-pub const COLL_WEIGHTS_MAX: u32 = 2;
-pub const EQUIV_CLASS_MAX: u32 = 2;
-pub const EXPR_NEST_MAX: u32 = 32;
-pub const LINE_MAX: u32 = 2048;
-pub const RE_DUP_MAX: u32 = 255;
-pub const NZERO: u32 = 20;
+pub const _LIBC_LIMITS_H_: u32 = 1;
+pub const MB_LEN_MAX: u32 = 16;
+pub const _BITS_POSIX1_LIM_H: u32 = 1;
+pub const _POSIX_AIO_LISTIO_MAX: u32 = 2;
+pub const _POSIX_AIO_MAX: u32 = 1;
 pub const _POSIX_ARG_MAX: u32 = 4096;
 pub const _POSIX_CHILD_MAX: u32 = 25;
+pub const _POSIX_DELAYTIMER_MAX: u32 = 32;
+pub const _POSIX_HOST_NAME_MAX: u32 = 255;
 pub const _POSIX_LINK_MAX: u32 = 8;
+pub const _POSIX_LOGIN_NAME_MAX: u32 = 9;
 pub const _POSIX_MAX_CANON: u32 = 255;
 pub const _POSIX_MAX_INPUT: u32 = 255;
+pub const _POSIX_MQ_OPEN_MAX: u32 = 8;
+pub const _POSIX_MQ_PRIO_MAX: u32 = 32;
 pub const _POSIX_NAME_MAX: u32 = 14;
 pub const _POSIX_NGROUPS_MAX: u32 = 8;
 pub const _POSIX_OPEN_MAX: u32 = 20;
 pub const _POSIX_PATH_MAX: u32 = 256;
 pub const _POSIX_PIPE_BUF: u32 = 512;
-pub const _POSIX_SSIZE_MAX: u32 = 32767;
-pub const _POSIX_STREAM_MAX: u32 = 8;
-pub const _POSIX_TZNAME_MAX: u32 = 6;
-pub const _POSIX2_BC_BASE_MAX: u32 = 99;
-pub const _POSIX2_BC_DIM_MAX: u32 = 2048;
-pub const _POSIX2_BC_SCALE_MAX: u32 = 99;
-pub const _POSIX2_BC_STRING_MAX: u32 = 1000;
-pub const _POSIX2_EQUIV_CLASS_MAX: u32 = 2;
-pub const _POSIX2_EXPR_NEST_MAX: u32 = 32;
-pub const _POSIX2_LINE_MAX: u32 = 2048;
-pub const _POSIX2_RE_DUP_MAX: u32 = 255;
-pub const _POSIX_AIO_LISTIO_MAX: u32 = 2;
-pub const _POSIX_AIO_MAX: u32 = 1;
-pub const _POSIX_DELAYTIMER_MAX: u32 = 32;
-pub const _POSIX_MQ_OPEN_MAX: u32 = 8;
-pub const _POSIX_MQ_PRIO_MAX: u32 = 32;
+pub const _POSIX_RE_DUP_MAX: u32 = 255;
 pub const _POSIX_RTSIG_MAX: u32 = 8;
 pub const _POSIX_SEM_NSEMS_MAX: u32 = 256;
 pub const _POSIX_SEM_VALUE_MAX: u32 = 32767;
 pub const _POSIX_SIGQUEUE_MAX: u32 = 32;
-pub const _POSIX_TIMER_MAX: u32 = 32;
-pub const _POSIX_CLOCKRES_MIN: u32 = 20000000;
-pub const _POSIX_THREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
-pub const _POSIX_THREAD_KEYS_MAX: u32 = 128;
-pub const _POSIX_THREAD_THREADS_MAX: u32 = 64;
-pub const PTHREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
-pub const PTHREAD_KEYS_MAX: u32 = 512;
-pub const PTHREAD_STACK_MIN: u32 = 16384;
-pub const _POSIX_HOST_NAME_MAX: u32 = 255;
-pub const _POSIX_LOGIN_NAME_MAX: u32 = 9;
-pub const _POSIX_SS_REPL_MAX: u32 = 4;
+pub const _POSIX_SSIZE_MAX: u32 = 32767;
+pub const _POSIX_STREAM_MAX: u32 = 8;
 pub const _POSIX_SYMLINK_MAX: u32 = 255;
 pub const _POSIX_SYMLOOP_MAX: u32 = 8;
-pub const _POSIX_TRACE_EVENT_NAME_MAX: u32 = 30;
-pub const _POSIX_TRACE_NAME_MAX: u32 = 8;
-pub const _POSIX_TRACE_SYS_MAX: u32 = 8;
-pub const _POSIX_TRACE_USER_EVENT_MAX: u32 = 32;
+pub const _POSIX_TIMER_MAX: u32 = 32;
 pub const _POSIX_TTY_NAME_MAX: u32 = 9;
-pub const _POSIX2_CHARCLASS_NAME_MAX: u32 = 14;
+pub const _POSIX_TZNAME_MAX: u32 = 6;
+pub const _POSIX_CLOCKRES_MIN: u32 = 20000000;
+pub const NR_OPEN: u32 = 1024;
+pub const NGROUPS_MAX: u32 = 65536;
+pub const ARG_MAX: u32 = 131072;
+pub const LINK_MAX: u32 = 127;
+pub const MAX_CANON: u32 = 255;
+pub const MAX_INPUT: u32 = 255;
+pub const NAME_MAX: u32 = 255;
+pub const PATH_MAX: u32 = 4096;
+pub const PIPE_BUF: u32 = 4096;
+pub const XATTR_NAME_MAX: u32 = 255;
+pub const XATTR_SIZE_MAX: u32 = 65536;
+pub const XATTR_LIST_MAX: u32 = 65536;
+pub const RTSIG_MAX: u32 = 32;
+pub const _POSIX_THREAD_KEYS_MAX: u32 = 128;
+pub const PTHREAD_KEYS_MAX: u32 = 1024;
+pub const _POSIX_THREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
+pub const PTHREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
+pub const _POSIX_THREAD_THREADS_MAX: u32 = 64;
+pub const AIO_PRIO_DELTA_MAX: u32 = 20;
+pub const PTHREAD_STACK_MIN: u32 = 16384;
+pub const DELAYTIMER_MAX: u32 = 2147483647;
+pub const TTY_NAME_MAX: u32 = 32;
+pub const LOGIN_NAME_MAX: u32 = 256;
+pub const HOST_NAME_MAX: u32 = 64;
+pub const MQ_PRIO_MAX: u32 = 32768;
+pub const SEM_VALUE_MAX: u32 = 2147483647;
+pub const _BITS_POSIX2_LIM_H: u32 = 1;
+pub const _POSIX2_BC_BASE_MAX: u32 = 99;
+pub const _POSIX2_BC_DIM_MAX: u32 = 2048;
+pub const _POSIX2_BC_SCALE_MAX: u32 = 99;
+pub const _POSIX2_BC_STRING_MAX: u32 = 1000;
 pub const _POSIX2_COLL_WEIGHTS_MAX: u32 = 2;
-pub const _POSIX_RE_DUP_MAX: u32 = 255;
-pub const OFF_MIN: i64 = -9223372036854775808;
-pub const OFF_MAX: u64 = 9223372036854775807;
-pub const PASS_MAX: u32 = 128;
-pub const NL_ARGMAX: u32 = 9;
-pub const NL_LANGMAX: u32 = 14;
-pub const NL_MSGMAX: u32 = 32767;
-pub const NL_NMAX: u32 = 1;
-pub const NL_SETMAX: u32 = 255;
-pub const NL_TEXTMAX: u32 = 2048;
-pub const _XOPEN_IOV_MAX: u32 = 16;
-pub const IOV_MAX: u32 = 1024;
-pub const _XOPEN_NAME_MAX: u32 = 255;
-pub const _XOPEN_PATH_MAX: u32 = 1024;
-pub const FLT_HAS_SUBNORM: u32 = 1;
-pub const DBL_HAS_SUBNORM: u32 = 1;
-pub const LDBL_HAS_SUBNORM: u32 = 1;
+pub const _POSIX2_EXPR_NEST_MAX: u32 = 32;
+pub const _POSIX2_LINE_MAX: u32 = 2048;
+pub const _POSIX2_RE_DUP_MAX: u32 = 255;
+pub const _POSIX2_CHARCLASS_NAME_MAX: u32 = 14;
+pub const BC_BASE_MAX: u32 = 99;
+pub const BC_DIM_MAX: u32 = 2048;
+pub const BC_SCALE_MAX: u32 = 99;
+pub const BC_STRING_MAX: u32 = 1000;
+pub const COLL_WEIGHTS_MAX: u32 = 255;
+pub const EXPR_NEST_MAX: u32 = 32;
+pub const LINE_MAX: u32 = 2048;
+pub const CHARCLASS_NAME_MAX: u32 = 2048;
+pub const RE_DUP_MAX: u32 = 32767;
+pub const _ASSERT_H: u32 = 1;
 pub const SCIP_BUILD_TYPE: &[u8; 8] = b"Release\0";
 pub const SCIP_VERSION_MAJOR: u32 = 10;
 pub const SCIP_VERSION_MINOR: u32 = 0;
@@ -759,8 +392,6 @@ pub const SCIP_VERSION_SUB: u32 = 0;
 pub const SCIP_SUBVERSION: u32 = 0;
 pub const SCIP_APIVERSION: u32 = 156;
 pub const SCIP_COPYRIGHT: &[u8; 52] = b"Copyright (c) 2002-2026 Zuse Institute Berlin (ZIB)\0";
-pub const SCIP_LONGINT_MAX: u64 = 9223372036854775807;
-pub const SCIP_LONGINT_MIN: i64 = -9223372036854775808;
 pub const SCIP_LONGINT_FORMAT: &[u8; 4] = b"lld\0";
 pub const SCIP_REAL_UNITROUNDOFF: f64 = 0.00000000000000011102230246251565;
 pub const SCIP_REAL_FORMAT: &[u8; 3] = b"lf\0";
@@ -795,221 +426,64 @@ pub const SCIP_DEFAULT_MEM_ARRAYGROWFAC: f64 = 1.2;
 pub const SCIP_DEFAULT_MEM_ARRAYGROWINIT: u32 = 4;
 pub const SCIP_MAXTREEDEPTH: u32 = 1073741822;
 pub const SCIP_PROBINGSCORE_PENALTYRATIO: u32 = 2;
-pub const __DARWIN_NSIG: u32 = 32;
-pub const NSIG: u32 = 32;
-pub const _ARM_SIGNAL_: u32 = 1;
-pub const SIGHUP: u32 = 1;
-pub const SIGINT: u32 = 2;
-pub const SIGQUIT: u32 = 3;
-pub const SIGILL: u32 = 4;
-pub const SIGTRAP: u32 = 5;
-pub const SIGABRT: u32 = 6;
-pub const SIGIOT: u32 = 6;
-pub const SIGEMT: u32 = 7;
-pub const SIGFPE: u32 = 8;
-pub const SIGKILL: u32 = 9;
-pub const SIGBUS: u32 = 10;
-pub const SIGSEGV: u32 = 11;
-pub const SIGSYS: u32 = 12;
-pub const SIGPIPE: u32 = 13;
-pub const SIGALRM: u32 = 14;
-pub const SIGTERM: u32 = 15;
-pub const SIGURG: u32 = 16;
-pub const SIGSTOP: u32 = 17;
-pub const SIGTSTP: u32 = 18;
-pub const SIGCONT: u32 = 19;
-pub const SIGCHLD: u32 = 20;
-pub const SIGTTIN: u32 = 21;
-pub const SIGTTOU: u32 = 22;
-pub const SIGIO: u32 = 23;
-pub const SIGXCPU: u32 = 24;
-pub const SIGXFSZ: u32 = 25;
-pub const SIGVTALRM: u32 = 26;
-pub const SIGPROF: u32 = 27;
-pub const SIGWINCH: u32 = 28;
-pub const SIGINFO: u32 = 29;
-pub const SIGUSR1: u32 = 30;
-pub const SIGUSR2: u32 = 31;
-pub const __DARWIN_OPAQUE_ARM_THREAD_STATE64: u32 = 0;
-pub const SIGEV_NONE: u32 = 0;
-pub const SIGEV_SIGNAL: u32 = 1;
-pub const SIGEV_THREAD: u32 = 3;
-pub const ILL_NOOP: u32 = 0;
-pub const ILL_ILLOPC: u32 = 1;
-pub const ILL_ILLTRP: u32 = 2;
-pub const ILL_PRVOPC: u32 = 3;
-pub const ILL_ILLOPN: u32 = 4;
-pub const ILL_ILLADR: u32 = 5;
-pub const ILL_PRVREG: u32 = 6;
-pub const ILL_COPROC: u32 = 7;
-pub const ILL_BADSTK: u32 = 8;
-pub const FPE_NOOP: u32 = 0;
-pub const FPE_FLTDIV: u32 = 1;
-pub const FPE_FLTOVF: u32 = 2;
-pub const FPE_FLTUND: u32 = 3;
-pub const FPE_FLTRES: u32 = 4;
-pub const FPE_FLTINV: u32 = 5;
-pub const FPE_FLTSUB: u32 = 6;
-pub const FPE_INTDIV: u32 = 7;
-pub const FPE_INTOVF: u32 = 8;
-pub const SEGV_NOOP: u32 = 0;
-pub const SEGV_MAPERR: u32 = 1;
-pub const SEGV_ACCERR: u32 = 2;
-pub const BUS_NOOP: u32 = 0;
-pub const BUS_ADRALN: u32 = 1;
-pub const BUS_ADRERR: u32 = 2;
-pub const BUS_OBJERR: u32 = 3;
-pub const TRAP_BRKPT: u32 = 1;
-pub const TRAP_TRACE: u32 = 2;
-pub const CLD_NOOP: u32 = 0;
-pub const CLD_EXITED: u32 = 1;
-pub const CLD_KILLED: u32 = 2;
-pub const CLD_DUMPED: u32 = 3;
-pub const CLD_TRAPPED: u32 = 4;
-pub const CLD_STOPPED: u32 = 5;
-pub const CLD_CONTINUED: u32 = 6;
-pub const POLL_IN: u32 = 1;
-pub const POLL_OUT: u32 = 2;
-pub const POLL_MSG: u32 = 3;
-pub const POLL_ERR: u32 = 4;
-pub const POLL_PRI: u32 = 5;
-pub const POLL_HUP: u32 = 6;
-pub const SA_ONSTACK: u32 = 1;
-pub const SA_RESTART: u32 = 2;
-pub const SA_RESETHAND: u32 = 4;
-pub const SA_NOCLDSTOP: u32 = 8;
-pub const SA_NODEFER: u32 = 16;
-pub const SA_NOCLDWAIT: u32 = 32;
-pub const SA_SIGINFO: u32 = 64;
-pub const SA_USERTRAMP: u32 = 256;
-pub const SA_64REGSET: u32 = 512;
-pub const SA_USERSPACE_MASK: u32 = 127;
-pub const SIG_BLOCK: u32 = 1;
-pub const SIG_UNBLOCK: u32 = 2;
-pub const SIG_SETMASK: u32 = 3;
-pub const SI_USER: u32 = 65537;
-pub const SI_QUEUE: u32 = 65538;
-pub const SI_TIMER: u32 = 65539;
-pub const SI_ASYNCIO: u32 = 65540;
-pub const SI_MESGQ: u32 = 65541;
-pub const SS_ONSTACK: u32 = 1;
-pub const SS_DISABLE: u32 = 4;
-pub const MINSIGSTKSZ: u32 = 32768;
-pub const SIGSTKSZ: u32 = 131072;
-pub const SV_ONSTACK: u32 = 1;
-pub const SV_INTERRUPT: u32 = 2;
-pub const SV_RESETHAND: u32 = 4;
-pub const SV_NODEFER: u32 = 16;
-pub const SV_NOCLDSTOP: u32 = 8;
-pub const SV_SIGINFO: u32 = 64;
-pub const PRIO_PROCESS: u32 = 0;
-pub const PRIO_PGRP: u32 = 1;
-pub const PRIO_USER: u32 = 2;
-pub const PRIO_DARWIN_THREAD: u32 = 3;
-pub const PRIO_DARWIN_PROCESS: u32 = 4;
-pub const PRIO_MIN: i32 = -20;
-pub const PRIO_MAX: u32 = 20;
-pub const PRIO_DARWIN_BG: u32 = 4096;
-pub const PRIO_DARWIN_NONUI: u32 = 4097;
-pub const RUSAGE_SELF: u32 = 0;
-pub const RUSAGE_CHILDREN: i32 = -1;
-pub const RUSAGE_INFO_V0: u32 = 0;
-pub const RUSAGE_INFO_V1: u32 = 1;
-pub const RUSAGE_INFO_V2: u32 = 2;
-pub const RUSAGE_INFO_V3: u32 = 3;
-pub const RUSAGE_INFO_V4: u32 = 4;
-pub const RUSAGE_INFO_V5: u32 = 5;
-pub const RUSAGE_INFO_V6: u32 = 6;
-pub const RUSAGE_INFO_CURRENT: u32 = 6;
-pub const RU_PROC_RUNS_RESLIDE: u32 = 1;
-pub const RLIMIT_CPU: u32 = 0;
-pub const RLIMIT_FSIZE: u32 = 1;
-pub const RLIMIT_DATA: u32 = 2;
-pub const RLIMIT_STACK: u32 = 3;
-pub const RLIMIT_CORE: u32 = 4;
-pub const RLIMIT_AS: u32 = 5;
-pub const RLIMIT_RSS: u32 = 5;
-pub const RLIMIT_MEMLOCK: u32 = 6;
-pub const RLIMIT_NPROC: u32 = 7;
-pub const RLIMIT_NOFILE: u32 = 8;
-pub const RLIM_NLIMITS: u32 = 9;
-pub const _RLIMIT_POSIX_FLAG: u32 = 4096;
-pub const RLIMIT_WAKEUPS_MONITOR: u32 = 1;
-pub const RLIMIT_CPU_USAGE_MONITOR: u32 = 2;
-pub const RLIMIT_THREAD_CPULIMITS: u32 = 3;
-pub const RLIMIT_FOOTPRINT_INTERVAL: u32 = 4;
-pub const WAKEMON_ENABLE: u32 = 1;
-pub const WAKEMON_DISABLE: u32 = 2;
-pub const WAKEMON_GET_PARAMS: u32 = 4;
-pub const WAKEMON_SET_DEFAULTS: u32 = 8;
-pub const WAKEMON_MAKE_FATAL: u32 = 16;
-pub const CPUMON_MAKE_FATAL: u32 = 4096;
-pub const FOOTPRINT_INTERVAL_RESET: u32 = 1;
-pub const IOPOL_TYPE_DISK: u32 = 0;
-pub const IOPOL_TYPE_VFS_ATIME_UPDATES: u32 = 2;
-pub const IOPOL_TYPE_VFS_MATERIALIZE_DATALESS_FILES: u32 = 3;
-pub const IOPOL_TYPE_VFS_STATFS_NO_DATA_VOLUME: u32 = 4;
-pub const IOPOL_TYPE_VFS_TRIGGER_RESOLVE: u32 = 5;
-pub const IOPOL_TYPE_VFS_IGNORE_CONTENT_PROTECTION: u32 = 6;
-pub const IOPOL_TYPE_VFS_IGNORE_PERMISSIONS: u32 = 7;
-pub const IOPOL_TYPE_VFS_SKIP_MTIME_UPDATE: u32 = 8;
-pub const IOPOL_TYPE_VFS_ALLOW_LOW_SPACE_WRITES: u32 = 9;
-pub const IOPOL_TYPE_VFS_DISALLOW_RW_FOR_O_EVTONLY: u32 = 10;
-pub const IOPOL_SCOPE_PROCESS: u32 = 0;
-pub const IOPOL_SCOPE_THREAD: u32 = 1;
-pub const IOPOL_SCOPE_DARWIN_BG: u32 = 2;
-pub const IOPOL_DEFAULT: u32 = 0;
-pub const IOPOL_IMPORTANT: u32 = 1;
-pub const IOPOL_PASSIVE: u32 = 2;
-pub const IOPOL_THROTTLE: u32 = 3;
-pub const IOPOL_UTILITY: u32 = 4;
-pub const IOPOL_STANDARD: u32 = 5;
-pub const IOPOL_APPLICATION: u32 = 5;
-pub const IOPOL_NORMAL: u32 = 1;
-pub const IOPOL_ATIME_UPDATES_DEFAULT: u32 = 0;
-pub const IOPOL_ATIME_UPDATES_OFF: u32 = 1;
-pub const IOPOL_MATERIALIZE_DATALESS_FILES_DEFAULT: u32 = 0;
-pub const IOPOL_MATERIALIZE_DATALESS_FILES_OFF: u32 = 1;
-pub const IOPOL_MATERIALIZE_DATALESS_FILES_ON: u32 = 2;
-pub const IOPOL_VFS_STATFS_NO_DATA_VOLUME_DEFAULT: u32 = 0;
-pub const IOPOL_VFS_STATFS_FORCE_NO_DATA_VOLUME: u32 = 1;
-pub const IOPOL_VFS_TRIGGER_RESOLVE_DEFAULT: u32 = 0;
-pub const IOPOL_VFS_TRIGGER_RESOLVE_OFF: u32 = 1;
-pub const IOPOL_VFS_CONTENT_PROTECTION_DEFAULT: u32 = 0;
-pub const IOPOL_VFS_CONTENT_PROTECTION_IGNORE: u32 = 1;
-pub const IOPOL_VFS_IGNORE_PERMISSIONS_OFF: u32 = 0;
-pub const IOPOL_VFS_IGNORE_PERMISSIONS_ON: u32 = 1;
-pub const IOPOL_VFS_SKIP_MTIME_UPDATE_OFF: u32 = 0;
-pub const IOPOL_VFS_SKIP_MTIME_UPDATE_ON: u32 = 1;
-pub const IOPOL_VFS_ALLOW_LOW_SPACE_WRITES_OFF: u32 = 0;
-pub const IOPOL_VFS_ALLOW_LOW_SPACE_WRITES_ON: u32 = 1;
-pub const IOPOL_VFS_DISALLOW_RW_FOR_O_EVTONLY_DEFAULT: u32 = 0;
-pub const IOPOL_VFS_DISALLOW_RW_FOR_O_EVTONLY_ON: u32 = 1;
-pub const IOPOL_VFS_NOCACHE_WRITE_FS_BLKSIZE_DEFAULT: u32 = 0;
-pub const IOPOL_VFS_NOCACHE_WRITE_FS_BLKSIZE_ON: u32 = 1;
+pub const _STDLIB_H: u32 = 1;
 pub const WNOHANG: u32 = 1;
 pub const WUNTRACED: u32 = 2;
-pub const WCOREFLAG: u32 = 128;
-pub const _WSTOPPED: u32 = 127;
+pub const WSTOPPED: u32 = 2;
 pub const WEXITED: u32 = 4;
-pub const WSTOPPED: u32 = 8;
-pub const WCONTINUED: u32 = 16;
-pub const WNOWAIT: u32 = 32;
-pub const WAIT_ANY: i32 = -1;
-pub const WAIT_MYPGRP: u32 = 0;
-pub const _QUAD_HIGHWORD: u32 = 1;
-pub const _QUAD_LOWWORD: u32 = 0;
-pub const __DARWIN_LITTLE_ENDIAN: u32 = 1234;
-pub const __DARWIN_BIG_ENDIAN: u32 = 4321;
-pub const __DARWIN_PDP_ENDIAN: u32 = 3412;
-pub const __DARWIN_BYTE_ORDER: u32 = 1234;
+pub const WCONTINUED: u32 = 8;
+pub const WNOWAIT: u32 = 16777216;
+pub const __WNOTHREAD: u32 = 536870912;
+pub const __WALL: u32 = 1073741824;
+pub const __WCLONE: u32 = 2147483648;
+pub const __W_CONTINUED: u32 = 65535;
+pub const __WCOREFLAG: u32 = 128;
+pub const __ldiv_t_defined: u32 = 1;
+pub const __lldiv_t_defined: u32 = 1;
+pub const RAND_MAX: u32 = 2147483647;
+pub const EXIT_FAILURE: u32 = 1;
+pub const EXIT_SUCCESS: u32 = 0;
+pub const _SYS_TYPES_H: u32 = 1;
+pub const __clock_t_defined: u32 = 1;
+pub const __clockid_t_defined: u32 = 1;
+pub const __time_t_defined: u32 = 1;
+pub const __timer_t_defined: u32 = 1;
+pub const __BIT_TYPES_DEFINED__: u32 = 1;
+pub const _ENDIAN_H: u32 = 1;
+pub const _BITS_ENDIAN_H: u32 = 1;
+pub const __LITTLE_ENDIAN: u32 = 1234;
+pub const __BIG_ENDIAN: u32 = 4321;
+pub const __PDP_ENDIAN: u32 = 3412;
+pub const _BITS_ENDIANNESS_H: u32 = 1;
+pub const __BYTE_ORDER: u32 = 1234;
+pub const __FLOAT_WORD_ORDER: u32 = 1234;
 pub const LITTLE_ENDIAN: u32 = 1234;
 pub const BIG_ENDIAN: u32 = 4321;
 pub const PDP_ENDIAN: u32 = 3412;
 pub const BYTE_ORDER: u32 = 1234;
-pub const EXIT_FAILURE: u32 = 1;
-pub const EXIT_SUCCESS: u32 = 0;
-pub const RAND_MAX: u32 = 2147483647;
+pub const _BITS_BYTESWAP_H: u32 = 1;
+pub const _BITS_UINTN_IDENTITY_H: u32 = 1;
+pub const _SYS_SELECT_H: u32 = 1;
+pub const __sigset_t_defined: u32 = 1;
+pub const __timeval_defined: u32 = 1;
+pub const _STRUCT_TIMESPEC: u32 = 1;
+pub const FD_SETSIZE: u32 = 1024;
+pub const _BITS_PTHREADTYPES_COMMON_H: u32 = 1;
+pub const _THREAD_SHARED_TYPES_H: u32 = 1;
+pub const _BITS_PTHREADTYPES_ARCH_H: u32 = 1;
+pub const __SIZEOF_PTHREAD_MUTEX_T: u32 = 40;
+pub const __SIZEOF_PTHREAD_ATTR_T: u32 = 56;
+pub const __SIZEOF_PTHREAD_RWLOCK_T: u32 = 56;
+pub const __SIZEOF_PTHREAD_BARRIER_T: u32 = 32;
+pub const __SIZEOF_PTHREAD_MUTEXATTR_T: u32 = 4;
+pub const __SIZEOF_PTHREAD_COND_T: u32 = 48;
+pub const __SIZEOF_PTHREAD_CONDATTR_T: u32 = 4;
+pub const __SIZEOF_PTHREAD_RWLOCKATTR_T: u32 = 8;
+pub const __SIZEOF_PTHREAD_BARRIERATTR_T: u32 = 4;
+pub const _THREAD_MUTEX_INTERNAL_H: u32 = 1;
+pub const __PTHREAD_MUTEX_HAVE_PREV: u32 = 1;
+pub const __have_pthread_attr_t: u32 = 1;
+pub const _ALLOCA_H: u32 = 1;
 pub const SCIP_PRESOLTIMING_NONE: u32 = 2;
 pub const SCIP_PRESOLTIMING_FAST: u32 = 4;
 pub const SCIP_PRESOLTIMING_MEDIUM: u32 = 8;
@@ -1037,166 +511,165 @@ pub const SCIP_HEURTIMING_DURINGPRESOLLOOP: u32 = 512;
 pub const SCIP_HEURTIMING_AFTERPROPLOOP: u32 = 1024;
 pub const SCIP_HEURTIMING_AFTERNODE: u32 = 24;
 pub const SCIP_HEURTIMING_AFTERPLUNGE: u32 = 96;
-pub const __PRI_8_LENGTH_MODIFIER__: &[u8; 3] = b"hh\0";
-pub const __PRI_64_LENGTH_MODIFIER__: &[u8; 3] = b"ll\0";
-pub const __SCN_64_LENGTH_MODIFIER__: &[u8; 3] = b"ll\0";
-pub const __PRI_MAX_LENGTH_MODIFIER__: &[u8; 2] = b"j\0";
-pub const __SCN_MAX_LENGTH_MODIFIER__: &[u8; 2] = b"j\0";
-pub const PRId8: &[u8; 4] = b"hhd\0";
-pub const PRIi8: &[u8; 4] = b"hhi\0";
-pub const PRIo8: &[u8; 4] = b"hho\0";
-pub const PRIu8: &[u8; 4] = b"hhu\0";
-pub const PRIx8: &[u8; 4] = b"hhx\0";
-pub const PRIX8: &[u8; 4] = b"hhX\0";
-pub const PRId16: &[u8; 3] = b"hd\0";
-pub const PRIi16: &[u8; 3] = b"hi\0";
-pub const PRIo16: &[u8; 3] = b"ho\0";
-pub const PRIu16: &[u8; 3] = b"hu\0";
-pub const PRIx16: &[u8; 3] = b"hx\0";
-pub const PRIX16: &[u8; 3] = b"hX\0";
+pub const _INTTYPES_H: u32 = 1;
+pub const ____gwchar_t_defined: u32 = 1;
+pub const __PRI64_PREFIX: &[u8; 2] = b"l\0";
+pub const __PRIPTR_PREFIX: &[u8; 2] = b"l\0";
+pub const PRId8: &[u8; 2] = b"d\0";
+pub const PRId16: &[u8; 2] = b"d\0";
 pub const PRId32: &[u8; 2] = b"d\0";
-pub const PRIi32: &[u8; 2] = b"i\0";
-pub const PRIo32: &[u8; 2] = b"o\0";
-pub const PRIu32: &[u8; 2] = b"u\0";
-pub const PRIx32: &[u8; 2] = b"x\0";
-pub const PRIX32: &[u8; 2] = b"X\0";
-pub const PRId64: &[u8; 4] = b"lld\0";
-pub const PRIi64: &[u8; 4] = b"lli\0";
-pub const PRIo64: &[u8; 4] = b"llo\0";
-pub const PRIu64: &[u8; 4] = b"llu\0";
-pub const PRIx64: &[u8; 4] = b"llx\0";
-pub const PRIX64: &[u8; 4] = b"llX\0";
-pub const PRIdLEAST8: &[u8; 4] = b"hhd\0";
-pub const PRIiLEAST8: &[u8; 4] = b"hhi\0";
-pub const PRIoLEAST8: &[u8; 4] = b"hho\0";
-pub const PRIuLEAST8: &[u8; 4] = b"hhu\0";
-pub const PRIxLEAST8: &[u8; 4] = b"hhx\0";
-pub const PRIXLEAST8: &[u8; 4] = b"hhX\0";
-pub const PRIdLEAST16: &[u8; 3] = b"hd\0";
-pub const PRIiLEAST16: &[u8; 3] = b"hi\0";
-pub const PRIoLEAST16: &[u8; 3] = b"ho\0";
-pub const PRIuLEAST16: &[u8; 3] = b"hu\0";
-pub const PRIxLEAST16: &[u8; 3] = b"hx\0";
-pub const PRIXLEAST16: &[u8; 3] = b"hX\0";
+pub const PRId64: &[u8; 3] = b"ld\0";
+pub const PRIdLEAST8: &[u8; 2] = b"d\0";
+pub const PRIdLEAST16: &[u8; 2] = b"d\0";
 pub const PRIdLEAST32: &[u8; 2] = b"d\0";
+pub const PRIdLEAST64: &[u8; 3] = b"ld\0";
+pub const PRIdFAST8: &[u8; 2] = b"d\0";
+pub const PRIdFAST16: &[u8; 3] = b"ld\0";
+pub const PRIdFAST32: &[u8; 3] = b"ld\0";
+pub const PRIdFAST64: &[u8; 3] = b"ld\0";
+pub const PRIi8: &[u8; 2] = b"i\0";
+pub const PRIi16: &[u8; 2] = b"i\0";
+pub const PRIi32: &[u8; 2] = b"i\0";
+pub const PRIi64: &[u8; 3] = b"li\0";
+pub const PRIiLEAST8: &[u8; 2] = b"i\0";
+pub const PRIiLEAST16: &[u8; 2] = b"i\0";
 pub const PRIiLEAST32: &[u8; 2] = b"i\0";
+pub const PRIiLEAST64: &[u8; 3] = b"li\0";
+pub const PRIiFAST8: &[u8; 2] = b"i\0";
+pub const PRIiFAST16: &[u8; 3] = b"li\0";
+pub const PRIiFAST32: &[u8; 3] = b"li\0";
+pub const PRIiFAST64: &[u8; 3] = b"li\0";
+pub const PRIo8: &[u8; 2] = b"o\0";
+pub const PRIo16: &[u8; 2] = b"o\0";
+pub const PRIo32: &[u8; 2] = b"o\0";
+pub const PRIo64: &[u8; 3] = b"lo\0";
+pub const PRIoLEAST8: &[u8; 2] = b"o\0";
+pub const PRIoLEAST16: &[u8; 2] = b"o\0";
 pub const PRIoLEAST32: &[u8; 2] = b"o\0";
+pub const PRIoLEAST64: &[u8; 3] = b"lo\0";
+pub const PRIoFAST8: &[u8; 2] = b"o\0";
+pub const PRIoFAST16: &[u8; 3] = b"lo\0";
+pub const PRIoFAST32: &[u8; 3] = b"lo\0";
+pub const PRIoFAST64: &[u8; 3] = b"lo\0";
+pub const PRIu8: &[u8; 2] = b"u\0";
+pub const PRIu16: &[u8; 2] = b"u\0";
+pub const PRIu32: &[u8; 2] = b"u\0";
+pub const PRIu64: &[u8; 3] = b"lu\0";
+pub const PRIuLEAST8: &[u8; 2] = b"u\0";
+pub const PRIuLEAST16: &[u8; 2] = b"u\0";
 pub const PRIuLEAST32: &[u8; 2] = b"u\0";
+pub const PRIuLEAST64: &[u8; 3] = b"lu\0";
+pub const PRIuFAST8: &[u8; 2] = b"u\0";
+pub const PRIuFAST16: &[u8; 3] = b"lu\0";
+pub const PRIuFAST32: &[u8; 3] = b"lu\0";
+pub const PRIuFAST64: &[u8; 3] = b"lu\0";
+pub const PRIx8: &[u8; 2] = b"x\0";
+pub const PRIx16: &[u8; 2] = b"x\0";
+pub const PRIx32: &[u8; 2] = b"x\0";
+pub const PRIx64: &[u8; 3] = b"lx\0";
+pub const PRIxLEAST8: &[u8; 2] = b"x\0";
+pub const PRIxLEAST16: &[u8; 2] = b"x\0";
 pub const PRIxLEAST32: &[u8; 2] = b"x\0";
+pub const PRIxLEAST64: &[u8; 3] = b"lx\0";
+pub const PRIxFAST8: &[u8; 2] = b"x\0";
+pub const PRIxFAST16: &[u8; 3] = b"lx\0";
+pub const PRIxFAST32: &[u8; 3] = b"lx\0";
+pub const PRIxFAST64: &[u8; 3] = b"lx\0";
+pub const PRIX8: &[u8; 2] = b"X\0";
+pub const PRIX16: &[u8; 2] = b"X\0";
+pub const PRIX32: &[u8; 2] = b"X\0";
+pub const PRIX64: &[u8; 3] = b"lX\0";
+pub const PRIXLEAST8: &[u8; 2] = b"X\0";
+pub const PRIXLEAST16: &[u8; 2] = b"X\0";
 pub const PRIXLEAST32: &[u8; 2] = b"X\0";
-pub const PRIdLEAST64: &[u8; 4] = b"lld\0";
-pub const PRIiLEAST64: &[u8; 4] = b"lli\0";
-pub const PRIoLEAST64: &[u8; 4] = b"llo\0";
-pub const PRIuLEAST64: &[u8; 4] = b"llu\0";
-pub const PRIxLEAST64: &[u8; 4] = b"llx\0";
-pub const PRIXLEAST64: &[u8; 4] = b"llX\0";
-pub const PRIdFAST8: &[u8; 4] = b"hhd\0";
-pub const PRIiFAST8: &[u8; 4] = b"hhi\0";
-pub const PRIoFAST8: &[u8; 4] = b"hho\0";
-pub const PRIuFAST8: &[u8; 4] = b"hhu\0";
-pub const PRIxFAST8: &[u8; 4] = b"hhx\0";
-pub const PRIXFAST8: &[u8; 4] = b"hhX\0";
-pub const PRIdFAST16: &[u8; 3] = b"hd\0";
-pub const PRIiFAST16: &[u8; 3] = b"hi\0";
-pub const PRIoFAST16: &[u8; 3] = b"ho\0";
-pub const PRIuFAST16: &[u8; 3] = b"hu\0";
-pub const PRIxFAST16: &[u8; 3] = b"hx\0";
-pub const PRIXFAST16: &[u8; 3] = b"hX\0";
-pub const PRIdFAST32: &[u8; 2] = b"d\0";
-pub const PRIiFAST32: &[u8; 2] = b"i\0";
-pub const PRIoFAST32: &[u8; 2] = b"o\0";
-pub const PRIuFAST32: &[u8; 2] = b"u\0";
-pub const PRIxFAST32: &[u8; 2] = b"x\0";
-pub const PRIXFAST32: &[u8; 2] = b"X\0";
-pub const PRIdFAST64: &[u8; 4] = b"lld\0";
-pub const PRIiFAST64: &[u8; 4] = b"lli\0";
-pub const PRIoFAST64: &[u8; 4] = b"llo\0";
-pub const PRIuFAST64: &[u8; 4] = b"llu\0";
-pub const PRIxFAST64: &[u8; 4] = b"llx\0";
-pub const PRIXFAST64: &[u8; 4] = b"llX\0";
+pub const PRIXLEAST64: &[u8; 3] = b"lX\0";
+pub const PRIXFAST8: &[u8; 2] = b"X\0";
+pub const PRIXFAST16: &[u8; 3] = b"lX\0";
+pub const PRIXFAST32: &[u8; 3] = b"lX\0";
+pub const PRIXFAST64: &[u8; 3] = b"lX\0";
+pub const PRIdMAX: &[u8; 3] = b"ld\0";
+pub const PRIiMAX: &[u8; 3] = b"li\0";
+pub const PRIoMAX: &[u8; 3] = b"lo\0";
+pub const PRIuMAX: &[u8; 3] = b"lu\0";
+pub const PRIxMAX: &[u8; 3] = b"lx\0";
+pub const PRIXMAX: &[u8; 3] = b"lX\0";
 pub const PRIdPTR: &[u8; 3] = b"ld\0";
 pub const PRIiPTR: &[u8; 3] = b"li\0";
 pub const PRIoPTR: &[u8; 3] = b"lo\0";
 pub const PRIuPTR: &[u8; 3] = b"lu\0";
 pub const PRIxPTR: &[u8; 3] = b"lx\0";
 pub const PRIXPTR: &[u8; 3] = b"lX\0";
-pub const PRIdMAX: &[u8; 3] = b"jd\0";
-pub const PRIiMAX: &[u8; 3] = b"ji\0";
-pub const PRIoMAX: &[u8; 3] = b"jo\0";
-pub const PRIuMAX: &[u8; 3] = b"ju\0";
-pub const PRIxMAX: &[u8; 3] = b"jx\0";
-pub const PRIXMAX: &[u8; 3] = b"jX\0";
 pub const SCNd8: &[u8; 4] = b"hhd\0";
-pub const SCNi8: &[u8; 4] = b"hhi\0";
-pub const SCNo8: &[u8; 4] = b"hho\0";
-pub const SCNu8: &[u8; 4] = b"hhu\0";
-pub const SCNx8: &[u8; 4] = b"hhx\0";
 pub const SCNd16: &[u8; 3] = b"hd\0";
-pub const SCNi16: &[u8; 3] = b"hi\0";
-pub const SCNo16: &[u8; 3] = b"ho\0";
-pub const SCNu16: &[u8; 3] = b"hu\0";
-pub const SCNx16: &[u8; 3] = b"hx\0";
 pub const SCNd32: &[u8; 2] = b"d\0";
-pub const SCNi32: &[u8; 2] = b"i\0";
-pub const SCNo32: &[u8; 2] = b"o\0";
-pub const SCNu32: &[u8; 2] = b"u\0";
-pub const SCNx32: &[u8; 2] = b"x\0";
-pub const SCNd64: &[u8; 4] = b"lld\0";
-pub const SCNi64: &[u8; 4] = b"lli\0";
-pub const SCNo64: &[u8; 4] = b"llo\0";
-pub const SCNu64: &[u8; 4] = b"llu\0";
-pub const SCNx64: &[u8; 4] = b"llx\0";
+pub const SCNd64: &[u8; 3] = b"ld\0";
 pub const SCNdLEAST8: &[u8; 4] = b"hhd\0";
-pub const SCNiLEAST8: &[u8; 4] = b"hhi\0";
-pub const SCNoLEAST8: &[u8; 4] = b"hho\0";
-pub const SCNuLEAST8: &[u8; 4] = b"hhu\0";
-pub const SCNxLEAST8: &[u8; 4] = b"hhx\0";
 pub const SCNdLEAST16: &[u8; 3] = b"hd\0";
-pub const SCNiLEAST16: &[u8; 3] = b"hi\0";
-pub const SCNoLEAST16: &[u8; 3] = b"ho\0";
-pub const SCNuLEAST16: &[u8; 3] = b"hu\0";
-pub const SCNxLEAST16: &[u8; 3] = b"hx\0";
 pub const SCNdLEAST32: &[u8; 2] = b"d\0";
-pub const SCNiLEAST32: &[u8; 2] = b"i\0";
-pub const SCNoLEAST32: &[u8; 2] = b"o\0";
-pub const SCNuLEAST32: &[u8; 2] = b"u\0";
-pub const SCNxLEAST32: &[u8; 2] = b"x\0";
-pub const SCNdLEAST64: &[u8; 4] = b"lld\0";
-pub const SCNiLEAST64: &[u8; 4] = b"lli\0";
-pub const SCNoLEAST64: &[u8; 4] = b"llo\0";
-pub const SCNuLEAST64: &[u8; 4] = b"llu\0";
-pub const SCNxLEAST64: &[u8; 4] = b"llx\0";
+pub const SCNdLEAST64: &[u8; 3] = b"ld\0";
 pub const SCNdFAST8: &[u8; 4] = b"hhd\0";
+pub const SCNdFAST16: &[u8; 3] = b"ld\0";
+pub const SCNdFAST32: &[u8; 3] = b"ld\0";
+pub const SCNdFAST64: &[u8; 3] = b"ld\0";
+pub const SCNi8: &[u8; 4] = b"hhi\0";
+pub const SCNi16: &[u8; 3] = b"hi\0";
+pub const SCNi32: &[u8; 2] = b"i\0";
+pub const SCNi64: &[u8; 3] = b"li\0";
+pub const SCNiLEAST8: &[u8; 4] = b"hhi\0";
+pub const SCNiLEAST16: &[u8; 3] = b"hi\0";
+pub const SCNiLEAST32: &[u8; 2] = b"i\0";
+pub const SCNiLEAST64: &[u8; 3] = b"li\0";
 pub const SCNiFAST8: &[u8; 4] = b"hhi\0";
-pub const SCNoFAST8: &[u8; 4] = b"hho\0";
+pub const SCNiFAST16: &[u8; 3] = b"li\0";
+pub const SCNiFAST32: &[u8; 3] = b"li\0";
+pub const SCNiFAST64: &[u8; 3] = b"li\0";
+pub const SCNu8: &[u8; 4] = b"hhu\0";
+pub const SCNu16: &[u8; 3] = b"hu\0";
+pub const SCNu32: &[u8; 2] = b"u\0";
+pub const SCNu64: &[u8; 3] = b"lu\0";
+pub const SCNuLEAST8: &[u8; 4] = b"hhu\0";
+pub const SCNuLEAST16: &[u8; 3] = b"hu\0";
+pub const SCNuLEAST32: &[u8; 2] = b"u\0";
+pub const SCNuLEAST64: &[u8; 3] = b"lu\0";
 pub const SCNuFAST8: &[u8; 4] = b"hhu\0";
+pub const SCNuFAST16: &[u8; 3] = b"lu\0";
+pub const SCNuFAST32: &[u8; 3] = b"lu\0";
+pub const SCNuFAST64: &[u8; 3] = b"lu\0";
+pub const SCNo8: &[u8; 4] = b"hho\0";
+pub const SCNo16: &[u8; 3] = b"ho\0";
+pub const SCNo32: &[u8; 2] = b"o\0";
+pub const SCNo64: &[u8; 3] = b"lo\0";
+pub const SCNoLEAST8: &[u8; 4] = b"hho\0";
+pub const SCNoLEAST16: &[u8; 3] = b"ho\0";
+pub const SCNoLEAST32: &[u8; 2] = b"o\0";
+pub const SCNoLEAST64: &[u8; 3] = b"lo\0";
+pub const SCNoFAST8: &[u8; 4] = b"hho\0";
+pub const SCNoFAST16: &[u8; 3] = b"lo\0";
+pub const SCNoFAST32: &[u8; 3] = b"lo\0";
+pub const SCNoFAST64: &[u8; 3] = b"lo\0";
+pub const SCNx8: &[u8; 4] = b"hhx\0";
+pub const SCNx16: &[u8; 3] = b"hx\0";
+pub const SCNx32: &[u8; 2] = b"x\0";
+pub const SCNx64: &[u8; 3] = b"lx\0";
+pub const SCNxLEAST8: &[u8; 4] = b"hhx\0";
+pub const SCNxLEAST16: &[u8; 3] = b"hx\0";
+pub const SCNxLEAST32: &[u8; 2] = b"x\0";
+pub const SCNxLEAST64: &[u8; 3] = b"lx\0";
 pub const SCNxFAST8: &[u8; 4] = b"hhx\0";
-pub const SCNdFAST16: &[u8; 3] = b"hd\0";
-pub const SCNiFAST16: &[u8; 3] = b"hi\0";
-pub const SCNoFAST16: &[u8; 3] = b"ho\0";
-pub const SCNuFAST16: &[u8; 3] = b"hu\0";
-pub const SCNxFAST16: &[u8; 3] = b"hx\0";
-pub const SCNdFAST32: &[u8; 2] = b"d\0";
-pub const SCNiFAST32: &[u8; 2] = b"i\0";
-pub const SCNoFAST32: &[u8; 2] = b"o\0";
-pub const SCNuFAST32: &[u8; 2] = b"u\0";
-pub const SCNxFAST32: &[u8; 2] = b"x\0";
-pub const SCNdFAST64: &[u8; 4] = b"lld\0";
-pub const SCNiFAST64: &[u8; 4] = b"lli\0";
-pub const SCNoFAST64: &[u8; 4] = b"llo\0";
-pub const SCNuFAST64: &[u8; 4] = b"llu\0";
-pub const SCNxFAST64: &[u8; 4] = b"llx\0";
+pub const SCNxFAST16: &[u8; 3] = b"lx\0";
+pub const SCNxFAST32: &[u8; 3] = b"lx\0";
+pub const SCNxFAST64: &[u8; 3] = b"lx\0";
+pub const SCNdMAX: &[u8; 3] = b"ld\0";
+pub const SCNiMAX: &[u8; 3] = b"li\0";
+pub const SCNoMAX: &[u8; 3] = b"lo\0";
+pub const SCNuMAX: &[u8; 3] = b"lu\0";
+pub const SCNxMAX: &[u8; 3] = b"lx\0";
 pub const SCNdPTR: &[u8; 3] = b"ld\0";
 pub const SCNiPTR: &[u8; 3] = b"li\0";
 pub const SCNoPTR: &[u8; 3] = b"lo\0";
 pub const SCNuPTR: &[u8; 3] = b"lu\0";
 pub const SCNxPTR: &[u8; 3] = b"lx\0";
-pub const SCNdMAX: &[u8; 3] = b"jd\0";
-pub const SCNiMAX: &[u8; 3] = b"ji\0";
-pub const SCNoMAX: &[u8; 3] = b"jo\0";
-pub const SCNuMAX: &[u8; 3] = b"ju\0";
-pub const SCNxMAX: &[u8; 3] = b"jx\0";
-pub const SCIP_EVENTTYPE_FORMAT: &[u8; 4] = b"llx\0";
+pub const SCIP_EVENTTYPE_FORMAT: &[u8; 3] = b"lx\0";
 pub const SCIP_VARTYPE_BINARY_CHAR: u8 = 66u8;
 pub const SCIP_VARTYPE_INTEGER_CHAR: u8 = 73u8;
 pub const SCIP_VARTYPE_CONTINUOUS_CHAR: u8 = 67u8;
@@ -1231,8 +704,10 @@ pub const SCIP_EXPRPRINT_ALL: u32 = 255;
 pub const SCIP_NLPPARAM_DEFAULT_VERBLEVEL: u32 = 0;
 pub const SCIP_DECOMP_LINKVAR: i32 = -1;
 pub const SCIP_DECOMP_LINKCONS: i32 = -2;
-pub const __GNUC_VA_LIST: u32 = 1;
-pub const __HAS_FIXED_CHK_PROTOTYPES: u32 = 1;
+pub const _STRING_H: u32 = 1;
+pub const _BITS_TYPES_LOCALE_T_H: u32 = 1;
+pub const _BITS_TYPES___LOCALE_T_H: u32 = 1;
+pub const _STRINGS_H: u32 = 1;
 pub const QUAD_EPSILON: f64 = 0.000000000001;
 pub const __bool_true_false_are_defined: u32 = 1;
 pub const true_: u32 = 1;
@@ -1251,498 +726,306 @@ pub const SYM_COMPUTETIMING_BEFOREPRESOL: u32 = 0;
 pub const SYM_COMPUTETIMING_DURINGPRESOL: u32 = 1;
 pub const SYM_COMPUTETIMING_AFTERPRESOL: u32 = 2;
 pub const ARTIFICIALVARNAMEPREFIX: &[u8; 14] = b"andresultant_\0";
+pub type __gnuc_va_list = __builtin_va_list;
+pub type __u_char = ::std::os::raw::c_uchar;
+pub type __u_short = ::std::os::raw::c_ushort;
+pub type __u_int = ::std::os::raw::c_uint;
+pub type __u_long = ::std::os::raw::c_ulong;
 pub type __int8_t = ::std::os::raw::c_schar;
 pub type __uint8_t = ::std::os::raw::c_uchar;
 pub type __int16_t = ::std::os::raw::c_short;
 pub type __uint16_t = ::std::os::raw::c_ushort;
 pub type __int32_t = ::std::os::raw::c_int;
 pub type __uint32_t = ::std::os::raw::c_uint;
-pub type __int64_t = ::std::os::raw::c_longlong;
-pub type __uint64_t = ::std::os::raw::c_ulonglong;
-pub type __darwin_intptr_t = ::std::os::raw::c_long;
-pub type __darwin_natural_t = ::std::os::raw::c_uint;
-pub type __darwin_ct_rune_t = ::std::os::raw::c_int;
+pub type __int64_t = ::std::os::raw::c_long;
+pub type __uint64_t = ::std::os::raw::c_ulong;
+pub type __int_least8_t = __int8_t;
+pub type __uint_least8_t = __uint8_t;
+pub type __int_least16_t = __int16_t;
+pub type __uint_least16_t = __uint16_t;
+pub type __int_least32_t = __int32_t;
+pub type __uint_least32_t = __uint32_t;
+pub type __int_least64_t = __int64_t;
+pub type __uint_least64_t = __uint64_t;
+pub type __quad_t = ::std::os::raw::c_long;
+pub type __u_quad_t = ::std::os::raw::c_ulong;
+pub type __intmax_t = ::std::os::raw::c_long;
+pub type __uintmax_t = ::std::os::raw::c_ulong;
+pub type __dev_t = ::std::os::raw::c_ulong;
+pub type __uid_t = ::std::os::raw::c_uint;
+pub type __gid_t = ::std::os::raw::c_uint;
+pub type __ino_t = ::std::os::raw::c_ulong;
+pub type __ino64_t = ::std::os::raw::c_ulong;
+pub type __mode_t = ::std::os::raw::c_uint;
+pub type __nlink_t = ::std::os::raw::c_ulong;
+pub type __off_t = ::std::os::raw::c_long;
+pub type __off64_t = ::std::os::raw::c_long;
+pub type __pid_t = ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __fsid_t {
+    pub __val: [::std::os::raw::c_int; 2usize],
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of __fsid_t"][::std::mem::size_of::<__fsid_t>() - 8usize];
+    ["Alignment of __fsid_t"][::std::mem::align_of::<__fsid_t>() - 4usize];
+    ["Offset of field: __fsid_t::__val"][::std::mem::offset_of!(__fsid_t, __val) - 0usize];
+};
+pub type __clock_t = ::std::os::raw::c_long;
+pub type __rlim_t = ::std::os::raw::c_ulong;
+pub type __rlim64_t = ::std::os::raw::c_ulong;
+pub type __id_t = ::std::os::raw::c_uint;
+pub type __time_t = ::std::os::raw::c_long;
+pub type __useconds_t = ::std::os::raw::c_uint;
+pub type __suseconds_t = ::std::os::raw::c_long;
+pub type __suseconds64_t = ::std::os::raw::c_long;
+pub type __daddr_t = ::std::os::raw::c_int;
+pub type __key_t = ::std::os::raw::c_int;
+pub type __clockid_t = ::std::os::raw::c_int;
+pub type __timer_t = *mut ::std::os::raw::c_void;
+pub type __blksize_t = ::std::os::raw::c_long;
+pub type __blkcnt_t = ::std::os::raw::c_long;
+pub type __blkcnt64_t = ::std::os::raw::c_long;
+pub type __fsblkcnt_t = ::std::os::raw::c_ulong;
+pub type __fsblkcnt64_t = ::std::os::raw::c_ulong;
+pub type __fsfilcnt_t = ::std::os::raw::c_ulong;
+pub type __fsfilcnt64_t = ::std::os::raw::c_ulong;
+pub type __fsword_t = ::std::os::raw::c_long;
+pub type __ssize_t = ::std::os::raw::c_long;
+pub type __syscall_slong_t = ::std::os::raw::c_long;
+pub type __syscall_ulong_t = ::std::os::raw::c_ulong;
+pub type __loff_t = __off64_t;
+pub type __caddr_t = *mut ::std::os::raw::c_char;
+pub type __intptr_t = ::std::os::raw::c_long;
+pub type __socklen_t = ::std::os::raw::c_uint;
+pub type __sig_atomic_t = ::std::os::raw::c_int;
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub union __mbstate_t {
-    pub __mbstate8: [::std::os::raw::c_char; 128usize],
-    pub _mbstateL: ::std::os::raw::c_longlong,
+pub struct __mbstate_t {
+    pub __count: ::std::os::raw::c_int,
+    pub __value: __mbstate_t__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union __mbstate_t__bindgen_ty_1 {
+    pub __wch: ::std::os::raw::c_uint,
+    pub __wchb: [::std::os::raw::c_char; 4usize],
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of __mbstate_t"][::std::mem::size_of::<__mbstate_t>() - 128usize];
-    ["Alignment of __mbstate_t"][::std::mem::align_of::<__mbstate_t>() - 8usize];
-    ["Offset of field: __mbstate_t::__mbstate8"]
-        [::std::mem::offset_of!(__mbstate_t, __mbstate8) - 0usize];
-    ["Offset of field: __mbstate_t::_mbstateL"]
-        [::std::mem::offset_of!(__mbstate_t, _mbstateL) - 0usize];
+    ["Size of __mbstate_t__bindgen_ty_1"]
+        [::std::mem::size_of::<__mbstate_t__bindgen_ty_1>() - 4usize];
+    ["Alignment of __mbstate_t__bindgen_ty_1"]
+        [::std::mem::align_of::<__mbstate_t__bindgen_ty_1>() - 4usize];
+    ["Offset of field: __mbstate_t__bindgen_ty_1::__wch"]
+        [::std::mem::offset_of!(__mbstate_t__bindgen_ty_1, __wch) - 0usize];
+    ["Offset of field: __mbstate_t__bindgen_ty_1::__wchb"]
+        [::std::mem::offset_of!(__mbstate_t__bindgen_ty_1, __wchb) - 0usize];
 };
-pub type __darwin_mbstate_t = __mbstate_t;
-pub type __darwin_ptrdiff_t = ::std::os::raw::c_long;
-pub type __darwin_size_t = ::std::os::raw::c_ulong;
-pub type __darwin_va_list = __builtin_va_list;
-pub type __darwin_wchar_t = ::std::os::raw::c_int;
-pub type __darwin_rune_t = __darwin_wchar_t;
-pub type __darwin_wint_t = ::std::os::raw::c_int;
-pub type __darwin_clock_t = ::std::os::raw::c_ulong;
-pub type __darwin_socklen_t = __uint32_t;
-pub type __darwin_ssize_t = ::std::os::raw::c_long;
-pub type __darwin_time_t = ::std::os::raw::c_long;
-pub type __darwin_blkcnt_t = __int64_t;
-pub type __darwin_blksize_t = __int32_t;
-pub type __darwin_dev_t = __int32_t;
-pub type __darwin_fsblkcnt_t = ::std::os::raw::c_uint;
-pub type __darwin_fsfilcnt_t = ::std::os::raw::c_uint;
-pub type __darwin_gid_t = __uint32_t;
-pub type __darwin_id_t = __uint32_t;
-pub type __darwin_ino64_t = __uint64_t;
-pub type __darwin_ino_t = __darwin_ino64_t;
-pub type __darwin_mach_port_name_t = __darwin_natural_t;
-pub type __darwin_mach_port_t = __darwin_mach_port_name_t;
-pub type __darwin_mode_t = __uint16_t;
-pub type __darwin_off_t = __int64_t;
-pub type __darwin_pid_t = __int32_t;
-pub type __darwin_sigset_t = __uint32_t;
-pub type __darwin_suseconds_t = __int32_t;
-pub type __darwin_uid_t = __uint32_t;
-pub type __darwin_useconds_t = __uint32_t;
-pub type __darwin_uuid_t = [::std::os::raw::c_uchar; 16usize];
-pub type __darwin_uuid_string_t = [::std::os::raw::c_char; 37usize];
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of __mbstate_t"][::std::mem::size_of::<__mbstate_t>() - 8usize];
+    ["Alignment of __mbstate_t"][::std::mem::align_of::<__mbstate_t>() - 4usize];
+    ["Offset of field: __mbstate_t::__count"]
+        [::std::mem::offset_of!(__mbstate_t, __count) - 0usize];
+    ["Offset of field: __mbstate_t::__value"]
+        [::std::mem::offset_of!(__mbstate_t, __value) - 4usize];
+};
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_pthread_handler_rec {
-    pub __routine: ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
-    pub __arg: *mut ::std::os::raw::c_void,
-    pub __next: *mut __darwin_pthread_handler_rec,
+#[derive(Copy, Clone)]
+pub struct _G_fpos_t {
+    pub __pos: __off_t,
+    pub __state: __mbstate_t,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of __darwin_pthread_handler_rec"]
-        [::std::mem::size_of::<__darwin_pthread_handler_rec>() - 24usize];
-    ["Alignment of __darwin_pthread_handler_rec"]
-        [::std::mem::align_of::<__darwin_pthread_handler_rec>() - 8usize];
-    ["Offset of field: __darwin_pthread_handler_rec::__routine"]
-        [::std::mem::offset_of!(__darwin_pthread_handler_rec, __routine) - 0usize];
-    ["Offset of field: __darwin_pthread_handler_rec::__arg"]
-        [::std::mem::offset_of!(__darwin_pthread_handler_rec, __arg) - 8usize];
-    ["Offset of field: __darwin_pthread_handler_rec::__next"]
-        [::std::mem::offset_of!(__darwin_pthread_handler_rec, __next) - 16usize];
+    ["Size of _G_fpos_t"][::std::mem::size_of::<_G_fpos_t>() - 16usize];
+    ["Alignment of _G_fpos_t"][::std::mem::align_of::<_G_fpos_t>() - 8usize];
+    ["Offset of field: _G_fpos_t::__pos"][::std::mem::offset_of!(_G_fpos_t, __pos) - 0usize];
+    ["Offset of field: _G_fpos_t::__state"][::std::mem::offset_of!(_G_fpos_t, __state) - 8usize];
 };
+pub type __fpos_t = _G_fpos_t;
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_attr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 56usize],
+#[derive(Copy, Clone)]
+pub struct _G_fpos64_t {
+    pub __pos: __off64_t,
+    pub __state: __mbstate_t,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of _opaque_pthread_attr_t"][::std::mem::size_of::<_opaque_pthread_attr_t>() - 64usize];
-    ["Alignment of _opaque_pthread_attr_t"]
-        [::std::mem::align_of::<_opaque_pthread_attr_t>() - 8usize];
-    ["Offset of field: _opaque_pthread_attr_t::__sig"]
-        [::std::mem::offset_of!(_opaque_pthread_attr_t, __sig) - 0usize];
-    ["Offset of field: _opaque_pthread_attr_t::__opaque"]
-        [::std::mem::offset_of!(_opaque_pthread_attr_t, __opaque) - 8usize];
+    ["Size of _G_fpos64_t"][::std::mem::size_of::<_G_fpos64_t>() - 16usize];
+    ["Alignment of _G_fpos64_t"][::std::mem::align_of::<_G_fpos64_t>() - 8usize];
+    ["Offset of field: _G_fpos64_t::__pos"][::std::mem::offset_of!(_G_fpos64_t, __pos) - 0usize];
+    ["Offset of field: _G_fpos64_t::__state"]
+        [::std::mem::offset_of!(_G_fpos64_t, __state) - 8usize];
 };
+pub type __fpos64_t = _G_fpos64_t;
+pub type __FILE = _IO_FILE;
+pub type FILE = _IO_FILE;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_cond_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 40usize],
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of _opaque_pthread_cond_t"][::std::mem::size_of::<_opaque_pthread_cond_t>() - 48usize];
-    ["Alignment of _opaque_pthread_cond_t"]
-        [::std::mem::align_of::<_opaque_pthread_cond_t>() - 8usize];
-    ["Offset of field: _opaque_pthread_cond_t::__sig"]
-        [::std::mem::offset_of!(_opaque_pthread_cond_t, __sig) - 0usize];
-    ["Offset of field: _opaque_pthread_cond_t::__opaque"]
-        [::std::mem::offset_of!(_opaque_pthread_cond_t, __opaque) - 8usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_condattr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 8usize],
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of _opaque_pthread_condattr_t"]
-        [::std::mem::size_of::<_opaque_pthread_condattr_t>() - 16usize];
-    ["Alignment of _opaque_pthread_condattr_t"]
-        [::std::mem::align_of::<_opaque_pthread_condattr_t>() - 8usize];
-    ["Offset of field: _opaque_pthread_condattr_t::__sig"]
-        [::std::mem::offset_of!(_opaque_pthread_condattr_t, __sig) - 0usize];
-    ["Offset of field: _opaque_pthread_condattr_t::__opaque"]
-        [::std::mem::offset_of!(_opaque_pthread_condattr_t, __opaque) - 8usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_mutex_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 56usize],
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of _opaque_pthread_mutex_t"][::std::mem::size_of::<_opaque_pthread_mutex_t>() - 64usize];
-    ["Alignment of _opaque_pthread_mutex_t"]
-        [::std::mem::align_of::<_opaque_pthread_mutex_t>() - 8usize];
-    ["Offset of field: _opaque_pthread_mutex_t::__sig"]
-        [::std::mem::offset_of!(_opaque_pthread_mutex_t, __sig) - 0usize];
-    ["Offset of field: _opaque_pthread_mutex_t::__opaque"]
-        [::std::mem::offset_of!(_opaque_pthread_mutex_t, __opaque) - 8usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_mutexattr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 8usize],
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of _opaque_pthread_mutexattr_t"]
-        [::std::mem::size_of::<_opaque_pthread_mutexattr_t>() - 16usize];
-    ["Alignment of _opaque_pthread_mutexattr_t"]
-        [::std::mem::align_of::<_opaque_pthread_mutexattr_t>() - 8usize];
-    ["Offset of field: _opaque_pthread_mutexattr_t::__sig"]
-        [::std::mem::offset_of!(_opaque_pthread_mutexattr_t, __sig) - 0usize];
-    ["Offset of field: _opaque_pthread_mutexattr_t::__opaque"]
-        [::std::mem::offset_of!(_opaque_pthread_mutexattr_t, __opaque) - 8usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_once_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 8usize],
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of _opaque_pthread_once_t"][::std::mem::size_of::<_opaque_pthread_once_t>() - 16usize];
-    ["Alignment of _opaque_pthread_once_t"]
-        [::std::mem::align_of::<_opaque_pthread_once_t>() - 8usize];
-    ["Offset of field: _opaque_pthread_once_t::__sig"]
-        [::std::mem::offset_of!(_opaque_pthread_once_t, __sig) - 0usize];
-    ["Offset of field: _opaque_pthread_once_t::__opaque"]
-        [::std::mem::offset_of!(_opaque_pthread_once_t, __opaque) - 8usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_rwlock_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 192usize],
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of _opaque_pthread_rwlock_t"]
-        [::std::mem::size_of::<_opaque_pthread_rwlock_t>() - 200usize];
-    ["Alignment of _opaque_pthread_rwlock_t"]
-        [::std::mem::align_of::<_opaque_pthread_rwlock_t>() - 8usize];
-    ["Offset of field: _opaque_pthread_rwlock_t::__sig"]
-        [::std::mem::offset_of!(_opaque_pthread_rwlock_t, __sig) - 0usize];
-    ["Offset of field: _opaque_pthread_rwlock_t::__opaque"]
-        [::std::mem::offset_of!(_opaque_pthread_rwlock_t, __opaque) - 8usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_rwlockattr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 16usize],
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of _opaque_pthread_rwlockattr_t"]
-        [::std::mem::size_of::<_opaque_pthread_rwlockattr_t>() - 24usize];
-    ["Alignment of _opaque_pthread_rwlockattr_t"]
-        [::std::mem::align_of::<_opaque_pthread_rwlockattr_t>() - 8usize];
-    ["Offset of field: _opaque_pthread_rwlockattr_t::__sig"]
-        [::std::mem::offset_of!(_opaque_pthread_rwlockattr_t, __sig) - 0usize];
-    ["Offset of field: _opaque_pthread_rwlockattr_t::__opaque"]
-        [::std::mem::offset_of!(_opaque_pthread_rwlockattr_t, __opaque) - 8usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __cleanup_stack: *mut __darwin_pthread_handler_rec,
-    pub __opaque: [::std::os::raw::c_char; 8176usize],
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of _opaque_pthread_t"][::std::mem::size_of::<_opaque_pthread_t>() - 8192usize];
-    ["Alignment of _opaque_pthread_t"][::std::mem::align_of::<_opaque_pthread_t>() - 8usize];
-    ["Offset of field: _opaque_pthread_t::__sig"]
-        [::std::mem::offset_of!(_opaque_pthread_t, __sig) - 0usize];
-    ["Offset of field: _opaque_pthread_t::__cleanup_stack"]
-        [::std::mem::offset_of!(_opaque_pthread_t, __cleanup_stack) - 8usize];
-    ["Offset of field: _opaque_pthread_t::__opaque"]
-        [::std::mem::offset_of!(_opaque_pthread_t, __opaque) - 16usize];
-};
-pub type __darwin_pthread_attr_t = _opaque_pthread_attr_t;
-pub type __darwin_pthread_cond_t = _opaque_pthread_cond_t;
-pub type __darwin_pthread_condattr_t = _opaque_pthread_condattr_t;
-pub type __darwin_pthread_key_t = ::std::os::raw::c_ulong;
-pub type __darwin_pthread_mutex_t = _opaque_pthread_mutex_t;
-pub type __darwin_pthread_mutexattr_t = _opaque_pthread_mutexattr_t;
-pub type __darwin_pthread_once_t = _opaque_pthread_once_t;
-pub type __darwin_pthread_rwlock_t = _opaque_pthread_rwlock_t;
-pub type __darwin_pthread_rwlockattr_t = _opaque_pthread_rwlockattr_t;
-pub type __darwin_pthread_t = *mut _opaque_pthread_t;
-pub type __darwin_nl_item = ::std::os::raw::c_int;
-pub type __darwin_wctrans_t = ::std::os::raw::c_int;
-pub type __darwin_wctype_t = __uint32_t;
-pub type u_int8_t = ::std::os::raw::c_uchar;
-pub type u_int16_t = ::std::os::raw::c_ushort;
-pub type u_int32_t = ::std::os::raw::c_uint;
-pub type u_int64_t = ::std::os::raw::c_ulonglong;
-pub type register_t = i64;
-pub type user_addr_t = u_int64_t;
-pub type user_size_t = u_int64_t;
-pub type user_ssize_t = i64;
-pub type user_long_t = i64;
-pub type user_ulong_t = u_int64_t;
-pub type user_time_t = i64;
-pub type user_off_t = i64;
-pub type syscall_arg_t = u_int64_t;
-pub type va_list = __darwin_va_list;
-unsafe extern "C" {
-    pub fn renameat(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
-        arg4: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn renamex_np(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_uint,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn renameatx_np(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
-        arg4: *const ::std::os::raw::c_char,
-        arg5: ::std::os::raw::c_uint,
-    ) -> ::std::os::raw::c_int;
-}
-pub type fpos_t = __darwin_off_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __sbuf {
-    pub _base: *mut ::std::os::raw::c_uchar,
-    pub _size: ::std::os::raw::c_int,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __sbuf"][::std::mem::size_of::<__sbuf>() - 16usize];
-    ["Alignment of __sbuf"][::std::mem::align_of::<__sbuf>() - 8usize];
-    ["Offset of field: __sbuf::_base"][::std::mem::offset_of!(__sbuf, _base) - 0usize];
-    ["Offset of field: __sbuf::_size"][::std::mem::offset_of!(__sbuf, _size) - 8usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __sFILEX {
+pub struct _IO_marker {
     _unused: [u8; 0],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct __sFILE {
-    pub _p: *mut ::std::os::raw::c_uchar,
-    pub _r: ::std::os::raw::c_int,
-    pub _w: ::std::os::raw::c_int,
-    pub _flags: ::std::os::raw::c_short,
-    pub _file: ::std::os::raw::c_short,
-    pub _bf: __sbuf,
-    pub _lbfsize: ::std::os::raw::c_int,
-    pub _cookie: *mut ::std::os::raw::c_void,
-    pub _close: ::std::option::Option<
-        unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
-    >,
-    pub _read: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: *mut ::std::os::raw::c_char,
-            arg3: ::std::os::raw::c_int,
-        ) -> ::std::os::raw::c_int,
-    >,
-    pub _seek: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: fpos_t,
-            arg3: ::std::os::raw::c_int,
-        ) -> fpos_t,
-    >,
-    pub _write: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_char,
-            arg3: ::std::os::raw::c_int,
-        ) -> ::std::os::raw::c_int,
-    >,
-    pub _ub: __sbuf,
-    pub _extra: *mut __sFILEX,
-    pub _ur: ::std::os::raw::c_int,
-    pub _ubuf: [::std::os::raw::c_uchar; 3usize],
-    pub _nbuf: [::std::os::raw::c_uchar; 1usize],
-    pub _lb: __sbuf,
-    pub _blksize: ::std::os::raw::c_int,
-    pub _offset: fpos_t,
+pub struct _IO_codecvt {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _IO_wide_data {
+    _unused: [u8; 0],
+}
+pub type _IO_lock_t = ::std::os::raw::c_void;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _IO_FILE {
+    pub _flags: ::std::os::raw::c_int,
+    pub _IO_read_ptr: *mut ::std::os::raw::c_char,
+    pub _IO_read_end: *mut ::std::os::raw::c_char,
+    pub _IO_read_base: *mut ::std::os::raw::c_char,
+    pub _IO_write_base: *mut ::std::os::raw::c_char,
+    pub _IO_write_ptr: *mut ::std::os::raw::c_char,
+    pub _IO_write_end: *mut ::std::os::raw::c_char,
+    pub _IO_buf_base: *mut ::std::os::raw::c_char,
+    pub _IO_buf_end: *mut ::std::os::raw::c_char,
+    pub _IO_save_base: *mut ::std::os::raw::c_char,
+    pub _IO_backup_base: *mut ::std::os::raw::c_char,
+    pub _IO_save_end: *mut ::std::os::raw::c_char,
+    pub _markers: *mut _IO_marker,
+    pub _chain: *mut _IO_FILE,
+    pub _fileno: ::std::os::raw::c_int,
+    pub _flags2: ::std::os::raw::c_int,
+    pub _old_offset: __off_t,
+    pub _cur_column: ::std::os::raw::c_ushort,
+    pub _vtable_offset: ::std::os::raw::c_schar,
+    pub _shortbuf: [::std::os::raw::c_char; 1usize],
+    pub _lock: *mut _IO_lock_t,
+    pub _offset: __off64_t,
+    pub _codecvt: *mut _IO_codecvt,
+    pub _wide_data: *mut _IO_wide_data,
+    pub _freeres_list: *mut _IO_FILE,
+    pub _freeres_buf: *mut ::std::os::raw::c_void,
+    pub __pad5: usize,
+    pub _mode: ::std::os::raw::c_int,
+    pub _unused2: [::std::os::raw::c_char; 20usize],
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of __sFILE"][::std::mem::size_of::<__sFILE>() - 152usize];
-    ["Alignment of __sFILE"][::std::mem::align_of::<__sFILE>() - 8usize];
-    ["Offset of field: __sFILE::_p"][::std::mem::offset_of!(__sFILE, _p) - 0usize];
-    ["Offset of field: __sFILE::_r"][::std::mem::offset_of!(__sFILE, _r) - 8usize];
-    ["Offset of field: __sFILE::_w"][::std::mem::offset_of!(__sFILE, _w) - 12usize];
-    ["Offset of field: __sFILE::_flags"][::std::mem::offset_of!(__sFILE, _flags) - 16usize];
-    ["Offset of field: __sFILE::_file"][::std::mem::offset_of!(__sFILE, _file) - 18usize];
-    ["Offset of field: __sFILE::_bf"][::std::mem::offset_of!(__sFILE, _bf) - 24usize];
-    ["Offset of field: __sFILE::_lbfsize"][::std::mem::offset_of!(__sFILE, _lbfsize) - 40usize];
-    ["Offset of field: __sFILE::_cookie"][::std::mem::offset_of!(__sFILE, _cookie) - 48usize];
-    ["Offset of field: __sFILE::_close"][::std::mem::offset_of!(__sFILE, _close) - 56usize];
-    ["Offset of field: __sFILE::_read"][::std::mem::offset_of!(__sFILE, _read) - 64usize];
-    ["Offset of field: __sFILE::_seek"][::std::mem::offset_of!(__sFILE, _seek) - 72usize];
-    ["Offset of field: __sFILE::_write"][::std::mem::offset_of!(__sFILE, _write) - 80usize];
-    ["Offset of field: __sFILE::_ub"][::std::mem::offset_of!(__sFILE, _ub) - 88usize];
-    ["Offset of field: __sFILE::_extra"][::std::mem::offset_of!(__sFILE, _extra) - 104usize];
-    ["Offset of field: __sFILE::_ur"][::std::mem::offset_of!(__sFILE, _ur) - 112usize];
-    ["Offset of field: __sFILE::_ubuf"][::std::mem::offset_of!(__sFILE, _ubuf) - 116usize];
-    ["Offset of field: __sFILE::_nbuf"][::std::mem::offset_of!(__sFILE, _nbuf) - 119usize];
-    ["Offset of field: __sFILE::_lb"][::std::mem::offset_of!(__sFILE, _lb) - 120usize];
-    ["Offset of field: __sFILE::_blksize"][::std::mem::offset_of!(__sFILE, _blksize) - 136usize];
-    ["Offset of field: __sFILE::_offset"][::std::mem::offset_of!(__sFILE, _offset) - 144usize];
+    ["Size of _IO_FILE"][::std::mem::size_of::<_IO_FILE>() - 216usize];
+    ["Alignment of _IO_FILE"][::std::mem::align_of::<_IO_FILE>() - 8usize];
+    ["Offset of field: _IO_FILE::_flags"][::std::mem::offset_of!(_IO_FILE, _flags) - 0usize];
+    ["Offset of field: _IO_FILE::_IO_read_ptr"]
+        [::std::mem::offset_of!(_IO_FILE, _IO_read_ptr) - 8usize];
+    ["Offset of field: _IO_FILE::_IO_read_end"]
+        [::std::mem::offset_of!(_IO_FILE, _IO_read_end) - 16usize];
+    ["Offset of field: _IO_FILE::_IO_read_base"]
+        [::std::mem::offset_of!(_IO_FILE, _IO_read_base) - 24usize];
+    ["Offset of field: _IO_FILE::_IO_write_base"]
+        [::std::mem::offset_of!(_IO_FILE, _IO_write_base) - 32usize];
+    ["Offset of field: _IO_FILE::_IO_write_ptr"]
+        [::std::mem::offset_of!(_IO_FILE, _IO_write_ptr) - 40usize];
+    ["Offset of field: _IO_FILE::_IO_write_end"]
+        [::std::mem::offset_of!(_IO_FILE, _IO_write_end) - 48usize];
+    ["Offset of field: _IO_FILE::_IO_buf_base"]
+        [::std::mem::offset_of!(_IO_FILE, _IO_buf_base) - 56usize];
+    ["Offset of field: _IO_FILE::_IO_buf_end"]
+        [::std::mem::offset_of!(_IO_FILE, _IO_buf_end) - 64usize];
+    ["Offset of field: _IO_FILE::_IO_save_base"]
+        [::std::mem::offset_of!(_IO_FILE, _IO_save_base) - 72usize];
+    ["Offset of field: _IO_FILE::_IO_backup_base"]
+        [::std::mem::offset_of!(_IO_FILE, _IO_backup_base) - 80usize];
+    ["Offset of field: _IO_FILE::_IO_save_end"]
+        [::std::mem::offset_of!(_IO_FILE, _IO_save_end) - 88usize];
+    ["Offset of field: _IO_FILE::_markers"][::std::mem::offset_of!(_IO_FILE, _markers) - 96usize];
+    ["Offset of field: _IO_FILE::_chain"][::std::mem::offset_of!(_IO_FILE, _chain) - 104usize];
+    ["Offset of field: _IO_FILE::_fileno"][::std::mem::offset_of!(_IO_FILE, _fileno) - 112usize];
+    ["Offset of field: _IO_FILE::_flags2"][::std::mem::offset_of!(_IO_FILE, _flags2) - 116usize];
+    ["Offset of field: _IO_FILE::_old_offset"]
+        [::std::mem::offset_of!(_IO_FILE, _old_offset) - 120usize];
+    ["Offset of field: _IO_FILE::_cur_column"]
+        [::std::mem::offset_of!(_IO_FILE, _cur_column) - 128usize];
+    ["Offset of field: _IO_FILE::_vtable_offset"]
+        [::std::mem::offset_of!(_IO_FILE, _vtable_offset) - 130usize];
+    ["Offset of field: _IO_FILE::_shortbuf"]
+        [::std::mem::offset_of!(_IO_FILE, _shortbuf) - 131usize];
+    ["Offset of field: _IO_FILE::_lock"][::std::mem::offset_of!(_IO_FILE, _lock) - 136usize];
+    ["Offset of field: _IO_FILE::_offset"][::std::mem::offset_of!(_IO_FILE, _offset) - 144usize];
+    ["Offset of field: _IO_FILE::_codecvt"][::std::mem::offset_of!(_IO_FILE, _codecvt) - 152usize];
+    ["Offset of field: _IO_FILE::_wide_data"]
+        [::std::mem::offset_of!(_IO_FILE, _wide_data) - 160usize];
+    ["Offset of field: _IO_FILE::_freeres_list"]
+        [::std::mem::offset_of!(_IO_FILE, _freeres_list) - 168usize];
+    ["Offset of field: _IO_FILE::_freeres_buf"]
+        [::std::mem::offset_of!(_IO_FILE, _freeres_buf) - 176usize];
+    ["Offset of field: _IO_FILE::__pad5"][::std::mem::offset_of!(_IO_FILE, __pad5) - 184usize];
+    ["Offset of field: _IO_FILE::_mode"][::std::mem::offset_of!(_IO_FILE, _mode) - 192usize];
+    ["Offset of field: _IO_FILE::_unused2"][::std::mem::offset_of!(_IO_FILE, _unused2) - 196usize];
 };
-pub type FILE = __sFILE;
+pub type cookie_read_function_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        __cookie: *mut ::std::os::raw::c_void,
+        __buf: *mut ::std::os::raw::c_char,
+        __nbytes: usize,
+    ) -> __ssize_t,
+>;
+pub type cookie_write_function_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        __cookie: *mut ::std::os::raw::c_void,
+        __buf: *const ::std::os::raw::c_char,
+        __nbytes: usize,
+    ) -> __ssize_t,
+>;
+pub type cookie_seek_function_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        __cookie: *mut ::std::os::raw::c_void,
+        __pos: *mut __off64_t,
+        __w: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int,
+>;
+pub type cookie_close_function_t = ::std::option::Option<
+    unsafe extern "C" fn(__cookie: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
+>;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _IO_cookie_io_functions_t {
+    pub read: cookie_read_function_t,
+    pub write: cookie_write_function_t,
+    pub seek: cookie_seek_function_t,
+    pub close: cookie_close_function_t,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of _IO_cookie_io_functions_t"]
+        [::std::mem::size_of::<_IO_cookie_io_functions_t>() - 32usize];
+    ["Alignment of _IO_cookie_io_functions_t"]
+        [::std::mem::align_of::<_IO_cookie_io_functions_t>() - 8usize];
+    ["Offset of field: _IO_cookie_io_functions_t::read"]
+        [::std::mem::offset_of!(_IO_cookie_io_functions_t, read) - 0usize];
+    ["Offset of field: _IO_cookie_io_functions_t::write"]
+        [::std::mem::offset_of!(_IO_cookie_io_functions_t, write) - 8usize];
+    ["Offset of field: _IO_cookie_io_functions_t::seek"]
+        [::std::mem::offset_of!(_IO_cookie_io_functions_t, seek) - 16usize];
+    ["Offset of field: _IO_cookie_io_functions_t::close"]
+        [::std::mem::offset_of!(_IO_cookie_io_functions_t, close) - 24usize];
+};
+pub type cookie_io_functions_t = _IO_cookie_io_functions_t;
+pub type va_list = __gnuc_va_list;
+pub type off_t = __off_t;
+pub type fpos_t = __fpos_t;
 unsafe extern "C" {
-    pub static mut __stdinp: *mut FILE;
+    pub static mut stdin: *mut FILE;
 }
 unsafe extern "C" {
-    pub static mut __stdoutp: *mut FILE;
+    pub static mut stdout: *mut FILE;
 }
 unsafe extern "C" {
-    pub static mut __stderrp: *mut FILE;
+    pub static mut stderr: *mut FILE;
 }
 unsafe extern "C" {
-    pub fn clearerr(arg1: *mut FILE);
-}
-unsafe extern "C" {
-    pub fn fclose(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn feof(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn ferror(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn fflush(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn fgetc(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn fgetpos(arg1: *mut FILE, arg2: *mut fpos_t) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn fgets(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
-        arg3: *mut FILE,
-    ) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn fopen(
-        __filename: *const ::std::os::raw::c_char,
-        __mode: *const ::std::os::raw::c_char,
-    ) -> *mut FILE;
-}
-unsafe extern "C" {
-    pub fn fprintf(
-        arg1: *mut FILE,
-        arg2: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn fputc(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn fputs(arg1: *const ::std::os::raw::c_char, arg2: *mut FILE) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn fread(
-        __ptr: *mut ::std::os::raw::c_void,
-        __size: ::std::os::raw::c_ulong,
-        __nitems: ::std::os::raw::c_ulong,
-        __stream: *mut FILE,
-    ) -> ::std::os::raw::c_ulong;
-}
-unsafe extern "C" {
-    pub fn freopen(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut FILE,
-    ) -> *mut FILE;
-}
-unsafe extern "C" {
-    pub fn fscanf(
-        arg1: *mut FILE,
-        arg2: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn fseek(
-        arg1: *mut FILE,
-        arg2: ::std::os::raw::c_long,
-        arg3: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn fsetpos(arg1: *mut FILE, arg2: *const fpos_t) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn ftell(arg1: *mut FILE) -> ::std::os::raw::c_long;
-}
-unsafe extern "C" {
-    pub fn fwrite(
-        __ptr: *const ::std::os::raw::c_void,
-        __size: ::std::os::raw::c_ulong,
-        __nitems: ::std::os::raw::c_ulong,
-        __stream: *mut FILE,
-    ) -> ::std::os::raw::c_ulong;
-}
-unsafe extern "C" {
-    pub fn getc(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn getchar() -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn gets(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn perror(arg1: *const ::std::os::raw::c_char);
-}
-unsafe extern "C" {
-    pub fn printf(arg1: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn putc(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn putchar(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn puts(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn remove(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+    pub fn remove(__filename: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
     pub fn rename(
@@ -1751,35 +1034,15 @@ unsafe extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn rewind(arg1: *mut FILE);
-}
-unsafe extern "C" {
-    pub fn scanf(arg1: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn setbuf(arg1: *mut FILE, arg2: *mut ::std::os::raw::c_char);
-}
-unsafe extern "C" {
-    pub fn setvbuf(
-        arg1: *mut FILE,
-        arg2: *mut ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
-        arg4: usize,
+    pub fn renameat(
+        __oldfd: ::std::os::raw::c_int,
+        __old: *const ::std::os::raw::c_char,
+        __newfd: ::std::os::raw::c_int,
+        __new: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn sprintf(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn sscanf(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
+    pub fn fclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
     pub fn tmpfile() -> *mut FILE;
@@ -1788,2639 +1051,1810 @@ unsafe extern "C" {
     pub fn tmpnam(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn ungetc(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn vfprintf(
-        arg1: *mut FILE,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: __builtin_va_list,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn vprintf(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: __builtin_va_list,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn vsprintf(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: __builtin_va_list,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn ctermid(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn fdopen(arg1: ::std::os::raw::c_int, arg2: *const ::std::os::raw::c_char) -> *mut FILE;
-}
-unsafe extern "C" {
-    pub fn fileno(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn pclose(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn popen(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-    ) -> *mut FILE;
-}
-unsafe extern "C" {
-    pub fn __srget(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn __svfscanf(
-        arg1: *mut FILE,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: va_list,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn __swbuf(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn flockfile(arg1: *mut FILE);
-}
-unsafe extern "C" {
-    pub fn ftrylockfile(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn funlockfile(arg1: *mut FILE);
-}
-unsafe extern "C" {
-    pub fn getc_unlocked(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn getchar_unlocked() -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn putc_unlocked(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn putchar_unlocked(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn getw(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn putw(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn tmpnam_r(__s: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     pub fn tempnam(
         __dir: *const ::std::os::raw::c_char,
-        __prefix: *const ::std::os::raw::c_char,
+        __pfx: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
-pub type off_t = __darwin_off_t;
 unsafe extern "C" {
-    pub fn fseeko(
+    pub fn fflush(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn fflush_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn fopen(
+        __filename: *const ::std::os::raw::c_char,
+        __modes: *const ::std::os::raw::c_char,
+    ) -> *mut FILE;
+}
+unsafe extern "C" {
+    pub fn freopen(
+        __filename: *const ::std::os::raw::c_char,
+        __modes: *const ::std::os::raw::c_char,
         __stream: *mut FILE,
-        __offset: off_t,
-        __whence: ::std::os::raw::c_int,
+    ) -> *mut FILE;
+}
+unsafe extern "C" {
+    pub fn fdopen(__fd: ::std::os::raw::c_int, __modes: *const ::std::os::raw::c_char)
+    -> *mut FILE;
+}
+unsafe extern "C" {
+    pub fn fopencookie(
+        __magic_cookie: *mut ::std::os::raw::c_void,
+        __modes: *const ::std::os::raw::c_char,
+        __io_funcs: cookie_io_functions_t,
+    ) -> *mut FILE;
+}
+unsafe extern "C" {
+    pub fn fmemopen(
+        __s: *mut ::std::os::raw::c_void,
+        __len: usize,
+        __modes: *const ::std::os::raw::c_char,
+    ) -> *mut FILE;
+}
+unsafe extern "C" {
+    pub fn open_memstream(
+        __bufloc: *mut *mut ::std::os::raw::c_char,
+        __sizeloc: *mut usize,
+    ) -> *mut FILE;
+}
+unsafe extern "C" {
+    pub fn setbuf(__stream: *mut FILE, __buf: *mut ::std::os::raw::c_char);
+}
+unsafe extern "C" {
+    pub fn setvbuf(
+        __stream: *mut FILE,
+        __buf: *mut ::std::os::raw::c_char,
+        __modes: ::std::os::raw::c_int,
+        __n: usize,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn ftello(__stream: *mut FILE) -> off_t;
+    pub fn setbuffer(__stream: *mut FILE, __buf: *mut ::std::os::raw::c_char, __size: usize);
+}
+unsafe extern "C" {
+    pub fn setlinebuf(__stream: *mut FILE);
+}
+unsafe extern "C" {
+    pub fn fprintf(
+        __stream: *mut FILE,
+        __format: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn printf(__format: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn sprintf(
+        __s: *mut ::std::os::raw::c_char,
+        __format: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn vfprintf(
+        __s: *mut FILE,
+        __format: *const ::std::os::raw::c_char,
+        __arg: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn vprintf(
+        __format: *const ::std::os::raw::c_char,
+        __arg: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn vsprintf(
+        __s: *mut ::std::os::raw::c_char,
+        __format: *const ::std::os::raw::c_char,
+        __arg: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
     pub fn snprintf(
-        __str: *mut ::std::os::raw::c_char,
-        __size: ::std::os::raw::c_ulong,
+        __s: *mut ::std::os::raw::c_char,
+        __maxlen: ::std::os::raw::c_ulong,
+        __format: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn vsnprintf(
+        __s: *mut ::std::os::raw::c_char,
+        __maxlen: ::std::os::raw::c_ulong,
+        __format: *const ::std::os::raw::c_char,
+        __arg: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn vasprintf(
+        __ptr: *mut *mut ::std::os::raw::c_char,
+        __f: *const ::std::os::raw::c_char,
+        __arg: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn __asprintf(
+        __ptr: *mut *mut ::std::os::raw::c_char,
+        __fmt: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn asprintf(
+        __ptr: *mut *mut ::std::os::raw::c_char,
+        __fmt: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn vdprintf(
+        __fd: ::std::os::raw::c_int,
+        __fmt: *const ::std::os::raw::c_char,
+        __arg: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn dprintf(
+        __fd: ::std::os::raw::c_int,
+        __fmt: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn fscanf(
+        __stream: *mut FILE,
+        __format: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn scanf(__format: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn sscanf(
+        __s: *const ::std::os::raw::c_char,
+        __format: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+pub type _Float32 = f32;
+pub type _Float64 = f64;
+pub type _Float32x = f64;
+pub type _Float64x = u128;
+unsafe extern "C" {
+    #[link_name = "\u{1}__isoc99_fscanf"]
+    pub fn fscanf1(
+        __stream: *mut FILE,
+        __format: *const ::std::os::raw::c_char,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    #[link_name = "\u{1}__isoc99_scanf"]
+    pub fn scanf1(__format: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    #[link_name = "\u{1}__isoc99_sscanf"]
+    pub fn sscanf1(
+        __s: *const ::std::os::raw::c_char,
         __format: *const ::std::os::raw::c_char,
         ...
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
     pub fn vfscanf(
-        __stream: *mut FILE,
+        __s: *mut FILE,
         __format: *const ::std::os::raw::c_char,
-        arg1: __builtin_va_list,
+        __arg: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
     pub fn vscanf(
         __format: *const ::std::os::raw::c_char,
-        arg1: __builtin_va_list,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn vsnprintf(
-        __str: *mut ::std::os::raw::c_char,
-        __size: ::std::os::raw::c_ulong,
-        __format: *const ::std::os::raw::c_char,
-        arg1: __builtin_va_list,
+        __arg: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
     pub fn vsscanf(
-        __str: *const ::std::os::raw::c_char,
+        __s: *const ::std::os::raw::c_char,
         __format: *const ::std::os::raw::c_char,
-        arg1: __builtin_va_list,
+        __arg: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn dprintf(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_char,
-        ...
+    #[link_name = "\u{1}__isoc99_vfscanf"]
+    pub fn vfscanf1(
+        __s: *mut FILE,
+        __format: *const ::std::os::raw::c_char,
+        __arg: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn vdprintf(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: va_list,
+    #[link_name = "\u{1}__isoc99_vscanf"]
+    pub fn vscanf1(
+        __format: *const ::std::os::raw::c_char,
+        __arg: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    #[link_name = "\u{1}__isoc99_vsscanf"]
+    pub fn vsscanf1(
+        __s: *const ::std::os::raw::c_char,
+        __format: *const ::std::os::raw::c_char,
+        __arg: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn fgetc(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn getc(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn getchar() -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn getc_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn getchar_unlocked() -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn fgetc_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn fputc(__c: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn putc(__c: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn putchar(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn fputc_unlocked(__c: ::std::os::raw::c_int, __stream: *mut FILE)
+    -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn putc_unlocked(__c: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn putchar_unlocked(__c: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn getw(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn putw(__w: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn fgets(
+        __s: *mut ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_int,
+        __stream: *mut FILE,
+    ) -> *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn __getdelim(
+        __lineptr: *mut *mut ::std::os::raw::c_char,
+        __n: *mut usize,
+        __delimiter: ::std::os::raw::c_int,
+        __stream: *mut FILE,
+    ) -> __ssize_t;
 }
 unsafe extern "C" {
     pub fn getdelim(
-        __linep: *mut *mut ::std::os::raw::c_char,
-        __linecapp: *mut usize,
+        __lineptr: *mut *mut ::std::os::raw::c_char,
+        __n: *mut usize,
         __delimiter: ::std::os::raw::c_int,
         __stream: *mut FILE,
-    ) -> isize;
+    ) -> __ssize_t;
 }
 unsafe extern "C" {
     pub fn getline(
-        __linep: *mut *mut ::std::os::raw::c_char,
-        __linecapp: *mut usize,
+        __lineptr: *mut *mut ::std::os::raw::c_char,
+        __n: *mut usize,
         __stream: *mut FILE,
-    ) -> isize;
+    ) -> __ssize_t;
 }
 unsafe extern "C" {
-    pub fn fmemopen(
-        __buf: *mut ::std::os::raw::c_void,
+    pub fn fputs(__s: *const ::std::os::raw::c_char, __stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn puts(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn ungetc(__c: ::std::os::raw::c_int, __stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn fread(
+        __ptr: *mut ::std::os::raw::c_void,
+        __size: ::std::os::raw::c_ulong,
+        __n: ::std::os::raw::c_ulong,
+        __stream: *mut FILE,
+    ) -> ::std::os::raw::c_ulong;
+}
+unsafe extern "C" {
+    pub fn fwrite(
+        __ptr: *const ::std::os::raw::c_void,
+        __size: ::std::os::raw::c_ulong,
+        __n: ::std::os::raw::c_ulong,
+        __s: *mut FILE,
+    ) -> ::std::os::raw::c_ulong;
+}
+unsafe extern "C" {
+    pub fn fread_unlocked(
+        __ptr: *mut ::std::os::raw::c_void,
         __size: usize,
-        __mode: *const ::std::os::raw::c_char,
+        __n: usize,
+        __stream: *mut FILE,
+    ) -> usize;
+}
+unsafe extern "C" {
+    pub fn fwrite_unlocked(
+        __ptr: *const ::std::os::raw::c_void,
+        __size: usize,
+        __n: usize,
+        __stream: *mut FILE,
+    ) -> usize;
+}
+unsafe extern "C" {
+    pub fn fseek(
+        __stream: *mut FILE,
+        __off: ::std::os::raw::c_long,
+        __whence: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn ftell(__stream: *mut FILE) -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn rewind(__stream: *mut FILE);
+}
+unsafe extern "C" {
+    pub fn fseeko(
+        __stream: *mut FILE,
+        __off: __off_t,
+        __whence: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn ftello(__stream: *mut FILE) -> __off_t;
+}
+unsafe extern "C" {
+    pub fn fgetpos(__stream: *mut FILE, __pos: *mut fpos_t) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn fsetpos(__stream: *mut FILE, __pos: *const fpos_t) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn clearerr(__stream: *mut FILE);
+}
+unsafe extern "C" {
+    pub fn feof(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn ferror(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn clearerr_unlocked(__stream: *mut FILE);
+}
+unsafe extern "C" {
+    pub fn feof_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn ferror_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn perror(__s: *const ::std::os::raw::c_char);
+}
+unsafe extern "C" {
+    pub fn fileno(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn fileno_unlocked(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn pclose(__stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn popen(
+        __command: *const ::std::os::raw::c_char,
+        __modes: *const ::std::os::raw::c_char,
     ) -> *mut FILE;
 }
 unsafe extern "C" {
-    pub fn open_memstream(
-        __bufp: *mut *mut ::std::os::raw::c_char,
-        __sizep: *mut usize,
-    ) -> *mut FILE;
+    pub fn ctermid(__s: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub static sys_nerr: ::std::os::raw::c_int;
+    pub fn flockfile(__stream: *mut FILE);
 }
 unsafe extern "C" {
-    pub static sys_errlist: [*const ::std::os::raw::c_char; 0usize];
+    pub fn ftrylockfile(__stream: *mut FILE) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn asprintf(
-        arg1: *mut *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
+    pub fn funlockfile(__stream: *mut FILE);
 }
 unsafe extern "C" {
-    pub fn ctermid_r(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+    pub fn __uflow(arg1: *mut FILE) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn fgetln(arg1: *mut FILE, arg2: *mut usize) -> *mut ::std::os::raw::c_char;
+    pub fn __overflow(arg1: *mut FILE, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
-unsafe extern "C" {
-    pub fn fmtcheck(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-    ) -> *const ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn fpurge(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn setbuffer(
-        arg1: *mut FILE,
-        arg2: *mut ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
-    );
-}
-unsafe extern "C" {
-    pub fn setlinebuf(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn vasprintf(
-        arg1: *mut *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: va_list,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn funopen(
-        arg1: *const ::std::os::raw::c_void,
-        arg2: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: *mut ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int,
-        >,
-        arg3: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int,
-        >,
-        arg4: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: fpos_t,
-                arg3: ::std::os::raw::c_int,
-            ) -> fpos_t,
-        >,
-        arg5: ::std::option::Option<
-            unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
-        >,
-    ) -> *mut FILE;
-}
-unsafe extern "C" {
-    pub fn __sprintf_chk(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
-        arg3: usize,
-        arg4: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn __snprintf_chk(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: usize,
-        arg3: ::std::os::raw::c_int,
-        arg4: usize,
-        arg5: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn __vsprintf_chk(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
-        arg3: usize,
-        arg4: *const ::std::os::raw::c_char,
-        arg5: va_list,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn __vsnprintf_chk(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: usize,
-        arg3: ::std::os::raw::c_int,
-        arg4: usize,
-        arg5: *const ::std::os::raw::c_char,
-        arg6: va_list,
-    ) -> ::std::os::raw::c_int;
-}
-pub type int_least8_t = i8;
-pub type int_least16_t = i16;
-pub type int_least32_t = i32;
-pub type int_least64_t = i64;
-pub type uint_least8_t = u8;
-pub type uint_least16_t = u16;
-pub type uint_least32_t = u32;
-pub type uint_least64_t = u64;
-pub type int_fast8_t = i8;
-pub type int_fast16_t = i16;
-pub type int_fast32_t = i32;
-pub type int_fast64_t = i64;
-pub type uint_fast8_t = u8;
-pub type uint_fast16_t = u16;
-pub type uint_fast32_t = u32;
-pub type uint_fast64_t = u64;
-pub type intmax_t = ::std::os::raw::c_long;
-pub type uintmax_t = ::std::os::raw::c_ulong;
+pub type int_least8_t = __int_least8_t;
+pub type int_least16_t = __int_least16_t;
+pub type int_least32_t = __int_least32_t;
+pub type int_least64_t = __int_least64_t;
+pub type uint_least8_t = __uint_least8_t;
+pub type uint_least16_t = __uint_least16_t;
+pub type uint_least32_t = __uint_least32_t;
+pub type uint_least64_t = __uint_least64_t;
+pub type int_fast8_t = ::std::os::raw::c_schar;
+pub type int_fast16_t = ::std::os::raw::c_long;
+pub type int_fast32_t = ::std::os::raw::c_long;
+pub type int_fast64_t = ::std::os::raw::c_long;
+pub type uint_fast8_t = ::std::os::raw::c_uchar;
+pub type uint_fast16_t = ::std::os::raw::c_ulong;
+pub type uint_fast32_t = ::std::os::raw::c_ulong;
+pub type uint_fast64_t = ::std::os::raw::c_ulong;
+pub type intmax_t = __intmax_t;
+pub type uintmax_t = __uintmax_t;
 pub type float_t = f32;
 pub type double_t = f64;
 unsafe extern "C" {
-    pub fn __math_errhandling() -> ::std::os::raw::c_int;
+    pub fn __fpclassify(__value: f64) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn __fpclassifyf(arg1: f32) -> ::std::os::raw::c_int;
+    pub fn __signbit(__value: f64) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn __fpclassifyd(arg1: f64) -> ::std::os::raw::c_int;
+    pub fn __isinf(__value: f64) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn __fpclassifyl(arg1: f64) -> ::std::os::raw::c_int;
+    pub fn __finite(__value: f64) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn acosf(arg1: f32) -> f32;
+    pub fn __isnan(__value: f64) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn acos(arg1: f64) -> f64;
+    pub fn __iseqsig(__x: f64, __y: f64) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn acosl(arg1: f64) -> f64;
+    pub fn __issignaling(__value: f64) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn asinf(arg1: f32) -> f32;
+    pub fn acos(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn asin(arg1: f64) -> f64;
+    pub fn __acos(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn asinl(arg1: f64) -> f64;
+    pub fn asin(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn atanf(arg1: f32) -> f32;
+    pub fn __asin(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn atan(arg1: f64) -> f64;
+    pub fn atan(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn atanl(arg1: f64) -> f64;
+    pub fn __atan(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn atan2f(arg1: f32, arg2: f32) -> f32;
+    pub fn atan2(__y: f64, __x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn atan2(arg1: f64, arg2: f64) -> f64;
+    pub fn __atan2(__y: f64, __x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn atan2l(arg1: f64, arg2: f64) -> f64;
+    pub fn cos(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn cosf(arg1: f32) -> f32;
+    pub fn __cos(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn cos(arg1: f64) -> f64;
+    pub fn sin(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn cosl(arg1: f64) -> f64;
+    pub fn __sin(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn sinf(arg1: f32) -> f32;
+    pub fn tan(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn sin(arg1: f64) -> f64;
+    pub fn __tan(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn sinl(arg1: f64) -> f64;
+    pub fn cosh(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn tanf(arg1: f32) -> f32;
+    pub fn __cosh(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn tan(arg1: f64) -> f64;
+    pub fn sinh(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn tanl(arg1: f64) -> f64;
+    pub fn __sinh(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn acoshf(arg1: f32) -> f32;
+    pub fn tanh(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn acosh(arg1: f64) -> f64;
+    pub fn __tanh(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn acoshl(arg1: f64) -> f64;
+    pub fn acosh(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn asinhf(arg1: f32) -> f32;
+    pub fn __acosh(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn asinh(arg1: f64) -> f64;
+    pub fn asinh(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn asinhl(arg1: f64) -> f64;
+    pub fn __asinh(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn atanhf(arg1: f32) -> f32;
+    pub fn atanh(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn atanh(arg1: f64) -> f64;
+    pub fn __atanh(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn atanhl(arg1: f64) -> f64;
+    pub fn exp(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn coshf(arg1: f32) -> f32;
+    pub fn __exp(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn cosh(arg1: f64) -> f64;
+    pub fn frexp(__x: f64, __exponent: *mut ::std::os::raw::c_int) -> f64;
 }
 unsafe extern "C" {
-    pub fn coshl(arg1: f64) -> f64;
+    pub fn __frexp(__x: f64, __exponent: *mut ::std::os::raw::c_int) -> f64;
 }
 unsafe extern "C" {
-    pub fn sinhf(arg1: f32) -> f32;
+    pub fn ldexp(__x: f64, __exponent: ::std::os::raw::c_int) -> f64;
 }
 unsafe extern "C" {
-    pub fn sinh(arg1: f64) -> f64;
+    pub fn __ldexp(__x: f64, __exponent: ::std::os::raw::c_int) -> f64;
 }
 unsafe extern "C" {
-    pub fn sinhl(arg1: f64) -> f64;
+    pub fn log(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn tanhf(arg1: f32) -> f32;
+    pub fn __log(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn tanh(arg1: f64) -> f64;
+    pub fn log10(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn tanhl(arg1: f64) -> f64;
+    pub fn __log10(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn expf(arg1: f32) -> f32;
+    pub fn modf(__x: f64, __iptr: *mut f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn exp(arg1: f64) -> f64;
+    pub fn __modf(__x: f64, __iptr: *mut f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn expl(arg1: f64) -> f64;
+    pub fn expm1(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn exp2f(arg1: f32) -> f32;
+    pub fn __expm1(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn exp2(arg1: f64) -> f64;
+    pub fn log1p(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn exp2l(arg1: f64) -> f64;
+    pub fn __log1p(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn expm1f(arg1: f32) -> f32;
+    pub fn logb(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn expm1(arg1: f64) -> f64;
+    pub fn __logb(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn expm1l(arg1: f64) -> f64;
+    pub fn exp2(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn logf(arg1: f32) -> f32;
+    pub fn __exp2(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn log(arg1: f64) -> f64;
+    pub fn log2(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn logl(arg1: f64) -> f64;
+    pub fn __log2(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn log10f(arg1: f32) -> f32;
+    pub fn pow(__x: f64, __y: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn log10(arg1: f64) -> f64;
+    pub fn __pow(__x: f64, __y: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn log10l(arg1: f64) -> f64;
+    pub fn sqrt(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn log2f(arg1: f32) -> f32;
+    pub fn __sqrt(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn log2(arg1: f64) -> f64;
+    pub fn hypot(__x: f64, __y: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn log2l(arg1: f64) -> f64;
+    pub fn __hypot(__x: f64, __y: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn log1pf(arg1: f32) -> f32;
+    pub fn cbrt(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn log1p(arg1: f64) -> f64;
+    pub fn __cbrt(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn log1pl(arg1: f64) -> f64;
+    pub fn ceil(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn logbf(arg1: f32) -> f32;
+    pub fn __ceil(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn logb(arg1: f64) -> f64;
+    pub fn fabs(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn logbl(arg1: f64) -> f64;
+    pub fn __fabs(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn modff(arg1: f32, arg2: *mut f32) -> f32;
+    pub fn floor(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn modf(arg1: f64, arg2: *mut f64) -> f64;
+    pub fn __floor(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn modfl(arg1: f64, arg2: *mut f64) -> f64;
+    pub fn fmod(__x: f64, __y: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn ldexpf(arg1: f32, arg2: ::std::os::raw::c_int) -> f32;
+    pub fn __fmod(__x: f64, __y: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn ldexp(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
+    pub fn isinf(__value: f64) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn ldexpl(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
+    pub fn finite(__value: f64) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn frexpf(arg1: f32, arg2: *mut ::std::os::raw::c_int) -> f32;
+    pub fn drem(__x: f64, __y: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn frexp(arg1: f64, arg2: *mut ::std::os::raw::c_int) -> f64;
+    pub fn __drem(__x: f64, __y: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn frexpl(arg1: f64, arg2: *mut ::std::os::raw::c_int) -> f64;
+    pub fn significand(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn ilogbf(arg1: f32) -> ::std::os::raw::c_int;
+    pub fn __significand(__x: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn ilogb(arg1: f64) -> ::std::os::raw::c_int;
+    pub fn copysign(__x: f64, __y: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn ilogbl(arg1: f64) -> ::std::os::raw::c_int;
+    pub fn __copysign(__x: f64, __y: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn scalbnf(arg1: f32, arg2: ::std::os::raw::c_int) -> f32;
+    pub fn nan(__tagb: *const ::std::os::raw::c_char) -> f64;
 }
 unsafe extern "C" {
-    pub fn scalbn(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
+    pub fn __nan(__tagb: *const ::std::os::raw::c_char) -> f64;
 }
 unsafe extern "C" {
-    pub fn scalbnl(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
-}
-unsafe extern "C" {
-    pub fn scalblnf(arg1: f32, arg2: ::std::os::raw::c_long) -> f32;
-}
-unsafe extern "C" {
-    pub fn scalbln(arg1: f64, arg2: ::std::os::raw::c_long) -> f64;
-}
-unsafe extern "C" {
-    pub fn scalblnl(arg1: f64, arg2: ::std::os::raw::c_long) -> f64;
-}
-unsafe extern "C" {
-    pub fn fabsf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn fabs(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn fabsl(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn cbrtf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn cbrt(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn cbrtl(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn hypotf(arg1: f32, arg2: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn hypot(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn hypotl(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn powf(arg1: f32, arg2: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn pow(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn powl(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn sqrtf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn sqrt(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn sqrtl(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn erff(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn erf(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn erfl(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn erfcf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn erfc(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn erfcl(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn lgammaf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn lgamma(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn lgammal(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn tgammaf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn tgamma(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn tgammal(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn ceilf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn ceil(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn ceill(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn floorf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn floor(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn floorl(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn nearbyintf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn nearbyint(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn nearbyintl(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn rintf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn rint(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn rintl(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn lrintf(arg1: f32) -> ::std::os::raw::c_long;
-}
-unsafe extern "C" {
-    pub fn lrint(arg1: f64) -> ::std::os::raw::c_long;
-}
-unsafe extern "C" {
-    pub fn lrintl(arg1: f64) -> ::std::os::raw::c_long;
-}
-unsafe extern "C" {
-    pub fn roundf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn round(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn roundl(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn lroundf(arg1: f32) -> ::std::os::raw::c_long;
-}
-unsafe extern "C" {
-    pub fn lround(arg1: f64) -> ::std::os::raw::c_long;
-}
-unsafe extern "C" {
-    pub fn lroundl(arg1: f64) -> ::std::os::raw::c_long;
-}
-unsafe extern "C" {
-    pub fn llrintf(arg1: f32) -> ::std::os::raw::c_longlong;
-}
-unsafe extern "C" {
-    pub fn llrint(arg1: f64) -> ::std::os::raw::c_longlong;
-}
-unsafe extern "C" {
-    pub fn llrintl(arg1: f64) -> ::std::os::raw::c_longlong;
-}
-unsafe extern "C" {
-    pub fn llroundf(arg1: f32) -> ::std::os::raw::c_longlong;
-}
-unsafe extern "C" {
-    pub fn llround(arg1: f64) -> ::std::os::raw::c_longlong;
-}
-unsafe extern "C" {
-    pub fn llroundl(arg1: f64) -> ::std::os::raw::c_longlong;
-}
-unsafe extern "C" {
-    pub fn truncf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn trunc(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn truncl(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn fmodf(arg1: f32, arg2: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn fmod(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn fmodl(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn remainderf(arg1: f32, arg2: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn remainder(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn remainderl(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn remquof(arg1: f32, arg2: f32, arg3: *mut ::std::os::raw::c_int) -> f32;
-}
-unsafe extern "C" {
-    pub fn remquo(arg1: f64, arg2: f64, arg3: *mut ::std::os::raw::c_int) -> f64;
-}
-unsafe extern "C" {
-    pub fn remquol(arg1: f64, arg2: f64, arg3: *mut ::std::os::raw::c_int) -> f64;
-}
-unsafe extern "C" {
-    pub fn copysignf(arg1: f32, arg2: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn copysign(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn copysignl(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn nanf(arg1: *const ::std::os::raw::c_char) -> f32;
-}
-unsafe extern "C" {
-    pub fn nan(arg1: *const ::std::os::raw::c_char) -> f64;
-}
-unsafe extern "C" {
-    pub fn nanl(arg1: *const ::std::os::raw::c_char) -> f64;
-}
-unsafe extern "C" {
-    pub fn nextafterf(arg1: f32, arg2: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn nextafter(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn nextafterl(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn nexttoward(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn nexttowardf(arg1: f32, arg2: f64) -> f32;
-}
-unsafe extern "C" {
-    pub fn nexttowardl(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn fdimf(arg1: f32, arg2: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn fdim(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn fdiml(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn fmaxf(arg1: f32, arg2: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn fmax(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn fmaxl(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn fminf(arg1: f32, arg2: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn fmin(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn fminl(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn fmaf(arg1: f32, arg2: f32, arg3: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn fma(arg1: f64, arg2: f64, arg3: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn fmal(arg1: f64, arg2: f64, arg3: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn __exp10f(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn __exp10(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn __cospif(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn __cospi(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn __sinpif(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn __sinpi(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn __tanpif(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn __tanpi(arg1: f64) -> f64;
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __float2 {
-    pub __sinval: f32,
-    pub __cosval: f32,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __float2"][::std::mem::size_of::<__float2>() - 8usize];
-    ["Alignment of __float2"][::std::mem::align_of::<__float2>() - 4usize];
-    ["Offset of field: __float2::__sinval"][::std::mem::offset_of!(__float2, __sinval) - 0usize];
-    ["Offset of field: __float2::__cosval"][::std::mem::offset_of!(__float2, __cosval) - 4usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __double2 {
-    pub __sinval: f64,
-    pub __cosval: f64,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __double2"][::std::mem::size_of::<__double2>() - 16usize];
-    ["Alignment of __double2"][::std::mem::align_of::<__double2>() - 8usize];
-    ["Offset of field: __double2::__sinval"][::std::mem::offset_of!(__double2, __sinval) - 0usize];
-    ["Offset of field: __double2::__cosval"][::std::mem::offset_of!(__double2, __cosval) - 8usize];
-};
-unsafe extern "C" {
-    pub fn __sincosf_stret(arg1: f32) -> __float2;
-}
-unsafe extern "C" {
-    pub fn __sincos_stret(arg1: f64) -> __double2;
-}
-unsafe extern "C" {
-    pub fn __sincospif_stret(arg1: f32) -> __float2;
-}
-unsafe extern "C" {
-    pub fn __sincospi_stret(arg1: f64) -> __double2;
+    pub fn isnan(__value: f64) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
     pub fn j0(arg1: f64) -> f64;
 }
 unsafe extern "C" {
+    pub fn __j0(arg1: f64) -> f64;
+}
+unsafe extern "C" {
     pub fn j1(arg1: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn __j1(arg1: f64) -> f64;
 }
 unsafe extern "C" {
     pub fn jn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
 }
 unsafe extern "C" {
+    pub fn __jn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
+}
+unsafe extern "C" {
     pub fn y0(arg1: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn __y0(arg1: f64) -> f64;
 }
 unsafe extern "C" {
     pub fn y1(arg1: f64) -> f64;
 }
 unsafe extern "C" {
+    pub fn __y1(arg1: f64) -> f64;
+}
+unsafe extern "C" {
     pub fn yn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn scalb(arg1: f64, arg2: f64) -> f64;
+    pub fn __yn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn erf(arg1: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn __erf(arg1: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn erfc(arg1: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn __erfc(arg1: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn lgamma(arg1: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn __lgamma(arg1: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn tgamma(arg1: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn __tgamma(arg1: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn gamma(arg1: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn __gamma(arg1: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn lgamma_r(arg1: f64, __signgamp: *mut ::std::os::raw::c_int) -> f64;
+}
+unsafe extern "C" {
+    pub fn __lgamma_r(arg1: f64, __signgamp: *mut ::std::os::raw::c_int) -> f64;
+}
+unsafe extern "C" {
+    pub fn rint(__x: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn __rint(__x: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn nextafter(__x: f64, __y: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn __nextafter(__x: f64, __y: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn nexttoward(__x: f64, __y: u128) -> f64;
+}
+unsafe extern "C" {
+    pub fn __nexttoward(__x: f64, __y: u128) -> f64;
+}
+unsafe extern "C" {
+    pub fn remainder(__x: f64, __y: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn __remainder(__x: f64, __y: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn scalbn(__x: f64, __n: ::std::os::raw::c_int) -> f64;
+}
+unsafe extern "C" {
+    pub fn __scalbn(__x: f64, __n: ::std::os::raw::c_int) -> f64;
+}
+unsafe extern "C" {
+    pub fn ilogb(__x: f64) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn __ilogb(__x: f64) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn scalbln(__x: f64, __n: ::std::os::raw::c_long) -> f64;
+}
+unsafe extern "C" {
+    pub fn __scalbln(__x: f64, __n: ::std::os::raw::c_long) -> f64;
+}
+unsafe extern "C" {
+    pub fn nearbyint(__x: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn __nearbyint(__x: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn round(__x: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn __round(__x: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn trunc(__x: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn __trunc(__x: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn remquo(__x: f64, __y: f64, __quo: *mut ::std::os::raw::c_int) -> f64;
+}
+unsafe extern "C" {
+    pub fn __remquo(__x: f64, __y: f64, __quo: *mut ::std::os::raw::c_int) -> f64;
+}
+unsafe extern "C" {
+    pub fn lrint(__x: f64) -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn __lrint(__x: f64) -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn llrint(__x: f64) -> ::std::os::raw::c_longlong;
+}
+unsafe extern "C" {
+    pub fn __llrint(__x: f64) -> ::std::os::raw::c_longlong;
+}
+unsafe extern "C" {
+    pub fn lround(__x: f64) -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn __lround(__x: f64) -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn llround(__x: f64) -> ::std::os::raw::c_longlong;
+}
+unsafe extern "C" {
+    pub fn __llround(__x: f64) -> ::std::os::raw::c_longlong;
+}
+unsafe extern "C" {
+    pub fn fdim(__x: f64, __y: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn __fdim(__x: f64, __y: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn fmax(__x: f64, __y: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn __fmax(__x: f64, __y: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn fmin(__x: f64, __y: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn __fmin(__x: f64, __y: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn fma(__x: f64, __y: f64, __z: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn __fma(__x: f64, __y: f64, __z: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn scalb(__x: f64, __n: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn __scalb(__x: f64, __n: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn __fpclassifyf(__value: f32) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn __signbitf(__value: f32) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn __isinff(__value: f32) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn __finitef(__value: f32) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn __isnanf(__value: f32) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn __iseqsigf(__x: f32, __y: f32) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn __issignalingf(__value: f32) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn acosf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __acosf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn asinf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __asinf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn atanf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __atanf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn atan2f(__y: f32, __x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __atan2f(__y: f32, __x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn cosf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __cosf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn sinf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __sinf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn tanf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __tanf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn coshf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __coshf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn sinhf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __sinhf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn tanhf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __tanhf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn acoshf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __acoshf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn asinhf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __asinhf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn atanhf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __atanhf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn expf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __expf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn frexpf(__x: f32, __exponent: *mut ::std::os::raw::c_int) -> f32;
+}
+unsafe extern "C" {
+    pub fn __frexpf(__x: f32, __exponent: *mut ::std::os::raw::c_int) -> f32;
+}
+unsafe extern "C" {
+    pub fn ldexpf(__x: f32, __exponent: ::std::os::raw::c_int) -> f32;
+}
+unsafe extern "C" {
+    pub fn __ldexpf(__x: f32, __exponent: ::std::os::raw::c_int) -> f32;
+}
+unsafe extern "C" {
+    pub fn logf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __logf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn log10f(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __log10f(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn modff(__x: f32, __iptr: *mut f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __modff(__x: f32, __iptr: *mut f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn expm1f(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __expm1f(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn log1pf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __log1pf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn logbf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __logbf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn exp2f(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __exp2f(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn log2f(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __log2f(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn powf(__x: f32, __y: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __powf(__x: f32, __y: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn sqrtf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __sqrtf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn hypotf(__x: f32, __y: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __hypotf(__x: f32, __y: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn cbrtf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __cbrtf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn ceilf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __ceilf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn fabsf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __fabsf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn floorf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __floorf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn fmodf(__x: f32, __y: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __fmodf(__x: f32, __y: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn isinff(__value: f32) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn finitef(__value: f32) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn dremf(__x: f32, __y: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __dremf(__x: f32, __y: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn significandf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __significandf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn copysignf(__x: f32, __y: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __copysignf(__x: f32, __y: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn nanf(__tagb: *const ::std::os::raw::c_char) -> f32;
+}
+unsafe extern "C" {
+    pub fn __nanf(__tagb: *const ::std::os::raw::c_char) -> f32;
+}
+unsafe extern "C" {
+    pub fn isnanf(__value: f32) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn j0f(arg1: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __j0f(arg1: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn j1f(arg1: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __j1f(arg1: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn jnf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __jnf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn y0f(arg1: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __y0f(arg1: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn y1f(arg1: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __y1f(arg1: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn ynf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __ynf(arg1: ::std::os::raw::c_int, arg2: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn erff(arg1: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __erff(arg1: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn erfcf(arg1: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __erfcf(arg1: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn lgammaf(arg1: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __lgammaf(arg1: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn tgammaf(arg1: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __tgammaf(arg1: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn gammaf(arg1: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __gammaf(arg1: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn lgammaf_r(arg1: f32, __signgamp: *mut ::std::os::raw::c_int) -> f32;
+}
+unsafe extern "C" {
+    pub fn __lgammaf_r(arg1: f32, __signgamp: *mut ::std::os::raw::c_int) -> f32;
+}
+unsafe extern "C" {
+    pub fn rintf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __rintf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn nextafterf(__x: f32, __y: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __nextafterf(__x: f32, __y: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn nexttowardf(__x: f32, __y: u128) -> f32;
+}
+unsafe extern "C" {
+    pub fn __nexttowardf(__x: f32, __y: u128) -> f32;
+}
+unsafe extern "C" {
+    pub fn remainderf(__x: f32, __y: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __remainderf(__x: f32, __y: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn scalbnf(__x: f32, __n: ::std::os::raw::c_int) -> f32;
+}
+unsafe extern "C" {
+    pub fn __scalbnf(__x: f32, __n: ::std::os::raw::c_int) -> f32;
+}
+unsafe extern "C" {
+    pub fn ilogbf(__x: f32) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn __ilogbf(__x: f32) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn scalblnf(__x: f32, __n: ::std::os::raw::c_long) -> f32;
+}
+unsafe extern "C" {
+    pub fn __scalblnf(__x: f32, __n: ::std::os::raw::c_long) -> f32;
+}
+unsafe extern "C" {
+    pub fn nearbyintf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __nearbyintf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn roundf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __roundf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn truncf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __truncf(__x: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn remquof(__x: f32, __y: f32, __quo: *mut ::std::os::raw::c_int) -> f32;
+}
+unsafe extern "C" {
+    pub fn __remquof(__x: f32, __y: f32, __quo: *mut ::std::os::raw::c_int) -> f32;
+}
+unsafe extern "C" {
+    pub fn lrintf(__x: f32) -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn __lrintf(__x: f32) -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn llrintf(__x: f32) -> ::std::os::raw::c_longlong;
+}
+unsafe extern "C" {
+    pub fn __llrintf(__x: f32) -> ::std::os::raw::c_longlong;
+}
+unsafe extern "C" {
+    pub fn lroundf(__x: f32) -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn __lroundf(__x: f32) -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn llroundf(__x: f32) -> ::std::os::raw::c_longlong;
+}
+unsafe extern "C" {
+    pub fn __llroundf(__x: f32) -> ::std::os::raw::c_longlong;
+}
+unsafe extern "C" {
+    pub fn fdimf(__x: f32, __y: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __fdimf(__x: f32, __y: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn fmaxf(__x: f32, __y: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __fmaxf(__x: f32, __y: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn fminf(__x: f32, __y: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __fminf(__x: f32, __y: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn fmaf(__x: f32, __y: f32, __z: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __fmaf(__x: f32, __y: f32, __z: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn scalbf(__x: f32, __n: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __scalbf(__x: f32, __n: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn __fpclassifyl(__value: u128) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn __signbitl(__value: u128) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn __isinfl(__value: u128) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn __finitel(__value: u128) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn __isnanl(__value: u128) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn __iseqsigl(__x: u128, __y: u128) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn __issignalingl(__value: u128) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn acosl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __acosl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn asinl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __asinl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn atanl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __atanl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn atan2l(__y: u128, __x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __atan2l(__y: u128, __x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn cosl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __cosl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn sinl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __sinl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn tanl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __tanl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn coshl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __coshl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn sinhl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __sinhl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn tanhl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __tanhl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn acoshl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __acoshl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn asinhl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __asinhl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn atanhl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __atanhl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn expl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __expl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn frexpl(__x: u128, __exponent: *mut ::std::os::raw::c_int) -> u128;
+}
+unsafe extern "C" {
+    pub fn __frexpl(__x: u128, __exponent: *mut ::std::os::raw::c_int) -> u128;
+}
+unsafe extern "C" {
+    pub fn ldexpl(__x: u128, __exponent: ::std::os::raw::c_int) -> u128;
+}
+unsafe extern "C" {
+    pub fn __ldexpl(__x: u128, __exponent: ::std::os::raw::c_int) -> u128;
+}
+unsafe extern "C" {
+    pub fn logl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __logl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn log10l(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __log10l(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn modfl(__x: u128, __iptr: *mut u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __modfl(__x: u128, __iptr: *mut u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn expm1l(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __expm1l(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn log1pl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __log1pl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn logbl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __logbl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn exp2l(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __exp2l(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn log2l(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __log2l(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn powl(__x: u128, __y: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __powl(__x: u128, __y: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn sqrtl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __sqrtl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn hypotl(__x: u128, __y: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __hypotl(__x: u128, __y: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn cbrtl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __cbrtl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn ceill(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __ceill(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn fabsl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __fabsl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn floorl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __floorl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn fmodl(__x: u128, __y: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __fmodl(__x: u128, __y: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn isinfl(__value: u128) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn finitel(__value: u128) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn dreml(__x: u128, __y: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __dreml(__x: u128, __y: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn significandl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __significandl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn copysignl(__x: u128, __y: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __copysignl(__x: u128, __y: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn nanl(__tagb: *const ::std::os::raw::c_char) -> u128;
+}
+unsafe extern "C" {
+    pub fn __nanl(__tagb: *const ::std::os::raw::c_char) -> u128;
+}
+unsafe extern "C" {
+    pub fn isnanl(__value: u128) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn j0l(arg1: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __j0l(arg1: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn j1l(arg1: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __j1l(arg1: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn jnl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __jnl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn y0l(arg1: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __y0l(arg1: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn y1l(arg1: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __y1l(arg1: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn ynl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __ynl(arg1: ::std::os::raw::c_int, arg2: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn erfl(arg1: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __erfl(arg1: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn erfcl(arg1: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __erfcl(arg1: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn lgammal(arg1: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __lgammal(arg1: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn tgammal(arg1: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __tgammal(arg1: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn gammal(arg1: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __gammal(arg1: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn lgammal_r(arg1: u128, __signgamp: *mut ::std::os::raw::c_int) -> u128;
+}
+unsafe extern "C" {
+    pub fn __lgammal_r(arg1: u128, __signgamp: *mut ::std::os::raw::c_int) -> u128;
+}
+unsafe extern "C" {
+    pub fn rintl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __rintl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn nextafterl(__x: u128, __y: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __nextafterl(__x: u128, __y: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn nexttowardl(__x: u128, __y: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __nexttowardl(__x: u128, __y: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn remainderl(__x: u128, __y: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __remainderl(__x: u128, __y: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn scalbnl(__x: u128, __n: ::std::os::raw::c_int) -> u128;
+}
+unsafe extern "C" {
+    pub fn __scalbnl(__x: u128, __n: ::std::os::raw::c_int) -> u128;
+}
+unsafe extern "C" {
+    pub fn ilogbl(__x: u128) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn __ilogbl(__x: u128) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn scalblnl(__x: u128, __n: ::std::os::raw::c_long) -> u128;
+}
+unsafe extern "C" {
+    pub fn __scalblnl(__x: u128, __n: ::std::os::raw::c_long) -> u128;
+}
+unsafe extern "C" {
+    pub fn nearbyintl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __nearbyintl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn roundl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __roundl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn truncl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __truncl(__x: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn remquol(__x: u128, __y: u128, __quo: *mut ::std::os::raw::c_int) -> u128;
+}
+unsafe extern "C" {
+    pub fn __remquol(__x: u128, __y: u128, __quo: *mut ::std::os::raw::c_int) -> u128;
+}
+unsafe extern "C" {
+    pub fn lrintl(__x: u128) -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn __lrintl(__x: u128) -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn llrintl(__x: u128) -> ::std::os::raw::c_longlong;
+}
+unsafe extern "C" {
+    pub fn __llrintl(__x: u128) -> ::std::os::raw::c_longlong;
+}
+unsafe extern "C" {
+    pub fn lroundl(__x: u128) -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn __lroundl(__x: u128) -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn llroundl(__x: u128) -> ::std::os::raw::c_longlong;
+}
+unsafe extern "C" {
+    pub fn __llroundl(__x: u128) -> ::std::os::raw::c_longlong;
+}
+unsafe extern "C" {
+    pub fn fdiml(__x: u128, __y: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __fdiml(__x: u128, __y: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn fmaxl(__x: u128, __y: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __fmaxl(__x: u128, __y: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn fminl(__x: u128, __y: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __fminl(__x: u128, __y: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn fmal(__x: u128, __y: u128, __z: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __fmal(__x: u128, __y: u128, __z: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn scalbl(__x: u128, __n: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __scalbl(__x: u128, __n: u128) -> u128;
 }
 unsafe extern "C" {
     pub static mut signgam: ::std::os::raw::c_int;
 }
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct exception {
-    pub type_: ::std::os::raw::c_int,
-    pub name: *mut ::std::os::raw::c_char,
-    pub arg1: f64,
-    pub arg2: f64,
-    pub retval: f64,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of exception"][::std::mem::size_of::<exception>() - 40usize];
-    ["Alignment of exception"][::std::mem::align_of::<exception>() - 8usize];
-    ["Offset of field: exception::type_"][::std::mem::offset_of!(exception, type_) - 0usize];
-    ["Offset of field: exception::name"][::std::mem::offset_of!(exception, name) - 8usize];
-    ["Offset of field: exception::arg1"][::std::mem::offset_of!(exception, arg1) - 16usize];
-    ["Offset of field: exception::arg2"][::std::mem::offset_of!(exception, arg2) - 24usize];
-    ["Offset of field: exception::retval"][::std::mem::offset_of!(exception, retval) - 32usize];
-};
+pub const FP_NAN: _bindgen_ty_1 = 0;
+pub const FP_INFINITE: _bindgen_ty_1 = 1;
+pub const FP_ZERO: _bindgen_ty_1 = 2;
+pub const FP_SUBNORMAL: _bindgen_ty_1 = 3;
+pub const FP_NORMAL: _bindgen_ty_1 = 4;
+pub type _bindgen_ty_1 = ::std::os::raw::c_uint;
 unsafe extern "C" {
-    pub fn __assert_rtn(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
-        arg4: *const ::std::os::raw::c_char,
+    pub fn __assert_fail(
+        __assertion: *const ::std::os::raw::c_char,
+        __file: *const ::std::os::raw::c_char,
+        __line: ::std::os::raw::c_uint,
+        __function: *const ::std::os::raw::c_char,
     ) -> !;
 }
-pub const idtype_t_P_ALL: idtype_t = 0;
-pub const idtype_t_P_PID: idtype_t = 1;
-pub const idtype_t_P_PGID: idtype_t = 2;
-pub type idtype_t = ::std::os::raw::c_uint;
-pub type pid_t = __darwin_pid_t;
-pub type id_t = __darwin_id_t;
-pub type sig_atomic_t = ::std::os::raw::c_int;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_arm_exception_state {
-    pub __exception: __uint32_t,
-    pub __fsr: __uint32_t,
-    pub __far: __uint32_t,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __darwin_arm_exception_state"]
-        [::std::mem::size_of::<__darwin_arm_exception_state>() - 12usize];
-    ["Alignment of __darwin_arm_exception_state"]
-        [::std::mem::align_of::<__darwin_arm_exception_state>() - 4usize];
-    ["Offset of field: __darwin_arm_exception_state::__exception"]
-        [::std::mem::offset_of!(__darwin_arm_exception_state, __exception) - 0usize];
-    ["Offset of field: __darwin_arm_exception_state::__fsr"]
-        [::std::mem::offset_of!(__darwin_arm_exception_state, __fsr) - 4usize];
-    ["Offset of field: __darwin_arm_exception_state::__far"]
-        [::std::mem::offset_of!(__darwin_arm_exception_state, __far) - 8usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_arm_exception_state64 {
-    pub __far: __uint64_t,
-    pub __esr: __uint32_t,
-    pub __exception: __uint32_t,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __darwin_arm_exception_state64"]
-        [::std::mem::size_of::<__darwin_arm_exception_state64>() - 16usize];
-    ["Alignment of __darwin_arm_exception_state64"]
-        [::std::mem::align_of::<__darwin_arm_exception_state64>() - 8usize];
-    ["Offset of field: __darwin_arm_exception_state64::__far"]
-        [::std::mem::offset_of!(__darwin_arm_exception_state64, __far) - 0usize];
-    ["Offset of field: __darwin_arm_exception_state64::__esr"]
-        [::std::mem::offset_of!(__darwin_arm_exception_state64, __esr) - 8usize];
-    ["Offset of field: __darwin_arm_exception_state64::__exception"]
-        [::std::mem::offset_of!(__darwin_arm_exception_state64, __exception) - 12usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_arm_thread_state {
-    pub __r: [__uint32_t; 13usize],
-    pub __sp: __uint32_t,
-    pub __lr: __uint32_t,
-    pub __pc: __uint32_t,
-    pub __cpsr: __uint32_t,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __darwin_arm_thread_state"]
-        [::std::mem::size_of::<__darwin_arm_thread_state>() - 68usize];
-    ["Alignment of __darwin_arm_thread_state"]
-        [::std::mem::align_of::<__darwin_arm_thread_state>() - 4usize];
-    ["Offset of field: __darwin_arm_thread_state::__r"]
-        [::std::mem::offset_of!(__darwin_arm_thread_state, __r) - 0usize];
-    ["Offset of field: __darwin_arm_thread_state::__sp"]
-        [::std::mem::offset_of!(__darwin_arm_thread_state, __sp) - 52usize];
-    ["Offset of field: __darwin_arm_thread_state::__lr"]
-        [::std::mem::offset_of!(__darwin_arm_thread_state, __lr) - 56usize];
-    ["Offset of field: __darwin_arm_thread_state::__pc"]
-        [::std::mem::offset_of!(__darwin_arm_thread_state, __pc) - 60usize];
-    ["Offset of field: __darwin_arm_thread_state::__cpsr"]
-        [::std::mem::offset_of!(__darwin_arm_thread_state, __cpsr) - 64usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_arm_thread_state64 {
-    pub __x: [__uint64_t; 29usize],
-    pub __fp: __uint64_t,
-    pub __lr: __uint64_t,
-    pub __sp: __uint64_t,
-    pub __pc: __uint64_t,
-    pub __cpsr: __uint32_t,
-    pub __pad: __uint32_t,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __darwin_arm_thread_state64"]
-        [::std::mem::size_of::<__darwin_arm_thread_state64>() - 272usize];
-    ["Alignment of __darwin_arm_thread_state64"]
-        [::std::mem::align_of::<__darwin_arm_thread_state64>() - 8usize];
-    ["Offset of field: __darwin_arm_thread_state64::__x"]
-        [::std::mem::offset_of!(__darwin_arm_thread_state64, __x) - 0usize];
-    ["Offset of field: __darwin_arm_thread_state64::__fp"]
-        [::std::mem::offset_of!(__darwin_arm_thread_state64, __fp) - 232usize];
-    ["Offset of field: __darwin_arm_thread_state64::__lr"]
-        [::std::mem::offset_of!(__darwin_arm_thread_state64, __lr) - 240usize];
-    ["Offset of field: __darwin_arm_thread_state64::__sp"]
-        [::std::mem::offset_of!(__darwin_arm_thread_state64, __sp) - 248usize];
-    ["Offset of field: __darwin_arm_thread_state64::__pc"]
-        [::std::mem::offset_of!(__darwin_arm_thread_state64, __pc) - 256usize];
-    ["Offset of field: __darwin_arm_thread_state64::__cpsr"]
-        [::std::mem::offset_of!(__darwin_arm_thread_state64, __cpsr) - 264usize];
-    ["Offset of field: __darwin_arm_thread_state64::__pad"]
-        [::std::mem::offset_of!(__darwin_arm_thread_state64, __pad) - 268usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_arm_vfp_state {
-    pub __r: [__uint32_t; 64usize],
-    pub __fpscr: __uint32_t,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __darwin_arm_vfp_state"][::std::mem::size_of::<__darwin_arm_vfp_state>() - 260usize];
-    ["Alignment of __darwin_arm_vfp_state"]
-        [::std::mem::align_of::<__darwin_arm_vfp_state>() - 4usize];
-    ["Offset of field: __darwin_arm_vfp_state::__r"]
-        [::std::mem::offset_of!(__darwin_arm_vfp_state, __r) - 0usize];
-    ["Offset of field: __darwin_arm_vfp_state::__fpscr"]
-        [::std::mem::offset_of!(__darwin_arm_vfp_state, __fpscr) - 256usize];
-};
-#[repr(C)]
-#[repr(align(16))]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_arm_neon_state64 {
-    pub __v: [__uint128_t; 32usize],
-    pub __fpsr: __uint32_t,
-    pub __fpcr: __uint32_t,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __darwin_arm_neon_state64"]
-        [::std::mem::size_of::<__darwin_arm_neon_state64>() - 528usize];
-    ["Alignment of __darwin_arm_neon_state64"]
-        [::std::mem::align_of::<__darwin_arm_neon_state64>() - 16usize];
-    ["Offset of field: __darwin_arm_neon_state64::__v"]
-        [::std::mem::offset_of!(__darwin_arm_neon_state64, __v) - 0usize];
-    ["Offset of field: __darwin_arm_neon_state64::__fpsr"]
-        [::std::mem::offset_of!(__darwin_arm_neon_state64, __fpsr) - 512usize];
-    ["Offset of field: __darwin_arm_neon_state64::__fpcr"]
-        [::std::mem::offset_of!(__darwin_arm_neon_state64, __fpcr) - 516usize];
-};
-#[repr(C)]
-#[repr(align(16))]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_arm_neon_state {
-    pub __v: [__uint128_t; 16usize],
-    pub __fpsr: __uint32_t,
-    pub __fpcr: __uint32_t,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __darwin_arm_neon_state"]
-        [::std::mem::size_of::<__darwin_arm_neon_state>() - 272usize];
-    ["Alignment of __darwin_arm_neon_state"]
-        [::std::mem::align_of::<__darwin_arm_neon_state>() - 16usize];
-    ["Offset of field: __darwin_arm_neon_state::__v"]
-        [::std::mem::offset_of!(__darwin_arm_neon_state, __v) - 0usize];
-    ["Offset of field: __darwin_arm_neon_state::__fpsr"]
-        [::std::mem::offset_of!(__darwin_arm_neon_state, __fpsr) - 256usize];
-    ["Offset of field: __darwin_arm_neon_state::__fpcr"]
-        [::std::mem::offset_of!(__darwin_arm_neon_state, __fpcr) - 260usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __arm_pagein_state {
-    pub __pagein_error: ::std::os::raw::c_int,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __arm_pagein_state"][::std::mem::size_of::<__arm_pagein_state>() - 4usize];
-    ["Alignment of __arm_pagein_state"][::std::mem::align_of::<__arm_pagein_state>() - 4usize];
-    ["Offset of field: __arm_pagein_state::__pagein_error"]
-        [::std::mem::offset_of!(__arm_pagein_state, __pagein_error) - 0usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __arm_legacy_debug_state {
-    pub __bvr: [__uint32_t; 16usize],
-    pub __bcr: [__uint32_t; 16usize],
-    pub __wvr: [__uint32_t; 16usize],
-    pub __wcr: [__uint32_t; 16usize],
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __arm_legacy_debug_state"]
-        [::std::mem::size_of::<__arm_legacy_debug_state>() - 256usize];
-    ["Alignment of __arm_legacy_debug_state"]
-        [::std::mem::align_of::<__arm_legacy_debug_state>() - 4usize];
-    ["Offset of field: __arm_legacy_debug_state::__bvr"]
-        [::std::mem::offset_of!(__arm_legacy_debug_state, __bvr) - 0usize];
-    ["Offset of field: __arm_legacy_debug_state::__bcr"]
-        [::std::mem::offset_of!(__arm_legacy_debug_state, __bcr) - 64usize];
-    ["Offset of field: __arm_legacy_debug_state::__wvr"]
-        [::std::mem::offset_of!(__arm_legacy_debug_state, __wvr) - 128usize];
-    ["Offset of field: __arm_legacy_debug_state::__wcr"]
-        [::std::mem::offset_of!(__arm_legacy_debug_state, __wcr) - 192usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_arm_debug_state32 {
-    pub __bvr: [__uint32_t; 16usize],
-    pub __bcr: [__uint32_t; 16usize],
-    pub __wvr: [__uint32_t; 16usize],
-    pub __wcr: [__uint32_t; 16usize],
-    pub __mdscr_el1: __uint64_t,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __darwin_arm_debug_state32"]
-        [::std::mem::size_of::<__darwin_arm_debug_state32>() - 264usize];
-    ["Alignment of __darwin_arm_debug_state32"]
-        [::std::mem::align_of::<__darwin_arm_debug_state32>() - 8usize];
-    ["Offset of field: __darwin_arm_debug_state32::__bvr"]
-        [::std::mem::offset_of!(__darwin_arm_debug_state32, __bvr) - 0usize];
-    ["Offset of field: __darwin_arm_debug_state32::__bcr"]
-        [::std::mem::offset_of!(__darwin_arm_debug_state32, __bcr) - 64usize];
-    ["Offset of field: __darwin_arm_debug_state32::__wvr"]
-        [::std::mem::offset_of!(__darwin_arm_debug_state32, __wvr) - 128usize];
-    ["Offset of field: __darwin_arm_debug_state32::__wcr"]
-        [::std::mem::offset_of!(__darwin_arm_debug_state32, __wcr) - 192usize];
-    ["Offset of field: __darwin_arm_debug_state32::__mdscr_el1"]
-        [::std::mem::offset_of!(__darwin_arm_debug_state32, __mdscr_el1) - 256usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_arm_debug_state64 {
-    pub __bvr: [__uint64_t; 16usize],
-    pub __bcr: [__uint64_t; 16usize],
-    pub __wvr: [__uint64_t; 16usize],
-    pub __wcr: [__uint64_t; 16usize],
-    pub __mdscr_el1: __uint64_t,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __darwin_arm_debug_state64"]
-        [::std::mem::size_of::<__darwin_arm_debug_state64>() - 520usize];
-    ["Alignment of __darwin_arm_debug_state64"]
-        [::std::mem::align_of::<__darwin_arm_debug_state64>() - 8usize];
-    ["Offset of field: __darwin_arm_debug_state64::__bvr"]
-        [::std::mem::offset_of!(__darwin_arm_debug_state64, __bvr) - 0usize];
-    ["Offset of field: __darwin_arm_debug_state64::__bcr"]
-        [::std::mem::offset_of!(__darwin_arm_debug_state64, __bcr) - 128usize];
-    ["Offset of field: __darwin_arm_debug_state64::__wvr"]
-        [::std::mem::offset_of!(__darwin_arm_debug_state64, __wvr) - 256usize];
-    ["Offset of field: __darwin_arm_debug_state64::__wcr"]
-        [::std::mem::offset_of!(__darwin_arm_debug_state64, __wcr) - 384usize];
-    ["Offset of field: __darwin_arm_debug_state64::__mdscr_el1"]
-        [::std::mem::offset_of!(__darwin_arm_debug_state64, __mdscr_el1) - 512usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_arm_cpmu_state64 {
-    pub __ctrs: [__uint64_t; 16usize],
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __darwin_arm_cpmu_state64"]
-        [::std::mem::size_of::<__darwin_arm_cpmu_state64>() - 128usize];
-    ["Alignment of __darwin_arm_cpmu_state64"]
-        [::std::mem::align_of::<__darwin_arm_cpmu_state64>() - 8usize];
-    ["Offset of field: __darwin_arm_cpmu_state64::__ctrs"]
-        [::std::mem::offset_of!(__darwin_arm_cpmu_state64, __ctrs) - 0usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_mcontext32 {
-    pub __es: __darwin_arm_exception_state,
-    pub __ss: __darwin_arm_thread_state,
-    pub __fs: __darwin_arm_vfp_state,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __darwin_mcontext32"][::std::mem::size_of::<__darwin_mcontext32>() - 340usize];
-    ["Alignment of __darwin_mcontext32"][::std::mem::align_of::<__darwin_mcontext32>() - 4usize];
-    ["Offset of field: __darwin_mcontext32::__es"]
-        [::std::mem::offset_of!(__darwin_mcontext32, __es) - 0usize];
-    ["Offset of field: __darwin_mcontext32::__ss"]
-        [::std::mem::offset_of!(__darwin_mcontext32, __ss) - 12usize];
-    ["Offset of field: __darwin_mcontext32::__fs"]
-        [::std::mem::offset_of!(__darwin_mcontext32, __fs) - 80usize];
-};
-#[repr(C)]
-#[repr(align(16))]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_mcontext64 {
-    pub __es: __darwin_arm_exception_state64,
-    pub __ss: __darwin_arm_thread_state64,
-    pub __ns: __darwin_arm_neon_state64,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __darwin_mcontext64"][::std::mem::size_of::<__darwin_mcontext64>() - 816usize];
-    ["Alignment of __darwin_mcontext64"][::std::mem::align_of::<__darwin_mcontext64>() - 16usize];
-    ["Offset of field: __darwin_mcontext64::__es"]
-        [::std::mem::offset_of!(__darwin_mcontext64, __es) - 0usize];
-    ["Offset of field: __darwin_mcontext64::__ss"]
-        [::std::mem::offset_of!(__darwin_mcontext64, __ss) - 16usize];
-    ["Offset of field: __darwin_mcontext64::__ns"]
-        [::std::mem::offset_of!(__darwin_mcontext64, __ns) - 288usize];
-};
-pub type mcontext_t = *mut __darwin_mcontext64;
-pub type pthread_attr_t = __darwin_pthread_attr_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_sigaltstack {
-    pub ss_sp: *mut ::std::os::raw::c_void,
-    pub ss_size: __darwin_size_t,
-    pub ss_flags: ::std::os::raw::c_int,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __darwin_sigaltstack"][::std::mem::size_of::<__darwin_sigaltstack>() - 24usize];
-    ["Alignment of __darwin_sigaltstack"][::std::mem::align_of::<__darwin_sigaltstack>() - 8usize];
-    ["Offset of field: __darwin_sigaltstack::ss_sp"]
-        [::std::mem::offset_of!(__darwin_sigaltstack, ss_sp) - 0usize];
-    ["Offset of field: __darwin_sigaltstack::ss_size"]
-        [::std::mem::offset_of!(__darwin_sigaltstack, ss_size) - 8usize];
-    ["Offset of field: __darwin_sigaltstack::ss_flags"]
-        [::std::mem::offset_of!(__darwin_sigaltstack, ss_flags) - 16usize];
-};
-pub type stack_t = __darwin_sigaltstack;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_ucontext {
-    pub uc_onstack: ::std::os::raw::c_int,
-    pub uc_sigmask: __darwin_sigset_t,
-    pub uc_stack: __darwin_sigaltstack,
-    pub uc_link: *mut __darwin_ucontext,
-    pub uc_mcsize: __darwin_size_t,
-    pub uc_mcontext: *mut __darwin_mcontext64,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __darwin_ucontext"][::std::mem::size_of::<__darwin_ucontext>() - 56usize];
-    ["Alignment of __darwin_ucontext"][::std::mem::align_of::<__darwin_ucontext>() - 8usize];
-    ["Offset of field: __darwin_ucontext::uc_onstack"]
-        [::std::mem::offset_of!(__darwin_ucontext, uc_onstack) - 0usize];
-    ["Offset of field: __darwin_ucontext::uc_sigmask"]
-        [::std::mem::offset_of!(__darwin_ucontext, uc_sigmask) - 4usize];
-    ["Offset of field: __darwin_ucontext::uc_stack"]
-        [::std::mem::offset_of!(__darwin_ucontext, uc_stack) - 8usize];
-    ["Offset of field: __darwin_ucontext::uc_link"]
-        [::std::mem::offset_of!(__darwin_ucontext, uc_link) - 32usize];
-    ["Offset of field: __darwin_ucontext::uc_mcsize"]
-        [::std::mem::offset_of!(__darwin_ucontext, uc_mcsize) - 40usize];
-    ["Offset of field: __darwin_ucontext::uc_mcontext"]
-        [::std::mem::offset_of!(__darwin_ucontext, uc_mcontext) - 48usize];
-};
-pub type ucontext_t = __darwin_ucontext;
-pub type sigset_t = __darwin_sigset_t;
-pub type uid_t = __darwin_uid_t;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union sigval {
-    pub sival_int: ::std::os::raw::c_int,
-    pub sival_ptr: *mut ::std::os::raw::c_void,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of sigval"][::std::mem::size_of::<sigval>() - 8usize];
-    ["Alignment of sigval"][::std::mem::align_of::<sigval>() - 8usize];
-    ["Offset of field: sigval::sival_int"][::std::mem::offset_of!(sigval, sival_int) - 0usize];
-    ["Offset of field: sigval::sival_ptr"][::std::mem::offset_of!(sigval, sival_ptr) - 0usize];
-};
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct sigevent {
-    pub sigev_notify: ::std::os::raw::c_int,
-    pub sigev_signo: ::std::os::raw::c_int,
-    pub sigev_value: sigval,
-    pub sigev_notify_function: ::std::option::Option<unsafe extern "C" fn(arg1: sigval)>,
-    pub sigev_notify_attributes: *mut pthread_attr_t,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of sigevent"][::std::mem::size_of::<sigevent>() - 32usize];
-    ["Alignment of sigevent"][::std::mem::align_of::<sigevent>() - 8usize];
-    ["Offset of field: sigevent::sigev_notify"]
-        [::std::mem::offset_of!(sigevent, sigev_notify) - 0usize];
-    ["Offset of field: sigevent::sigev_signo"]
-        [::std::mem::offset_of!(sigevent, sigev_signo) - 4usize];
-    ["Offset of field: sigevent::sigev_value"]
-        [::std::mem::offset_of!(sigevent, sigev_value) - 8usize];
-    ["Offset of field: sigevent::sigev_notify_function"]
-        [::std::mem::offset_of!(sigevent, sigev_notify_function) - 16usize];
-    ["Offset of field: sigevent::sigev_notify_attributes"]
-        [::std::mem::offset_of!(sigevent, sigev_notify_attributes) - 24usize];
-};
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __siginfo {
-    pub si_signo: ::std::os::raw::c_int,
-    pub si_errno: ::std::os::raw::c_int,
-    pub si_code: ::std::os::raw::c_int,
-    pub si_pid: pid_t,
-    pub si_uid: uid_t,
-    pub si_status: ::std::os::raw::c_int,
-    pub si_addr: *mut ::std::os::raw::c_void,
-    pub si_value: sigval,
-    pub si_band: ::std::os::raw::c_long,
-    pub __pad: [::std::os::raw::c_ulong; 7usize],
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __siginfo"][::std::mem::size_of::<__siginfo>() - 104usize];
-    ["Alignment of __siginfo"][::std::mem::align_of::<__siginfo>() - 8usize];
-    ["Offset of field: __siginfo::si_signo"][::std::mem::offset_of!(__siginfo, si_signo) - 0usize];
-    ["Offset of field: __siginfo::si_errno"][::std::mem::offset_of!(__siginfo, si_errno) - 4usize];
-    ["Offset of field: __siginfo::si_code"][::std::mem::offset_of!(__siginfo, si_code) - 8usize];
-    ["Offset of field: __siginfo::si_pid"][::std::mem::offset_of!(__siginfo, si_pid) - 12usize];
-    ["Offset of field: __siginfo::si_uid"][::std::mem::offset_of!(__siginfo, si_uid) - 16usize];
-    ["Offset of field: __siginfo::si_status"]
-        [::std::mem::offset_of!(__siginfo, si_status) - 20usize];
-    ["Offset of field: __siginfo::si_addr"][::std::mem::offset_of!(__siginfo, si_addr) - 24usize];
-    ["Offset of field: __siginfo::si_value"][::std::mem::offset_of!(__siginfo, si_value) - 32usize];
-    ["Offset of field: __siginfo::si_band"][::std::mem::offset_of!(__siginfo, si_band) - 40usize];
-    ["Offset of field: __siginfo::__pad"][::std::mem::offset_of!(__siginfo, __pad) - 48usize];
-};
-pub type siginfo_t = __siginfo;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union __sigaction_u {
-    pub __sa_handler: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    pub __sa_sigaction: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: ::std::os::raw::c_int,
-            arg2: *mut __siginfo,
-            arg3: *mut ::std::os::raw::c_void,
-        ),
-    >,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __sigaction_u"][::std::mem::size_of::<__sigaction_u>() - 8usize];
-    ["Alignment of __sigaction_u"][::std::mem::align_of::<__sigaction_u>() - 8usize];
-    ["Offset of field: __sigaction_u::__sa_handler"]
-        [::std::mem::offset_of!(__sigaction_u, __sa_handler) - 0usize];
-    ["Offset of field: __sigaction_u::__sa_sigaction"]
-        [::std::mem::offset_of!(__sigaction_u, __sa_sigaction) - 0usize];
-};
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct __sigaction {
-    pub __sigaction_u: __sigaction_u,
-    pub sa_tramp: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: ::std::os::raw::c_int,
-            arg3: ::std::os::raw::c_int,
-            arg4: *mut siginfo_t,
-            arg5: *mut ::std::os::raw::c_void,
-        ),
-    >,
-    pub sa_mask: sigset_t,
-    pub sa_flags: ::std::os::raw::c_int,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __sigaction"][::std::mem::size_of::<__sigaction>() - 24usize];
-    ["Alignment of __sigaction"][::std::mem::align_of::<__sigaction>() - 8usize];
-    ["Offset of field: __sigaction::__sigaction_u"]
-        [::std::mem::offset_of!(__sigaction, __sigaction_u) - 0usize];
-    ["Offset of field: __sigaction::sa_tramp"]
-        [::std::mem::offset_of!(__sigaction, sa_tramp) - 8usize];
-    ["Offset of field: __sigaction::sa_mask"]
-        [::std::mem::offset_of!(__sigaction, sa_mask) - 16usize];
-    ["Offset of field: __sigaction::sa_flags"]
-        [::std::mem::offset_of!(__sigaction, sa_flags) - 20usize];
-};
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct sigaction {
-    pub __sigaction_u: __sigaction_u,
-    pub sa_mask: sigset_t,
-    pub sa_flags: ::std::os::raw::c_int,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of sigaction"][::std::mem::size_of::<sigaction>() - 16usize];
-    ["Alignment of sigaction"][::std::mem::align_of::<sigaction>() - 8usize];
-    ["Offset of field: sigaction::__sigaction_u"]
-        [::std::mem::offset_of!(sigaction, __sigaction_u) - 0usize];
-    ["Offset of field: sigaction::sa_mask"][::std::mem::offset_of!(sigaction, sa_mask) - 8usize];
-    ["Offset of field: sigaction::sa_flags"][::std::mem::offset_of!(sigaction, sa_flags) - 12usize];
-};
-pub type sig_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sigvec {
-    pub sv_handler: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    pub sv_mask: ::std::os::raw::c_int,
-    pub sv_flags: ::std::os::raw::c_int,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of sigvec"][::std::mem::size_of::<sigvec>() - 16usize];
-    ["Alignment of sigvec"][::std::mem::align_of::<sigvec>() - 8usize];
-    ["Offset of field: sigvec::sv_handler"][::std::mem::offset_of!(sigvec, sv_handler) - 0usize];
-    ["Offset of field: sigvec::sv_mask"][::std::mem::offset_of!(sigvec, sv_mask) - 8usize];
-    ["Offset of field: sigvec::sv_flags"][::std::mem::offset_of!(sigvec, sv_flags) - 12usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sigstack {
-    pub ss_sp: *mut ::std::os::raw::c_char,
-    pub ss_onstack: ::std::os::raw::c_int,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of sigstack"][::std::mem::size_of::<sigstack>() - 16usize];
-    ["Alignment of sigstack"][::std::mem::align_of::<sigstack>() - 8usize];
-    ["Offset of field: sigstack::ss_sp"][::std::mem::offset_of!(sigstack, ss_sp) - 0usize];
-    ["Offset of field: sigstack::ss_onstack"]
-        [::std::mem::offset_of!(sigstack, ss_onstack) - 8usize];
-};
 unsafe extern "C" {
-    pub fn signal(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    ) -> ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: ::std::os::raw::c_int,
-            arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-        ),
-    >;
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timeval {
-    pub tv_sec: __darwin_time_t,
-    pub tv_usec: __darwin_suseconds_t,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of timeval"][::std::mem::size_of::<timeval>() - 16usize];
-    ["Alignment of timeval"][::std::mem::align_of::<timeval>() - 8usize];
-    ["Offset of field: timeval::tv_sec"][::std::mem::offset_of!(timeval, tv_sec) - 0usize];
-    ["Offset of field: timeval::tv_usec"][::std::mem::offset_of!(timeval, tv_usec) - 8usize];
-};
-pub type rlim_t = __uint64_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct rusage {
-    pub ru_utime: timeval,
-    pub ru_stime: timeval,
-    pub ru_maxrss: ::std::os::raw::c_long,
-    pub ru_ixrss: ::std::os::raw::c_long,
-    pub ru_idrss: ::std::os::raw::c_long,
-    pub ru_isrss: ::std::os::raw::c_long,
-    pub ru_minflt: ::std::os::raw::c_long,
-    pub ru_majflt: ::std::os::raw::c_long,
-    pub ru_nswap: ::std::os::raw::c_long,
-    pub ru_inblock: ::std::os::raw::c_long,
-    pub ru_oublock: ::std::os::raw::c_long,
-    pub ru_msgsnd: ::std::os::raw::c_long,
-    pub ru_msgrcv: ::std::os::raw::c_long,
-    pub ru_nsignals: ::std::os::raw::c_long,
-    pub ru_nvcsw: ::std::os::raw::c_long,
-    pub ru_nivcsw: ::std::os::raw::c_long,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of rusage"][::std::mem::size_of::<rusage>() - 144usize];
-    ["Alignment of rusage"][::std::mem::align_of::<rusage>() - 8usize];
-    ["Offset of field: rusage::ru_utime"][::std::mem::offset_of!(rusage, ru_utime) - 0usize];
-    ["Offset of field: rusage::ru_stime"][::std::mem::offset_of!(rusage, ru_stime) - 16usize];
-    ["Offset of field: rusage::ru_maxrss"][::std::mem::offset_of!(rusage, ru_maxrss) - 32usize];
-    ["Offset of field: rusage::ru_ixrss"][::std::mem::offset_of!(rusage, ru_ixrss) - 40usize];
-    ["Offset of field: rusage::ru_idrss"][::std::mem::offset_of!(rusage, ru_idrss) - 48usize];
-    ["Offset of field: rusage::ru_isrss"][::std::mem::offset_of!(rusage, ru_isrss) - 56usize];
-    ["Offset of field: rusage::ru_minflt"][::std::mem::offset_of!(rusage, ru_minflt) - 64usize];
-    ["Offset of field: rusage::ru_majflt"][::std::mem::offset_of!(rusage, ru_majflt) - 72usize];
-    ["Offset of field: rusage::ru_nswap"][::std::mem::offset_of!(rusage, ru_nswap) - 80usize];
-    ["Offset of field: rusage::ru_inblock"][::std::mem::offset_of!(rusage, ru_inblock) - 88usize];
-    ["Offset of field: rusage::ru_oublock"][::std::mem::offset_of!(rusage, ru_oublock) - 96usize];
-    ["Offset of field: rusage::ru_msgsnd"][::std::mem::offset_of!(rusage, ru_msgsnd) - 104usize];
-    ["Offset of field: rusage::ru_msgrcv"][::std::mem::offset_of!(rusage, ru_msgrcv) - 112usize];
-    ["Offset of field: rusage::ru_nsignals"]
-        [::std::mem::offset_of!(rusage, ru_nsignals) - 120usize];
-    ["Offset of field: rusage::ru_nvcsw"][::std::mem::offset_of!(rusage, ru_nvcsw) - 128usize];
-    ["Offset of field: rusage::ru_nivcsw"][::std::mem::offset_of!(rusage, ru_nivcsw) - 136usize];
-};
-pub type rusage_info_t = *mut ::std::os::raw::c_void;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct rusage_info_v0 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of rusage_info_v0"][::std::mem::size_of::<rusage_info_v0>() - 96usize];
-    ["Alignment of rusage_info_v0"][::std::mem::align_of::<rusage_info_v0>() - 8usize];
-    ["Offset of field: rusage_info_v0::ri_uuid"]
-        [::std::mem::offset_of!(rusage_info_v0, ri_uuid) - 0usize];
-    ["Offset of field: rusage_info_v0::ri_user_time"]
-        [::std::mem::offset_of!(rusage_info_v0, ri_user_time) - 16usize];
-    ["Offset of field: rusage_info_v0::ri_system_time"]
-        [::std::mem::offset_of!(rusage_info_v0, ri_system_time) - 24usize];
-    ["Offset of field: rusage_info_v0::ri_pkg_idle_wkups"]
-        [::std::mem::offset_of!(rusage_info_v0, ri_pkg_idle_wkups) - 32usize];
-    ["Offset of field: rusage_info_v0::ri_interrupt_wkups"]
-        [::std::mem::offset_of!(rusage_info_v0, ri_interrupt_wkups) - 40usize];
-    ["Offset of field: rusage_info_v0::ri_pageins"]
-        [::std::mem::offset_of!(rusage_info_v0, ri_pageins) - 48usize];
-    ["Offset of field: rusage_info_v0::ri_wired_size"]
-        [::std::mem::offset_of!(rusage_info_v0, ri_wired_size) - 56usize];
-    ["Offset of field: rusage_info_v0::ri_resident_size"]
-        [::std::mem::offset_of!(rusage_info_v0, ri_resident_size) - 64usize];
-    ["Offset of field: rusage_info_v0::ri_phys_footprint"]
-        [::std::mem::offset_of!(rusage_info_v0, ri_phys_footprint) - 72usize];
-    ["Offset of field: rusage_info_v0::ri_proc_start_abstime"]
-        [::std::mem::offset_of!(rusage_info_v0, ri_proc_start_abstime) - 80usize];
-    ["Offset of field: rusage_info_v0::ri_proc_exit_abstime"]
-        [::std::mem::offset_of!(rusage_info_v0, ri_proc_exit_abstime) - 88usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct rusage_info_v1 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of rusage_info_v1"][::std::mem::size_of::<rusage_info_v1>() - 144usize];
-    ["Alignment of rusage_info_v1"][::std::mem::align_of::<rusage_info_v1>() - 8usize];
-    ["Offset of field: rusage_info_v1::ri_uuid"]
-        [::std::mem::offset_of!(rusage_info_v1, ri_uuid) - 0usize];
-    ["Offset of field: rusage_info_v1::ri_user_time"]
-        [::std::mem::offset_of!(rusage_info_v1, ri_user_time) - 16usize];
-    ["Offset of field: rusage_info_v1::ri_system_time"]
-        [::std::mem::offset_of!(rusage_info_v1, ri_system_time) - 24usize];
-    ["Offset of field: rusage_info_v1::ri_pkg_idle_wkups"]
-        [::std::mem::offset_of!(rusage_info_v1, ri_pkg_idle_wkups) - 32usize];
-    ["Offset of field: rusage_info_v1::ri_interrupt_wkups"]
-        [::std::mem::offset_of!(rusage_info_v1, ri_interrupt_wkups) - 40usize];
-    ["Offset of field: rusage_info_v1::ri_pageins"]
-        [::std::mem::offset_of!(rusage_info_v1, ri_pageins) - 48usize];
-    ["Offset of field: rusage_info_v1::ri_wired_size"]
-        [::std::mem::offset_of!(rusage_info_v1, ri_wired_size) - 56usize];
-    ["Offset of field: rusage_info_v1::ri_resident_size"]
-        [::std::mem::offset_of!(rusage_info_v1, ri_resident_size) - 64usize];
-    ["Offset of field: rusage_info_v1::ri_phys_footprint"]
-        [::std::mem::offset_of!(rusage_info_v1, ri_phys_footprint) - 72usize];
-    ["Offset of field: rusage_info_v1::ri_proc_start_abstime"]
-        [::std::mem::offset_of!(rusage_info_v1, ri_proc_start_abstime) - 80usize];
-    ["Offset of field: rusage_info_v1::ri_proc_exit_abstime"]
-        [::std::mem::offset_of!(rusage_info_v1, ri_proc_exit_abstime) - 88usize];
-    ["Offset of field: rusage_info_v1::ri_child_user_time"]
-        [::std::mem::offset_of!(rusage_info_v1, ri_child_user_time) - 96usize];
-    ["Offset of field: rusage_info_v1::ri_child_system_time"]
-        [::std::mem::offset_of!(rusage_info_v1, ri_child_system_time) - 104usize];
-    ["Offset of field: rusage_info_v1::ri_child_pkg_idle_wkups"]
-        [::std::mem::offset_of!(rusage_info_v1, ri_child_pkg_idle_wkups) - 112usize];
-    ["Offset of field: rusage_info_v1::ri_child_interrupt_wkups"]
-        [::std::mem::offset_of!(rusage_info_v1, ri_child_interrupt_wkups) - 120usize];
-    ["Offset of field: rusage_info_v1::ri_child_pageins"]
-        [::std::mem::offset_of!(rusage_info_v1, ri_child_pageins) - 128usize];
-    ["Offset of field: rusage_info_v1::ri_child_elapsed_abstime"]
-        [::std::mem::offset_of!(rusage_info_v1, ri_child_elapsed_abstime) - 136usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct rusage_info_v2 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of rusage_info_v2"][::std::mem::size_of::<rusage_info_v2>() - 160usize];
-    ["Alignment of rusage_info_v2"][::std::mem::align_of::<rusage_info_v2>() - 8usize];
-    ["Offset of field: rusage_info_v2::ri_uuid"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_uuid) - 0usize];
-    ["Offset of field: rusage_info_v2::ri_user_time"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_user_time) - 16usize];
-    ["Offset of field: rusage_info_v2::ri_system_time"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_system_time) - 24usize];
-    ["Offset of field: rusage_info_v2::ri_pkg_idle_wkups"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_pkg_idle_wkups) - 32usize];
-    ["Offset of field: rusage_info_v2::ri_interrupt_wkups"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_interrupt_wkups) - 40usize];
-    ["Offset of field: rusage_info_v2::ri_pageins"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_pageins) - 48usize];
-    ["Offset of field: rusage_info_v2::ri_wired_size"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_wired_size) - 56usize];
-    ["Offset of field: rusage_info_v2::ri_resident_size"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_resident_size) - 64usize];
-    ["Offset of field: rusage_info_v2::ri_phys_footprint"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_phys_footprint) - 72usize];
-    ["Offset of field: rusage_info_v2::ri_proc_start_abstime"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_proc_start_abstime) - 80usize];
-    ["Offset of field: rusage_info_v2::ri_proc_exit_abstime"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_proc_exit_abstime) - 88usize];
-    ["Offset of field: rusage_info_v2::ri_child_user_time"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_child_user_time) - 96usize];
-    ["Offset of field: rusage_info_v2::ri_child_system_time"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_child_system_time) - 104usize];
-    ["Offset of field: rusage_info_v2::ri_child_pkg_idle_wkups"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_child_pkg_idle_wkups) - 112usize];
-    ["Offset of field: rusage_info_v2::ri_child_interrupt_wkups"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_child_interrupt_wkups) - 120usize];
-    ["Offset of field: rusage_info_v2::ri_child_pageins"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_child_pageins) - 128usize];
-    ["Offset of field: rusage_info_v2::ri_child_elapsed_abstime"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_child_elapsed_abstime) - 136usize];
-    ["Offset of field: rusage_info_v2::ri_diskio_bytesread"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_diskio_bytesread) - 144usize];
-    ["Offset of field: rusage_info_v2::ri_diskio_byteswritten"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_diskio_byteswritten) - 152usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct rusage_info_v3 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-    pub ri_cpu_time_qos_default: u64,
-    pub ri_cpu_time_qos_maintenance: u64,
-    pub ri_cpu_time_qos_background: u64,
-    pub ri_cpu_time_qos_utility: u64,
-    pub ri_cpu_time_qos_legacy: u64,
-    pub ri_cpu_time_qos_user_initiated: u64,
-    pub ri_cpu_time_qos_user_interactive: u64,
-    pub ri_billed_system_time: u64,
-    pub ri_serviced_system_time: u64,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of rusage_info_v3"][::std::mem::size_of::<rusage_info_v3>() - 232usize];
-    ["Alignment of rusage_info_v3"][::std::mem::align_of::<rusage_info_v3>() - 8usize];
-    ["Offset of field: rusage_info_v3::ri_uuid"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_uuid) - 0usize];
-    ["Offset of field: rusage_info_v3::ri_user_time"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_user_time) - 16usize];
-    ["Offset of field: rusage_info_v3::ri_system_time"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_system_time) - 24usize];
-    ["Offset of field: rusage_info_v3::ri_pkg_idle_wkups"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_pkg_idle_wkups) - 32usize];
-    ["Offset of field: rusage_info_v3::ri_interrupt_wkups"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_interrupt_wkups) - 40usize];
-    ["Offset of field: rusage_info_v3::ri_pageins"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_pageins) - 48usize];
-    ["Offset of field: rusage_info_v3::ri_wired_size"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_wired_size) - 56usize];
-    ["Offset of field: rusage_info_v3::ri_resident_size"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_resident_size) - 64usize];
-    ["Offset of field: rusage_info_v3::ri_phys_footprint"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_phys_footprint) - 72usize];
-    ["Offset of field: rusage_info_v3::ri_proc_start_abstime"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_proc_start_abstime) - 80usize];
-    ["Offset of field: rusage_info_v3::ri_proc_exit_abstime"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_proc_exit_abstime) - 88usize];
-    ["Offset of field: rusage_info_v3::ri_child_user_time"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_child_user_time) - 96usize];
-    ["Offset of field: rusage_info_v3::ri_child_system_time"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_child_system_time) - 104usize];
-    ["Offset of field: rusage_info_v3::ri_child_pkg_idle_wkups"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_child_pkg_idle_wkups) - 112usize];
-    ["Offset of field: rusage_info_v3::ri_child_interrupt_wkups"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_child_interrupt_wkups) - 120usize];
-    ["Offset of field: rusage_info_v3::ri_child_pageins"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_child_pageins) - 128usize];
-    ["Offset of field: rusage_info_v3::ri_child_elapsed_abstime"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_child_elapsed_abstime) - 136usize];
-    ["Offset of field: rusage_info_v3::ri_diskio_bytesread"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_diskio_bytesread) - 144usize];
-    ["Offset of field: rusage_info_v3::ri_diskio_byteswritten"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_diskio_byteswritten) - 152usize];
-    ["Offset of field: rusage_info_v3::ri_cpu_time_qos_default"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_cpu_time_qos_default) - 160usize];
-    ["Offset of field: rusage_info_v3::ri_cpu_time_qos_maintenance"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_cpu_time_qos_maintenance) - 168usize];
-    ["Offset of field: rusage_info_v3::ri_cpu_time_qos_background"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_cpu_time_qos_background) - 176usize];
-    ["Offset of field: rusage_info_v3::ri_cpu_time_qos_utility"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_cpu_time_qos_utility) - 184usize];
-    ["Offset of field: rusage_info_v3::ri_cpu_time_qos_legacy"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_cpu_time_qos_legacy) - 192usize];
-    ["Offset of field: rusage_info_v3::ri_cpu_time_qos_user_initiated"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_cpu_time_qos_user_initiated) - 200usize];
-    ["Offset of field: rusage_info_v3::ri_cpu_time_qos_user_interactive"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_cpu_time_qos_user_interactive) - 208usize];
-    ["Offset of field: rusage_info_v3::ri_billed_system_time"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_billed_system_time) - 216usize];
-    ["Offset of field: rusage_info_v3::ri_serviced_system_time"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_serviced_system_time) - 224usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct rusage_info_v4 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-    pub ri_cpu_time_qos_default: u64,
-    pub ri_cpu_time_qos_maintenance: u64,
-    pub ri_cpu_time_qos_background: u64,
-    pub ri_cpu_time_qos_utility: u64,
-    pub ri_cpu_time_qos_legacy: u64,
-    pub ri_cpu_time_qos_user_initiated: u64,
-    pub ri_cpu_time_qos_user_interactive: u64,
-    pub ri_billed_system_time: u64,
-    pub ri_serviced_system_time: u64,
-    pub ri_logical_writes: u64,
-    pub ri_lifetime_max_phys_footprint: u64,
-    pub ri_instructions: u64,
-    pub ri_cycles: u64,
-    pub ri_billed_energy: u64,
-    pub ri_serviced_energy: u64,
-    pub ri_interval_max_phys_footprint: u64,
-    pub ri_runnable_time: u64,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of rusage_info_v4"][::std::mem::size_of::<rusage_info_v4>() - 296usize];
-    ["Alignment of rusage_info_v4"][::std::mem::align_of::<rusage_info_v4>() - 8usize];
-    ["Offset of field: rusage_info_v4::ri_uuid"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_uuid) - 0usize];
-    ["Offset of field: rusage_info_v4::ri_user_time"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_user_time) - 16usize];
-    ["Offset of field: rusage_info_v4::ri_system_time"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_system_time) - 24usize];
-    ["Offset of field: rusage_info_v4::ri_pkg_idle_wkups"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_pkg_idle_wkups) - 32usize];
-    ["Offset of field: rusage_info_v4::ri_interrupt_wkups"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_interrupt_wkups) - 40usize];
-    ["Offset of field: rusage_info_v4::ri_pageins"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_pageins) - 48usize];
-    ["Offset of field: rusage_info_v4::ri_wired_size"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_wired_size) - 56usize];
-    ["Offset of field: rusage_info_v4::ri_resident_size"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_resident_size) - 64usize];
-    ["Offset of field: rusage_info_v4::ri_phys_footprint"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_phys_footprint) - 72usize];
-    ["Offset of field: rusage_info_v4::ri_proc_start_abstime"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_proc_start_abstime) - 80usize];
-    ["Offset of field: rusage_info_v4::ri_proc_exit_abstime"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_proc_exit_abstime) - 88usize];
-    ["Offset of field: rusage_info_v4::ri_child_user_time"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_child_user_time) - 96usize];
-    ["Offset of field: rusage_info_v4::ri_child_system_time"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_child_system_time) - 104usize];
-    ["Offset of field: rusage_info_v4::ri_child_pkg_idle_wkups"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_child_pkg_idle_wkups) - 112usize];
-    ["Offset of field: rusage_info_v4::ri_child_interrupt_wkups"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_child_interrupt_wkups) - 120usize];
-    ["Offset of field: rusage_info_v4::ri_child_pageins"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_child_pageins) - 128usize];
-    ["Offset of field: rusage_info_v4::ri_child_elapsed_abstime"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_child_elapsed_abstime) - 136usize];
-    ["Offset of field: rusage_info_v4::ri_diskio_bytesread"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_diskio_bytesread) - 144usize];
-    ["Offset of field: rusage_info_v4::ri_diskio_byteswritten"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_diskio_byteswritten) - 152usize];
-    ["Offset of field: rusage_info_v4::ri_cpu_time_qos_default"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_cpu_time_qos_default) - 160usize];
-    ["Offset of field: rusage_info_v4::ri_cpu_time_qos_maintenance"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_cpu_time_qos_maintenance) - 168usize];
-    ["Offset of field: rusage_info_v4::ri_cpu_time_qos_background"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_cpu_time_qos_background) - 176usize];
-    ["Offset of field: rusage_info_v4::ri_cpu_time_qos_utility"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_cpu_time_qos_utility) - 184usize];
-    ["Offset of field: rusage_info_v4::ri_cpu_time_qos_legacy"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_cpu_time_qos_legacy) - 192usize];
-    ["Offset of field: rusage_info_v4::ri_cpu_time_qos_user_initiated"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_cpu_time_qos_user_initiated) - 200usize];
-    ["Offset of field: rusage_info_v4::ri_cpu_time_qos_user_interactive"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_cpu_time_qos_user_interactive) - 208usize];
-    ["Offset of field: rusage_info_v4::ri_billed_system_time"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_billed_system_time) - 216usize];
-    ["Offset of field: rusage_info_v4::ri_serviced_system_time"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_serviced_system_time) - 224usize];
-    ["Offset of field: rusage_info_v4::ri_logical_writes"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_logical_writes) - 232usize];
-    ["Offset of field: rusage_info_v4::ri_lifetime_max_phys_footprint"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_lifetime_max_phys_footprint) - 240usize];
-    ["Offset of field: rusage_info_v4::ri_instructions"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_instructions) - 248usize];
-    ["Offset of field: rusage_info_v4::ri_cycles"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_cycles) - 256usize];
-    ["Offset of field: rusage_info_v4::ri_billed_energy"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_billed_energy) - 264usize];
-    ["Offset of field: rusage_info_v4::ri_serviced_energy"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_serviced_energy) - 272usize];
-    ["Offset of field: rusage_info_v4::ri_interval_max_phys_footprint"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_interval_max_phys_footprint) - 280usize];
-    ["Offset of field: rusage_info_v4::ri_runnable_time"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_runnable_time) - 288usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct rusage_info_v5 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-    pub ri_cpu_time_qos_default: u64,
-    pub ri_cpu_time_qos_maintenance: u64,
-    pub ri_cpu_time_qos_background: u64,
-    pub ri_cpu_time_qos_utility: u64,
-    pub ri_cpu_time_qos_legacy: u64,
-    pub ri_cpu_time_qos_user_initiated: u64,
-    pub ri_cpu_time_qos_user_interactive: u64,
-    pub ri_billed_system_time: u64,
-    pub ri_serviced_system_time: u64,
-    pub ri_logical_writes: u64,
-    pub ri_lifetime_max_phys_footprint: u64,
-    pub ri_instructions: u64,
-    pub ri_cycles: u64,
-    pub ri_billed_energy: u64,
-    pub ri_serviced_energy: u64,
-    pub ri_interval_max_phys_footprint: u64,
-    pub ri_runnable_time: u64,
-    pub ri_flags: u64,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of rusage_info_v5"][::std::mem::size_of::<rusage_info_v5>() - 304usize];
-    ["Alignment of rusage_info_v5"][::std::mem::align_of::<rusage_info_v5>() - 8usize];
-    ["Offset of field: rusage_info_v5::ri_uuid"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_uuid) - 0usize];
-    ["Offset of field: rusage_info_v5::ri_user_time"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_user_time) - 16usize];
-    ["Offset of field: rusage_info_v5::ri_system_time"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_system_time) - 24usize];
-    ["Offset of field: rusage_info_v5::ri_pkg_idle_wkups"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_pkg_idle_wkups) - 32usize];
-    ["Offset of field: rusage_info_v5::ri_interrupt_wkups"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_interrupt_wkups) - 40usize];
-    ["Offset of field: rusage_info_v5::ri_pageins"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_pageins) - 48usize];
-    ["Offset of field: rusage_info_v5::ri_wired_size"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_wired_size) - 56usize];
-    ["Offset of field: rusage_info_v5::ri_resident_size"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_resident_size) - 64usize];
-    ["Offset of field: rusage_info_v5::ri_phys_footprint"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_phys_footprint) - 72usize];
-    ["Offset of field: rusage_info_v5::ri_proc_start_abstime"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_proc_start_abstime) - 80usize];
-    ["Offset of field: rusage_info_v5::ri_proc_exit_abstime"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_proc_exit_abstime) - 88usize];
-    ["Offset of field: rusage_info_v5::ri_child_user_time"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_child_user_time) - 96usize];
-    ["Offset of field: rusage_info_v5::ri_child_system_time"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_child_system_time) - 104usize];
-    ["Offset of field: rusage_info_v5::ri_child_pkg_idle_wkups"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_child_pkg_idle_wkups) - 112usize];
-    ["Offset of field: rusage_info_v5::ri_child_interrupt_wkups"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_child_interrupt_wkups) - 120usize];
-    ["Offset of field: rusage_info_v5::ri_child_pageins"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_child_pageins) - 128usize];
-    ["Offset of field: rusage_info_v5::ri_child_elapsed_abstime"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_child_elapsed_abstime) - 136usize];
-    ["Offset of field: rusage_info_v5::ri_diskio_bytesread"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_diskio_bytesread) - 144usize];
-    ["Offset of field: rusage_info_v5::ri_diskio_byteswritten"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_diskio_byteswritten) - 152usize];
-    ["Offset of field: rusage_info_v5::ri_cpu_time_qos_default"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_cpu_time_qos_default) - 160usize];
-    ["Offset of field: rusage_info_v5::ri_cpu_time_qos_maintenance"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_cpu_time_qos_maintenance) - 168usize];
-    ["Offset of field: rusage_info_v5::ri_cpu_time_qos_background"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_cpu_time_qos_background) - 176usize];
-    ["Offset of field: rusage_info_v5::ri_cpu_time_qos_utility"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_cpu_time_qos_utility) - 184usize];
-    ["Offset of field: rusage_info_v5::ri_cpu_time_qos_legacy"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_cpu_time_qos_legacy) - 192usize];
-    ["Offset of field: rusage_info_v5::ri_cpu_time_qos_user_initiated"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_cpu_time_qos_user_initiated) - 200usize];
-    ["Offset of field: rusage_info_v5::ri_cpu_time_qos_user_interactive"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_cpu_time_qos_user_interactive) - 208usize];
-    ["Offset of field: rusage_info_v5::ri_billed_system_time"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_billed_system_time) - 216usize];
-    ["Offset of field: rusage_info_v5::ri_serviced_system_time"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_serviced_system_time) - 224usize];
-    ["Offset of field: rusage_info_v5::ri_logical_writes"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_logical_writes) - 232usize];
-    ["Offset of field: rusage_info_v5::ri_lifetime_max_phys_footprint"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_lifetime_max_phys_footprint) - 240usize];
-    ["Offset of field: rusage_info_v5::ri_instructions"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_instructions) - 248usize];
-    ["Offset of field: rusage_info_v5::ri_cycles"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_cycles) - 256usize];
-    ["Offset of field: rusage_info_v5::ri_billed_energy"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_billed_energy) - 264usize];
-    ["Offset of field: rusage_info_v5::ri_serviced_energy"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_serviced_energy) - 272usize];
-    ["Offset of field: rusage_info_v5::ri_interval_max_phys_footprint"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_interval_max_phys_footprint) - 280usize];
-    ["Offset of field: rusage_info_v5::ri_runnable_time"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_runnable_time) - 288usize];
-    ["Offset of field: rusage_info_v5::ri_flags"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_flags) - 296usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct rusage_info_v6 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-    pub ri_cpu_time_qos_default: u64,
-    pub ri_cpu_time_qos_maintenance: u64,
-    pub ri_cpu_time_qos_background: u64,
-    pub ri_cpu_time_qos_utility: u64,
-    pub ri_cpu_time_qos_legacy: u64,
-    pub ri_cpu_time_qos_user_initiated: u64,
-    pub ri_cpu_time_qos_user_interactive: u64,
-    pub ri_billed_system_time: u64,
-    pub ri_serviced_system_time: u64,
-    pub ri_logical_writes: u64,
-    pub ri_lifetime_max_phys_footprint: u64,
-    pub ri_instructions: u64,
-    pub ri_cycles: u64,
-    pub ri_billed_energy: u64,
-    pub ri_serviced_energy: u64,
-    pub ri_interval_max_phys_footprint: u64,
-    pub ri_runnable_time: u64,
-    pub ri_flags: u64,
-    pub ri_user_ptime: u64,
-    pub ri_system_ptime: u64,
-    pub ri_pinstructions: u64,
-    pub ri_pcycles: u64,
-    pub ri_energy_nj: u64,
-    pub ri_penergy_nj: u64,
-    pub ri_secure_time_in_system: u64,
-    pub ri_secure_ptime_in_system: u64,
-    pub ri_reserved: [u64; 12usize],
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of rusage_info_v6"][::std::mem::size_of::<rusage_info_v6>() - 464usize];
-    ["Alignment of rusage_info_v6"][::std::mem::align_of::<rusage_info_v6>() - 8usize];
-    ["Offset of field: rusage_info_v6::ri_uuid"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_uuid) - 0usize];
-    ["Offset of field: rusage_info_v6::ri_user_time"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_user_time) - 16usize];
-    ["Offset of field: rusage_info_v6::ri_system_time"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_system_time) - 24usize];
-    ["Offset of field: rusage_info_v6::ri_pkg_idle_wkups"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_pkg_idle_wkups) - 32usize];
-    ["Offset of field: rusage_info_v6::ri_interrupt_wkups"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_interrupt_wkups) - 40usize];
-    ["Offset of field: rusage_info_v6::ri_pageins"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_pageins) - 48usize];
-    ["Offset of field: rusage_info_v6::ri_wired_size"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_wired_size) - 56usize];
-    ["Offset of field: rusage_info_v6::ri_resident_size"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_resident_size) - 64usize];
-    ["Offset of field: rusage_info_v6::ri_phys_footprint"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_phys_footprint) - 72usize];
-    ["Offset of field: rusage_info_v6::ri_proc_start_abstime"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_proc_start_abstime) - 80usize];
-    ["Offset of field: rusage_info_v6::ri_proc_exit_abstime"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_proc_exit_abstime) - 88usize];
-    ["Offset of field: rusage_info_v6::ri_child_user_time"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_child_user_time) - 96usize];
-    ["Offset of field: rusage_info_v6::ri_child_system_time"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_child_system_time) - 104usize];
-    ["Offset of field: rusage_info_v6::ri_child_pkg_idle_wkups"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_child_pkg_idle_wkups) - 112usize];
-    ["Offset of field: rusage_info_v6::ri_child_interrupt_wkups"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_child_interrupt_wkups) - 120usize];
-    ["Offset of field: rusage_info_v6::ri_child_pageins"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_child_pageins) - 128usize];
-    ["Offset of field: rusage_info_v6::ri_child_elapsed_abstime"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_child_elapsed_abstime) - 136usize];
-    ["Offset of field: rusage_info_v6::ri_diskio_bytesread"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_diskio_bytesread) - 144usize];
-    ["Offset of field: rusage_info_v6::ri_diskio_byteswritten"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_diskio_byteswritten) - 152usize];
-    ["Offset of field: rusage_info_v6::ri_cpu_time_qos_default"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_cpu_time_qos_default) - 160usize];
-    ["Offset of field: rusage_info_v6::ri_cpu_time_qos_maintenance"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_cpu_time_qos_maintenance) - 168usize];
-    ["Offset of field: rusage_info_v6::ri_cpu_time_qos_background"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_cpu_time_qos_background) - 176usize];
-    ["Offset of field: rusage_info_v6::ri_cpu_time_qos_utility"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_cpu_time_qos_utility) - 184usize];
-    ["Offset of field: rusage_info_v6::ri_cpu_time_qos_legacy"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_cpu_time_qos_legacy) - 192usize];
-    ["Offset of field: rusage_info_v6::ri_cpu_time_qos_user_initiated"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_cpu_time_qos_user_initiated) - 200usize];
-    ["Offset of field: rusage_info_v6::ri_cpu_time_qos_user_interactive"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_cpu_time_qos_user_interactive) - 208usize];
-    ["Offset of field: rusage_info_v6::ri_billed_system_time"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_billed_system_time) - 216usize];
-    ["Offset of field: rusage_info_v6::ri_serviced_system_time"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_serviced_system_time) - 224usize];
-    ["Offset of field: rusage_info_v6::ri_logical_writes"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_logical_writes) - 232usize];
-    ["Offset of field: rusage_info_v6::ri_lifetime_max_phys_footprint"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_lifetime_max_phys_footprint) - 240usize];
-    ["Offset of field: rusage_info_v6::ri_instructions"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_instructions) - 248usize];
-    ["Offset of field: rusage_info_v6::ri_cycles"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_cycles) - 256usize];
-    ["Offset of field: rusage_info_v6::ri_billed_energy"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_billed_energy) - 264usize];
-    ["Offset of field: rusage_info_v6::ri_serviced_energy"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_serviced_energy) - 272usize];
-    ["Offset of field: rusage_info_v6::ri_interval_max_phys_footprint"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_interval_max_phys_footprint) - 280usize];
-    ["Offset of field: rusage_info_v6::ri_runnable_time"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_runnable_time) - 288usize];
-    ["Offset of field: rusage_info_v6::ri_flags"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_flags) - 296usize];
-    ["Offset of field: rusage_info_v6::ri_user_ptime"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_user_ptime) - 304usize];
-    ["Offset of field: rusage_info_v6::ri_system_ptime"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_system_ptime) - 312usize];
-    ["Offset of field: rusage_info_v6::ri_pinstructions"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_pinstructions) - 320usize];
-    ["Offset of field: rusage_info_v6::ri_pcycles"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_pcycles) - 328usize];
-    ["Offset of field: rusage_info_v6::ri_energy_nj"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_energy_nj) - 336usize];
-    ["Offset of field: rusage_info_v6::ri_penergy_nj"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_penergy_nj) - 344usize];
-    ["Offset of field: rusage_info_v6::ri_secure_time_in_system"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_secure_time_in_system) - 352usize];
-    ["Offset of field: rusage_info_v6::ri_secure_ptime_in_system"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_secure_ptime_in_system) - 360usize];
-    ["Offset of field: rusage_info_v6::ri_reserved"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_reserved) - 368usize];
-};
-pub type rusage_info_current = rusage_info_v6;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct rlimit {
-    pub rlim_cur: rlim_t,
-    pub rlim_max: rlim_t,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of rlimit"][::std::mem::size_of::<rlimit>() - 16usize];
-    ["Alignment of rlimit"][::std::mem::align_of::<rlimit>() - 8usize];
-    ["Offset of field: rlimit::rlim_cur"][::std::mem::offset_of!(rlimit, rlim_cur) - 0usize];
-    ["Offset of field: rlimit::rlim_max"][::std::mem::offset_of!(rlimit, rlim_max) - 8usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct proc_rlimit_control_wakeupmon {
-    pub wm_flags: u32,
-    pub wm_rate: i32,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of proc_rlimit_control_wakeupmon"]
-        [::std::mem::size_of::<proc_rlimit_control_wakeupmon>() - 8usize];
-    ["Alignment of proc_rlimit_control_wakeupmon"]
-        [::std::mem::align_of::<proc_rlimit_control_wakeupmon>() - 4usize];
-    ["Offset of field: proc_rlimit_control_wakeupmon::wm_flags"]
-        [::std::mem::offset_of!(proc_rlimit_control_wakeupmon, wm_flags) - 0usize];
-    ["Offset of field: proc_rlimit_control_wakeupmon::wm_rate"]
-        [::std::mem::offset_of!(proc_rlimit_control_wakeupmon, wm_rate) - 4usize];
-};
-unsafe extern "C" {
-    pub fn getpriority(arg1: ::std::os::raw::c_int, arg2: id_t) -> ::std::os::raw::c_int;
+    pub fn __assert_perror_fail(
+        __errnum: ::std::os::raw::c_int,
+        __file: *const ::std::os::raw::c_char,
+        __line: ::std::os::raw::c_uint,
+        __function: *const ::std::os::raw::c_char,
+    ) -> !;
 }
 unsafe extern "C" {
-    pub fn getiopolicy_np(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
+    pub fn __assert(
+        __assertion: *const ::std::os::raw::c_char,
+        __file: *const ::std::os::raw::c_char,
+        __line: ::std::os::raw::c_int,
+    ) -> !;
 }
-unsafe extern "C" {
-    pub fn getrlimit(arg1: ::std::os::raw::c_int, arg2: *mut rlimit) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn getrusage(arg1: ::std::os::raw::c_int, arg2: *mut rusage) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn setpriority(
-        arg1: ::std::os::raw::c_int,
-        arg2: id_t,
-        arg3: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn setiopolicy_np(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-        arg3: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn setrlimit(arg1: ::std::os::raw::c_int, arg2: *const rlimit) -> ::std::os::raw::c_int;
-}
-#[repr(C, packed)]
-#[derive(Debug, Copy, Clone)]
-pub struct _OSUnalignedU16 {
-    pub __val: u16,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of _OSUnalignedU16"][::std::mem::size_of::<_OSUnalignedU16>() - 2usize];
-    ["Alignment of _OSUnalignedU16"][::std::mem::align_of::<_OSUnalignedU16>() - 1usize];
-    ["Offset of field: _OSUnalignedU16::__val"]
-        [::std::mem::offset_of!(_OSUnalignedU16, __val) - 0usize];
-};
-#[repr(C, packed)]
-#[derive(Debug, Copy, Clone)]
-pub struct _OSUnalignedU32 {
-    pub __val: u32,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of _OSUnalignedU32"][::std::mem::size_of::<_OSUnalignedU32>() - 4usize];
-    ["Alignment of _OSUnalignedU32"][::std::mem::align_of::<_OSUnalignedU32>() - 1usize];
-    ["Offset of field: _OSUnalignedU32::__val"]
-        [::std::mem::offset_of!(_OSUnalignedU32, __val) - 0usize];
-};
-#[repr(C, packed)]
-#[derive(Debug, Copy, Clone)]
-pub struct _OSUnalignedU64 {
-    pub __val: u64,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of _OSUnalignedU64"][::std::mem::size_of::<_OSUnalignedU64>() - 8usize];
-    ["Alignment of _OSUnalignedU64"][::std::mem::align_of::<_OSUnalignedU64>() - 1usize];
-    ["Offset of field: _OSUnalignedU64::__val"]
-        [::std::mem::offset_of!(_OSUnalignedU64, __val) - 0usize];
-};
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union wait {
-    pub w_status: ::std::os::raw::c_int,
-    pub w_T: wait__bindgen_ty_1,
-    pub w_S: wait__bindgen_ty_2,
-}
-#[repr(C)]
-#[repr(align(4))]
-#[derive(Debug, Copy, Clone)]
-pub struct wait__bindgen_ty_1 {
-    pub _bitfield_align_1: [u16; 0],
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of wait__bindgen_ty_1"][::std::mem::size_of::<wait__bindgen_ty_1>() - 4usize];
-    ["Alignment of wait__bindgen_ty_1"][::std::mem::align_of::<wait__bindgen_ty_1>() - 4usize];
-};
-impl wait__bindgen_ty_1 {
-    #[inline]
-    pub fn w_Termsig(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 7u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Termsig(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(0usize, 7u8, val as u64)
-        }
-    }
-    #[inline]
-    pub unsafe fn w_Termsig_raw(this: *const Self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 4usize]>>::raw_get(
-                ::std::ptr::addr_of!((*this)._bitfield_1),
-                0usize,
-                7u8,
-            ) as u32)
-        }
-    }
-    #[inline]
-    pub unsafe fn set_w_Termsig_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            <__BindgenBitfieldUnit<[u8; 4usize]>>::raw_set(
-                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
-                0usize,
-                7u8,
-                val as u64,
-            )
-        }
-    }
-    #[inline]
-    pub fn w_Coredump(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(7usize, 1u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Coredump(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(7usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub unsafe fn w_Coredump_raw(this: *const Self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 4usize]>>::raw_get(
-                ::std::ptr::addr_of!((*this)._bitfield_1),
-                7usize,
-                1u8,
-            ) as u32)
-        }
-    }
-    #[inline]
-    pub unsafe fn set_w_Coredump_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            <__BindgenBitfieldUnit<[u8; 4usize]>>::raw_set(
-                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
-                7usize,
-                1u8,
-                val as u64,
-            )
-        }
-    }
-    #[inline]
-    pub fn w_Retcode(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 8u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Retcode(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(8usize, 8u8, val as u64)
-        }
-    }
-    #[inline]
-    pub unsafe fn w_Retcode_raw(this: *const Self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 4usize]>>::raw_get(
-                ::std::ptr::addr_of!((*this)._bitfield_1),
-                8usize,
-                8u8,
-            ) as u32)
-        }
-    }
-    #[inline]
-    pub unsafe fn set_w_Retcode_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            <__BindgenBitfieldUnit<[u8; 4usize]>>::raw_set(
-                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
-                8usize,
-                8u8,
-                val as u64,
-            )
-        }
-    }
-    #[inline]
-    pub fn w_Filler(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(16usize, 16u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Filler(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(16usize, 16u8, val as u64)
-        }
-    }
-    #[inline]
-    pub unsafe fn w_Filler_raw(this: *const Self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 4usize]>>::raw_get(
-                ::std::ptr::addr_of!((*this)._bitfield_1),
-                16usize,
-                16u8,
-            ) as u32)
-        }
-    }
-    #[inline]
-    pub unsafe fn set_w_Filler_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            <__BindgenBitfieldUnit<[u8; 4usize]>>::raw_set(
-                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
-                16usize,
-                16u8,
-                val as u64,
-            )
-        }
-    }
-    #[inline]
-    pub fn new_bitfield_1(
-        w_Termsig: ::std::os::raw::c_uint,
-        w_Coredump: ::std::os::raw::c_uint,
-        w_Retcode: ::std::os::raw::c_uint,
-        w_Filler: ::std::os::raw::c_uint,
-    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
-        __bindgen_bitfield_unit.set(0usize, 7u8, {
-            let w_Termsig: u32 = unsafe { ::std::mem::transmute(w_Termsig) };
-            w_Termsig as u64
-        });
-        __bindgen_bitfield_unit.set(7usize, 1u8, {
-            let w_Coredump: u32 = unsafe { ::std::mem::transmute(w_Coredump) };
-            w_Coredump as u64
-        });
-        __bindgen_bitfield_unit.set(8usize, 8u8, {
-            let w_Retcode: u32 = unsafe { ::std::mem::transmute(w_Retcode) };
-            w_Retcode as u64
-        });
-        __bindgen_bitfield_unit.set(16usize, 16u8, {
-            let w_Filler: u32 = unsafe { ::std::mem::transmute(w_Filler) };
-            w_Filler as u64
-        });
-        __bindgen_bitfield_unit
-    }
-}
-#[repr(C)]
-#[repr(align(4))]
-#[derive(Debug, Copy, Clone)]
-pub struct wait__bindgen_ty_2 {
-    pub _bitfield_align_1: [u16; 0],
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of wait__bindgen_ty_2"][::std::mem::size_of::<wait__bindgen_ty_2>() - 4usize];
-    ["Alignment of wait__bindgen_ty_2"][::std::mem::align_of::<wait__bindgen_ty_2>() - 4usize];
-};
-impl wait__bindgen_ty_2 {
-    #[inline]
-    pub fn w_Stopval(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 8u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Stopval(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(0usize, 8u8, val as u64)
-        }
-    }
-    #[inline]
-    pub unsafe fn w_Stopval_raw(this: *const Self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 4usize]>>::raw_get(
-                ::std::ptr::addr_of!((*this)._bitfield_1),
-                0usize,
-                8u8,
-            ) as u32)
-        }
-    }
-    #[inline]
-    pub unsafe fn set_w_Stopval_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            <__BindgenBitfieldUnit<[u8; 4usize]>>::raw_set(
-                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
-                0usize,
-                8u8,
-                val as u64,
-            )
-        }
-    }
-    #[inline]
-    pub fn w_Stopsig(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 8u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Stopsig(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(8usize, 8u8, val as u64)
-        }
-    }
-    #[inline]
-    pub unsafe fn w_Stopsig_raw(this: *const Self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 4usize]>>::raw_get(
-                ::std::ptr::addr_of!((*this)._bitfield_1),
-                8usize,
-                8u8,
-            ) as u32)
-        }
-    }
-    #[inline]
-    pub unsafe fn set_w_Stopsig_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            <__BindgenBitfieldUnit<[u8; 4usize]>>::raw_set(
-                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
-                8usize,
-                8u8,
-                val as u64,
-            )
-        }
-    }
-    #[inline]
-    pub fn w_Filler(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(16usize, 16u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Filler(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(16usize, 16u8, val as u64)
-        }
-    }
-    #[inline]
-    pub unsafe fn w_Filler_raw(this: *const Self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 4usize]>>::raw_get(
-                ::std::ptr::addr_of!((*this)._bitfield_1),
-                16usize,
-                16u8,
-            ) as u32)
-        }
-    }
-    #[inline]
-    pub unsafe fn set_w_Filler_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            <__BindgenBitfieldUnit<[u8; 4usize]>>::raw_set(
-                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
-                16usize,
-                16u8,
-                val as u64,
-            )
-        }
-    }
-    #[inline]
-    pub fn new_bitfield_1(
-        w_Stopval: ::std::os::raw::c_uint,
-        w_Stopsig: ::std::os::raw::c_uint,
-        w_Filler: ::std::os::raw::c_uint,
-    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
-        __bindgen_bitfield_unit.set(0usize, 8u8, {
-            let w_Stopval: u32 = unsafe { ::std::mem::transmute(w_Stopval) };
-            w_Stopval as u64
-        });
-        __bindgen_bitfield_unit.set(8usize, 8u8, {
-            let w_Stopsig: u32 = unsafe { ::std::mem::transmute(w_Stopsig) };
-            w_Stopsig as u64
-        });
-        __bindgen_bitfield_unit.set(16usize, 16u8, {
-            let w_Filler: u32 = unsafe { ::std::mem::transmute(w_Filler) };
-            w_Filler as u64
-        });
-        __bindgen_bitfield_unit
-    }
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of wait"][::std::mem::size_of::<wait>() - 4usize];
-    ["Alignment of wait"][::std::mem::align_of::<wait>() - 4usize];
-    ["Offset of field: wait::w_status"][::std::mem::offset_of!(wait, w_status) - 0usize];
-    ["Offset of field: wait::w_T"][::std::mem::offset_of!(wait, w_T) - 0usize];
-    ["Offset of field: wait::w_S"][::std::mem::offset_of!(wait, w_S) - 0usize];
-};
-unsafe extern "C" {
-    pub fn wait(arg1: *mut ::std::os::raw::c_int) -> pid_t;
-}
-unsafe extern "C" {
-    pub fn waitpid(
-        arg1: pid_t,
-        arg2: *mut ::std::os::raw::c_int,
-        arg3: ::std::os::raw::c_int,
-    ) -> pid_t;
-}
-unsafe extern "C" {
-    pub fn waitid(
-        arg1: idtype_t,
-        arg2: id_t,
-        arg3: *mut siginfo_t,
-        arg4: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn wait3(
-        arg1: *mut ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-        arg3: *mut rusage,
-    ) -> pid_t;
-}
-unsafe extern "C" {
-    pub fn wait4(
-        arg1: pid_t,
-        arg2: *mut ::std::os::raw::c_int,
-        arg3: ::std::os::raw::c_int,
-        arg4: *mut rusage,
-    ) -> pid_t;
-}
-unsafe extern "C" {
-    pub fn alloca(arg1: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void;
-}
-pub type ct_rune_t = __darwin_ct_rune_t;
-pub type rune_t = __darwin_rune_t;
-pub type wchar_t = __darwin_wchar_t;
+pub type wchar_t = ::std::os::raw::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct div_t {
@@ -4461,115 +2895,722 @@ const _: () = {
     ["Offset of field: lldiv_t::rem"][::std::mem::offset_of!(lldiv_t, rem) - 8usize];
 };
 unsafe extern "C" {
-    pub static mut __mb_cur_max: ::std::os::raw::c_int;
-}
-pub type malloc_type_id_t = ::std::os::raw::c_ulonglong;
-unsafe extern "C" {
-    pub fn malloc_type_malloc(
-        size: usize,
-        type_id: malloc_type_id_t,
-    ) -> *mut ::std::os::raw::c_void;
+    pub fn __ctype_get_mb_cur_max() -> usize;
 }
 unsafe extern "C" {
-    pub fn malloc_type_calloc(
-        count: usize,
-        size: usize,
-        type_id: malloc_type_id_t,
-    ) -> *mut ::std::os::raw::c_void;
+    pub fn atof(__nptr: *const ::std::os::raw::c_char) -> f64;
 }
 unsafe extern "C" {
-    pub fn malloc_type_free(ptr: *mut ::std::os::raw::c_void, type_id: malloc_type_id_t);
+    pub fn atoi(__nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn malloc_type_realloc(
-        ptr: *mut ::std::os::raw::c_void,
-        size: usize,
-        type_id: malloc_type_id_t,
-    ) -> *mut ::std::os::raw::c_void;
+    pub fn atol(__nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
 }
 unsafe extern "C" {
-    pub fn malloc_type_valloc(
-        size: usize,
-        type_id: malloc_type_id_t,
-    ) -> *mut ::std::os::raw::c_void;
+    pub fn atoll(__nptr: *const ::std::os::raw::c_char) -> ::std::os::raw::c_longlong;
 }
 unsafe extern "C" {
-    pub fn malloc_type_aligned_alloc(
-        alignment: usize,
-        size: usize,
-        type_id: malloc_type_id_t,
-    ) -> *mut ::std::os::raw::c_void;
+    pub fn strtod(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+    ) -> f64;
 }
 unsafe extern "C" {
-    pub fn malloc_type_posix_memalign(
-        memptr: *mut *mut ::std::os::raw::c_void,
-        alignment: usize,
-        size: usize,
-        type_id: malloc_type_id_t,
+    pub fn strtof(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+    ) -> f32;
+}
+unsafe extern "C" {
+    pub fn strtold(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+    ) -> u128;
+}
+unsafe extern "C" {
+    pub fn strtol(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn strtoul(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_ulong;
+}
+unsafe extern "C" {
+    pub fn strtoq(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_longlong;
+}
+unsafe extern "C" {
+    pub fn strtouq(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_ulonglong;
+}
+unsafe extern "C" {
+    pub fn strtoll(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_longlong;
+}
+unsafe extern "C" {
+    pub fn strtoull(
+        __nptr: *const ::std::os::raw::c_char,
+        __endptr: *mut *mut ::std::os::raw::c_char,
+        __base: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_ulonglong;
+}
+unsafe extern "C" {
+    pub fn l64a(__n: ::std::os::raw::c_long) -> *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn a64l(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
+}
+pub type u_char = __u_char;
+pub type u_short = __u_short;
+pub type u_int = __u_int;
+pub type u_long = __u_long;
+pub type quad_t = __quad_t;
+pub type u_quad_t = __u_quad_t;
+pub type fsid_t = __fsid_t;
+pub type loff_t = __loff_t;
+pub type ino_t = __ino_t;
+pub type dev_t = __dev_t;
+pub type gid_t = __gid_t;
+pub type mode_t = __mode_t;
+pub type nlink_t = __nlink_t;
+pub type uid_t = __uid_t;
+pub type pid_t = __pid_t;
+pub type id_t = __id_t;
+pub type daddr_t = __daddr_t;
+pub type caddr_t = __caddr_t;
+pub type key_t = __key_t;
+pub type clock_t = __clock_t;
+pub type clockid_t = __clockid_t;
+pub type time_t = __time_t;
+pub type timer_t = __timer_t;
+pub type ulong = ::std::os::raw::c_ulong;
+pub type ushort = ::std::os::raw::c_ushort;
+pub type uint = ::std::os::raw::c_uint;
+pub type u_int8_t = __uint8_t;
+pub type u_int16_t = __uint16_t;
+pub type u_int32_t = __uint32_t;
+pub type u_int64_t = __uint64_t;
+pub type register_t = ::std::os::raw::c_long;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __sigset_t {
+    pub __val: [::std::os::raw::c_ulong; 16usize],
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of __sigset_t"][::std::mem::size_of::<__sigset_t>() - 128usize];
+    ["Alignment of __sigset_t"][::std::mem::align_of::<__sigset_t>() - 8usize];
+    ["Offset of field: __sigset_t::__val"][::std::mem::offset_of!(__sigset_t, __val) - 0usize];
+};
+pub type sigset_t = __sigset_t;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct timeval {
+    pub tv_sec: __time_t,
+    pub tv_usec: __suseconds_t,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of timeval"][::std::mem::size_of::<timeval>() - 16usize];
+    ["Alignment of timeval"][::std::mem::align_of::<timeval>() - 8usize];
+    ["Offset of field: timeval::tv_sec"][::std::mem::offset_of!(timeval, tv_sec) - 0usize];
+    ["Offset of field: timeval::tv_usec"][::std::mem::offset_of!(timeval, tv_usec) - 8usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct timespec {
+    pub tv_sec: __time_t,
+    pub tv_nsec: __syscall_slong_t,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of timespec"][::std::mem::size_of::<timespec>() - 16usize];
+    ["Alignment of timespec"][::std::mem::align_of::<timespec>() - 8usize];
+    ["Offset of field: timespec::tv_sec"][::std::mem::offset_of!(timespec, tv_sec) - 0usize];
+    ["Offset of field: timespec::tv_nsec"][::std::mem::offset_of!(timespec, tv_nsec) - 8usize];
+};
+pub type suseconds_t = __suseconds_t;
+pub type __fd_mask = ::std::os::raw::c_long;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct fd_set {
+    pub __fds_bits: [__fd_mask; 16usize],
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of fd_set"][::std::mem::size_of::<fd_set>() - 128usize];
+    ["Alignment of fd_set"][::std::mem::align_of::<fd_set>() - 8usize];
+    ["Offset of field: fd_set::__fds_bits"][::std::mem::offset_of!(fd_set, __fds_bits) - 0usize];
+};
+pub type fd_mask = __fd_mask;
+unsafe extern "C" {
+    pub fn select(
+        __nfds: ::std::os::raw::c_int,
+        __readfds: *mut fd_set,
+        __writefds: *mut fd_set,
+        __exceptfds: *mut fd_set,
+        __timeout: *mut timeval,
     ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn pselect(
+        __nfds: ::std::os::raw::c_int,
+        __readfds: *mut fd_set,
+        __writefds: *mut fd_set,
+        __exceptfds: *mut fd_set,
+        __timeout: *const timespec,
+        __sigmask: *const __sigset_t,
+    ) -> ::std::os::raw::c_int;
+}
+pub type blksize_t = __blksize_t;
+pub type blkcnt_t = __blkcnt_t;
+pub type fsblkcnt_t = __fsblkcnt_t;
+pub type fsfilcnt_t = __fsfilcnt_t;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union __atomic_wide_counter {
+    pub __value64: ::std::os::raw::c_ulonglong,
+    pub __value32: __atomic_wide_counter__bindgen_ty_1,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct _malloc_zone_t {
-    _unused: [u8; 0],
+pub struct __atomic_wide_counter__bindgen_ty_1 {
+    pub __low: ::std::os::raw::c_uint,
+    pub __high: ::std::os::raw::c_uint,
 }
-pub type malloc_zone_t = _malloc_zone_t;
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of __atomic_wide_counter__bindgen_ty_1"]
+        [::std::mem::size_of::<__atomic_wide_counter__bindgen_ty_1>() - 8usize];
+    ["Alignment of __atomic_wide_counter__bindgen_ty_1"]
+        [::std::mem::align_of::<__atomic_wide_counter__bindgen_ty_1>() - 4usize];
+    ["Offset of field: __atomic_wide_counter__bindgen_ty_1::__low"]
+        [::std::mem::offset_of!(__atomic_wide_counter__bindgen_ty_1, __low) - 0usize];
+    ["Offset of field: __atomic_wide_counter__bindgen_ty_1::__high"]
+        [::std::mem::offset_of!(__atomic_wide_counter__bindgen_ty_1, __high) - 4usize];
+};
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of __atomic_wide_counter"][::std::mem::size_of::<__atomic_wide_counter>() - 8usize];
+    ["Alignment of __atomic_wide_counter"]
+        [::std::mem::align_of::<__atomic_wide_counter>() - 8usize];
+    ["Offset of field: __atomic_wide_counter::__value64"]
+        [::std::mem::offset_of!(__atomic_wide_counter, __value64) - 0usize];
+    ["Offset of field: __atomic_wide_counter::__value32"]
+        [::std::mem::offset_of!(__atomic_wide_counter, __value32) - 0usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __pthread_internal_list {
+    pub __prev: *mut __pthread_internal_list,
+    pub __next: *mut __pthread_internal_list,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of __pthread_internal_list"][::std::mem::size_of::<__pthread_internal_list>() - 16usize];
+    ["Alignment of __pthread_internal_list"]
+        [::std::mem::align_of::<__pthread_internal_list>() - 8usize];
+    ["Offset of field: __pthread_internal_list::__prev"]
+        [::std::mem::offset_of!(__pthread_internal_list, __prev) - 0usize];
+    ["Offset of field: __pthread_internal_list::__next"]
+        [::std::mem::offset_of!(__pthread_internal_list, __next) - 8usize];
+};
+pub type __pthread_list_t = __pthread_internal_list;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __pthread_internal_slist {
+    pub __next: *mut __pthread_internal_slist,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of __pthread_internal_slist"]
+        [::std::mem::size_of::<__pthread_internal_slist>() - 8usize];
+    ["Alignment of __pthread_internal_slist"]
+        [::std::mem::align_of::<__pthread_internal_slist>() - 8usize];
+    ["Offset of field: __pthread_internal_slist::__next"]
+        [::std::mem::offset_of!(__pthread_internal_slist, __next) - 0usize];
+};
+pub type __pthread_slist_t = __pthread_internal_slist;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __pthread_mutex_s {
+    pub __lock: ::std::os::raw::c_int,
+    pub __count: ::std::os::raw::c_uint,
+    pub __owner: ::std::os::raw::c_int,
+    pub __nusers: ::std::os::raw::c_uint,
+    pub __kind: ::std::os::raw::c_int,
+    pub __spins: ::std::os::raw::c_short,
+    pub __elision: ::std::os::raw::c_short,
+    pub __list: __pthread_list_t,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of __pthread_mutex_s"][::std::mem::size_of::<__pthread_mutex_s>() - 40usize];
+    ["Alignment of __pthread_mutex_s"][::std::mem::align_of::<__pthread_mutex_s>() - 8usize];
+    ["Offset of field: __pthread_mutex_s::__lock"]
+        [::std::mem::offset_of!(__pthread_mutex_s, __lock) - 0usize];
+    ["Offset of field: __pthread_mutex_s::__count"]
+        [::std::mem::offset_of!(__pthread_mutex_s, __count) - 4usize];
+    ["Offset of field: __pthread_mutex_s::__owner"]
+        [::std::mem::offset_of!(__pthread_mutex_s, __owner) - 8usize];
+    ["Offset of field: __pthread_mutex_s::__nusers"]
+        [::std::mem::offset_of!(__pthread_mutex_s, __nusers) - 12usize];
+    ["Offset of field: __pthread_mutex_s::__kind"]
+        [::std::mem::offset_of!(__pthread_mutex_s, __kind) - 16usize];
+    ["Offset of field: __pthread_mutex_s::__spins"]
+        [::std::mem::offset_of!(__pthread_mutex_s, __spins) - 20usize];
+    ["Offset of field: __pthread_mutex_s::__elision"]
+        [::std::mem::offset_of!(__pthread_mutex_s, __elision) - 22usize];
+    ["Offset of field: __pthread_mutex_s::__list"]
+        [::std::mem::offset_of!(__pthread_mutex_s, __list) - 24usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __pthread_rwlock_arch_t {
+    pub __readers: ::std::os::raw::c_uint,
+    pub __writers: ::std::os::raw::c_uint,
+    pub __wrphase_futex: ::std::os::raw::c_uint,
+    pub __writers_futex: ::std::os::raw::c_uint,
+    pub __pad3: ::std::os::raw::c_uint,
+    pub __pad4: ::std::os::raw::c_uint,
+    pub __cur_writer: ::std::os::raw::c_int,
+    pub __shared: ::std::os::raw::c_int,
+    pub __rwelision: ::std::os::raw::c_schar,
+    pub __pad1: [::std::os::raw::c_uchar; 7usize],
+    pub __pad2: ::std::os::raw::c_ulong,
+    pub __flags: ::std::os::raw::c_uint,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of __pthread_rwlock_arch_t"][::std::mem::size_of::<__pthread_rwlock_arch_t>() - 56usize];
+    ["Alignment of __pthread_rwlock_arch_t"]
+        [::std::mem::align_of::<__pthread_rwlock_arch_t>() - 8usize];
+    ["Offset of field: __pthread_rwlock_arch_t::__readers"]
+        [::std::mem::offset_of!(__pthread_rwlock_arch_t, __readers) - 0usize];
+    ["Offset of field: __pthread_rwlock_arch_t::__writers"]
+        [::std::mem::offset_of!(__pthread_rwlock_arch_t, __writers) - 4usize];
+    ["Offset of field: __pthread_rwlock_arch_t::__wrphase_futex"]
+        [::std::mem::offset_of!(__pthread_rwlock_arch_t, __wrphase_futex) - 8usize];
+    ["Offset of field: __pthread_rwlock_arch_t::__writers_futex"]
+        [::std::mem::offset_of!(__pthread_rwlock_arch_t, __writers_futex) - 12usize];
+    ["Offset of field: __pthread_rwlock_arch_t::__pad3"]
+        [::std::mem::offset_of!(__pthread_rwlock_arch_t, __pad3) - 16usize];
+    ["Offset of field: __pthread_rwlock_arch_t::__pad4"]
+        [::std::mem::offset_of!(__pthread_rwlock_arch_t, __pad4) - 20usize];
+    ["Offset of field: __pthread_rwlock_arch_t::__cur_writer"]
+        [::std::mem::offset_of!(__pthread_rwlock_arch_t, __cur_writer) - 24usize];
+    ["Offset of field: __pthread_rwlock_arch_t::__shared"]
+        [::std::mem::offset_of!(__pthread_rwlock_arch_t, __shared) - 28usize];
+    ["Offset of field: __pthread_rwlock_arch_t::__rwelision"]
+        [::std::mem::offset_of!(__pthread_rwlock_arch_t, __rwelision) - 32usize];
+    ["Offset of field: __pthread_rwlock_arch_t::__pad1"]
+        [::std::mem::offset_of!(__pthread_rwlock_arch_t, __pad1) - 33usize];
+    ["Offset of field: __pthread_rwlock_arch_t::__pad2"]
+        [::std::mem::offset_of!(__pthread_rwlock_arch_t, __pad2) - 40usize];
+    ["Offset of field: __pthread_rwlock_arch_t::__flags"]
+        [::std::mem::offset_of!(__pthread_rwlock_arch_t, __flags) - 48usize];
+};
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __pthread_cond_s {
+    pub __wseq: __atomic_wide_counter,
+    pub __g1_start: __atomic_wide_counter,
+    pub __g_refs: [::std::os::raw::c_uint; 2usize],
+    pub __g_size: [::std::os::raw::c_uint; 2usize],
+    pub __g1_orig_size: ::std::os::raw::c_uint,
+    pub __wrefs: ::std::os::raw::c_uint,
+    pub __g_signals: [::std::os::raw::c_uint; 2usize],
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of __pthread_cond_s"][::std::mem::size_of::<__pthread_cond_s>() - 48usize];
+    ["Alignment of __pthread_cond_s"][::std::mem::align_of::<__pthread_cond_s>() - 8usize];
+    ["Offset of field: __pthread_cond_s::__wseq"]
+        [::std::mem::offset_of!(__pthread_cond_s, __wseq) - 0usize];
+    ["Offset of field: __pthread_cond_s::__g1_start"]
+        [::std::mem::offset_of!(__pthread_cond_s, __g1_start) - 8usize];
+    ["Offset of field: __pthread_cond_s::__g_refs"]
+        [::std::mem::offset_of!(__pthread_cond_s, __g_refs) - 16usize];
+    ["Offset of field: __pthread_cond_s::__g_size"]
+        [::std::mem::offset_of!(__pthread_cond_s, __g_size) - 24usize];
+    ["Offset of field: __pthread_cond_s::__g1_orig_size"]
+        [::std::mem::offset_of!(__pthread_cond_s, __g1_orig_size) - 32usize];
+    ["Offset of field: __pthread_cond_s::__wrefs"]
+        [::std::mem::offset_of!(__pthread_cond_s, __wrefs) - 36usize];
+    ["Offset of field: __pthread_cond_s::__g_signals"]
+        [::std::mem::offset_of!(__pthread_cond_s, __g_signals) - 40usize];
+};
+pub type __tss_t = ::std::os::raw::c_uint;
+pub type __thrd_t = ::std::os::raw::c_ulong;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __once_flag {
+    pub __data: ::std::os::raw::c_int,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of __once_flag"][::std::mem::size_of::<__once_flag>() - 4usize];
+    ["Alignment of __once_flag"][::std::mem::align_of::<__once_flag>() - 4usize];
+    ["Offset of field: __once_flag::__data"][::std::mem::offset_of!(__once_flag, __data) - 0usize];
+};
+pub type pthread_t = ::std::os::raw::c_ulong;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_mutexattr_t {
+    pub __size: [::std::os::raw::c_char; 4usize],
+    pub __align: ::std::os::raw::c_int,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of pthread_mutexattr_t"][::std::mem::size_of::<pthread_mutexattr_t>() - 4usize];
+    ["Alignment of pthread_mutexattr_t"][::std::mem::align_of::<pthread_mutexattr_t>() - 4usize];
+    ["Offset of field: pthread_mutexattr_t::__size"]
+        [::std::mem::offset_of!(pthread_mutexattr_t, __size) - 0usize];
+    ["Offset of field: pthread_mutexattr_t::__align"]
+        [::std::mem::offset_of!(pthread_mutexattr_t, __align) - 0usize];
+};
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_condattr_t {
+    pub __size: [::std::os::raw::c_char; 4usize],
+    pub __align: ::std::os::raw::c_int,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of pthread_condattr_t"][::std::mem::size_of::<pthread_condattr_t>() - 4usize];
+    ["Alignment of pthread_condattr_t"][::std::mem::align_of::<pthread_condattr_t>() - 4usize];
+    ["Offset of field: pthread_condattr_t::__size"]
+        [::std::mem::offset_of!(pthread_condattr_t, __size) - 0usize];
+    ["Offset of field: pthread_condattr_t::__align"]
+        [::std::mem::offset_of!(pthread_condattr_t, __align) - 0usize];
+};
+pub type pthread_key_t = ::std::os::raw::c_uint;
+pub type pthread_once_t = ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_attr_t {
+    pub __size: [::std::os::raw::c_char; 56usize],
+    pub __align: ::std::os::raw::c_long,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of pthread_attr_t"][::std::mem::size_of::<pthread_attr_t>() - 56usize];
+    ["Alignment of pthread_attr_t"][::std::mem::align_of::<pthread_attr_t>() - 8usize];
+    ["Offset of field: pthread_attr_t::__size"]
+        [::std::mem::offset_of!(pthread_attr_t, __size) - 0usize];
+    ["Offset of field: pthread_attr_t::__align"]
+        [::std::mem::offset_of!(pthread_attr_t, __align) - 0usize];
+};
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_mutex_t {
+    pub __data: __pthread_mutex_s,
+    pub __size: [::std::os::raw::c_char; 40usize],
+    pub __align: ::std::os::raw::c_long,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of pthread_mutex_t"][::std::mem::size_of::<pthread_mutex_t>() - 40usize];
+    ["Alignment of pthread_mutex_t"][::std::mem::align_of::<pthread_mutex_t>() - 8usize];
+    ["Offset of field: pthread_mutex_t::__data"]
+        [::std::mem::offset_of!(pthread_mutex_t, __data) - 0usize];
+    ["Offset of field: pthread_mutex_t::__size"]
+        [::std::mem::offset_of!(pthread_mutex_t, __size) - 0usize];
+    ["Offset of field: pthread_mutex_t::__align"]
+        [::std::mem::offset_of!(pthread_mutex_t, __align) - 0usize];
+};
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_cond_t {
+    pub __data: __pthread_cond_s,
+    pub __size: [::std::os::raw::c_char; 48usize],
+    pub __align: ::std::os::raw::c_longlong,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of pthread_cond_t"][::std::mem::size_of::<pthread_cond_t>() - 48usize];
+    ["Alignment of pthread_cond_t"][::std::mem::align_of::<pthread_cond_t>() - 8usize];
+    ["Offset of field: pthread_cond_t::__data"]
+        [::std::mem::offset_of!(pthread_cond_t, __data) - 0usize];
+    ["Offset of field: pthread_cond_t::__size"]
+        [::std::mem::offset_of!(pthread_cond_t, __size) - 0usize];
+    ["Offset of field: pthread_cond_t::__align"]
+        [::std::mem::offset_of!(pthread_cond_t, __align) - 0usize];
+};
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_rwlock_t {
+    pub __data: __pthread_rwlock_arch_t,
+    pub __size: [::std::os::raw::c_char; 56usize],
+    pub __align: ::std::os::raw::c_long,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of pthread_rwlock_t"][::std::mem::size_of::<pthread_rwlock_t>() - 56usize];
+    ["Alignment of pthread_rwlock_t"][::std::mem::align_of::<pthread_rwlock_t>() - 8usize];
+    ["Offset of field: pthread_rwlock_t::__data"]
+        [::std::mem::offset_of!(pthread_rwlock_t, __data) - 0usize];
+    ["Offset of field: pthread_rwlock_t::__size"]
+        [::std::mem::offset_of!(pthread_rwlock_t, __size) - 0usize];
+    ["Offset of field: pthread_rwlock_t::__align"]
+        [::std::mem::offset_of!(pthread_rwlock_t, __align) - 0usize];
+};
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_rwlockattr_t {
+    pub __size: [::std::os::raw::c_char; 8usize],
+    pub __align: ::std::os::raw::c_long,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of pthread_rwlockattr_t"][::std::mem::size_of::<pthread_rwlockattr_t>() - 8usize];
+    ["Alignment of pthread_rwlockattr_t"][::std::mem::align_of::<pthread_rwlockattr_t>() - 8usize];
+    ["Offset of field: pthread_rwlockattr_t::__size"]
+        [::std::mem::offset_of!(pthread_rwlockattr_t, __size) - 0usize];
+    ["Offset of field: pthread_rwlockattr_t::__align"]
+        [::std::mem::offset_of!(pthread_rwlockattr_t, __align) - 0usize];
+};
+pub type pthread_spinlock_t = ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_barrier_t {
+    pub __size: [::std::os::raw::c_char; 32usize],
+    pub __align: ::std::os::raw::c_long,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of pthread_barrier_t"][::std::mem::size_of::<pthread_barrier_t>() - 32usize];
+    ["Alignment of pthread_barrier_t"][::std::mem::align_of::<pthread_barrier_t>() - 8usize];
+    ["Offset of field: pthread_barrier_t::__size"]
+        [::std::mem::offset_of!(pthread_barrier_t, __size) - 0usize];
+    ["Offset of field: pthread_barrier_t::__align"]
+        [::std::mem::offset_of!(pthread_barrier_t, __align) - 0usize];
+};
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union pthread_barrierattr_t {
+    pub __size: [::std::os::raw::c_char; 4usize],
+    pub __align: ::std::os::raw::c_int,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of pthread_barrierattr_t"][::std::mem::size_of::<pthread_barrierattr_t>() - 4usize];
+    ["Alignment of pthread_barrierattr_t"]
+        [::std::mem::align_of::<pthread_barrierattr_t>() - 4usize];
+    ["Offset of field: pthread_barrierattr_t::__size"]
+        [::std::mem::offset_of!(pthread_barrierattr_t, __size) - 0usize];
+    ["Offset of field: pthread_barrierattr_t::__align"]
+        [::std::mem::offset_of!(pthread_barrierattr_t, __align) - 0usize];
+};
 unsafe extern "C" {
-    pub fn malloc_type_zone_malloc(
-        zone: *mut malloc_zone_t,
-        size: usize,
-        type_id: malloc_type_id_t,
-    ) -> *mut ::std::os::raw::c_void;
+    pub fn random() -> ::std::os::raw::c_long;
 }
 unsafe extern "C" {
-    pub fn malloc_type_zone_calloc(
-        zone: *mut malloc_zone_t,
-        count: usize,
-        size: usize,
-        type_id: malloc_type_id_t,
-    ) -> *mut ::std::os::raw::c_void;
+    pub fn srandom(__seed: ::std::os::raw::c_uint);
 }
 unsafe extern "C" {
-    pub fn malloc_type_zone_free(
-        zone: *mut malloc_zone_t,
-        ptr: *mut ::std::os::raw::c_void,
-        type_id: malloc_type_id_t,
-    );
+    pub fn initstate(
+        __seed: ::std::os::raw::c_uint,
+        __statebuf: *mut ::std::os::raw::c_char,
+        __statelen: usize,
+    ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn malloc_type_zone_realloc(
-        zone: *mut malloc_zone_t,
-        ptr: *mut ::std::os::raw::c_void,
-        size: usize,
-        type_id: malloc_type_id_t,
-    ) -> *mut ::std::os::raw::c_void;
+    pub fn setstate(__statebuf: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct random_data {
+    pub fptr: *mut i32,
+    pub rptr: *mut i32,
+    pub state: *mut i32,
+    pub rand_type: ::std::os::raw::c_int,
+    pub rand_deg: ::std::os::raw::c_int,
+    pub rand_sep: ::std::os::raw::c_int,
+    pub end_ptr: *mut i32,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of random_data"][::std::mem::size_of::<random_data>() - 48usize];
+    ["Alignment of random_data"][::std::mem::align_of::<random_data>() - 8usize];
+    ["Offset of field: random_data::fptr"][::std::mem::offset_of!(random_data, fptr) - 0usize];
+    ["Offset of field: random_data::rptr"][::std::mem::offset_of!(random_data, rptr) - 8usize];
+    ["Offset of field: random_data::state"][::std::mem::offset_of!(random_data, state) - 16usize];
+    ["Offset of field: random_data::rand_type"]
+        [::std::mem::offset_of!(random_data, rand_type) - 24usize];
+    ["Offset of field: random_data::rand_deg"]
+        [::std::mem::offset_of!(random_data, rand_deg) - 28usize];
+    ["Offset of field: random_data::rand_sep"]
+        [::std::mem::offset_of!(random_data, rand_sep) - 32usize];
+    ["Offset of field: random_data::end_ptr"]
+        [::std::mem::offset_of!(random_data, end_ptr) - 40usize];
+};
+unsafe extern "C" {
+    pub fn random_r(__buf: *mut random_data, __result: *mut i32) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn malloc_type_zone_valloc(
-        zone: *mut malloc_zone_t,
-        size: usize,
-        type_id: malloc_type_id_t,
-    ) -> *mut ::std::os::raw::c_void;
+    pub fn srandom_r(
+        __seed: ::std::os::raw::c_uint,
+        __buf: *mut random_data,
+    ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn malloc_type_zone_memalign(
-        zone: *mut malloc_zone_t,
-        alignment: usize,
-        size: usize,
-        type_id: malloc_type_id_t,
-    ) -> *mut ::std::os::raw::c_void;
+    pub fn initstate_r(
+        __seed: ::std::os::raw::c_uint,
+        __statebuf: *mut ::std::os::raw::c_char,
+        __statelen: usize,
+        __buf: *mut random_data,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn setstate_r(
+        __statebuf: *mut ::std::os::raw::c_char,
+        __buf: *mut random_data,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn rand() -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn srand(__seed: ::std::os::raw::c_uint);
+}
+unsafe extern "C" {
+    pub fn rand_r(__seed: *mut ::std::os::raw::c_uint) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn drand48() -> f64;
+}
+unsafe extern "C" {
+    pub fn erand48(__xsubi: *mut ::std::os::raw::c_ushort) -> f64;
+}
+unsafe extern "C" {
+    pub fn lrand48() -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn nrand48(__xsubi: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn mrand48() -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn jrand48(__xsubi: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn srand48(__seedval: ::std::os::raw::c_long);
+}
+unsafe extern "C" {
+    pub fn seed48(__seed16v: *mut ::std::os::raw::c_ushort) -> *mut ::std::os::raw::c_ushort;
+}
+unsafe extern "C" {
+    pub fn lcong48(__param: *mut ::std::os::raw::c_ushort);
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct drand48_data {
+    pub __x: [::std::os::raw::c_ushort; 3usize],
+    pub __old_x: [::std::os::raw::c_ushort; 3usize],
+    pub __c: ::std::os::raw::c_ushort,
+    pub __init: ::std::os::raw::c_ushort,
+    pub __a: ::std::os::raw::c_ulonglong,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of drand48_data"][::std::mem::size_of::<drand48_data>() - 24usize];
+    ["Alignment of drand48_data"][::std::mem::align_of::<drand48_data>() - 8usize];
+    ["Offset of field: drand48_data::__x"][::std::mem::offset_of!(drand48_data, __x) - 0usize];
+    ["Offset of field: drand48_data::__old_x"]
+        [::std::mem::offset_of!(drand48_data, __old_x) - 6usize];
+    ["Offset of field: drand48_data::__c"][::std::mem::offset_of!(drand48_data, __c) - 12usize];
+    ["Offset of field: drand48_data::__init"]
+        [::std::mem::offset_of!(drand48_data, __init) - 14usize];
+    ["Offset of field: drand48_data::__a"][::std::mem::offset_of!(drand48_data, __a) - 16usize];
+};
+unsafe extern "C" {
+    pub fn drand48_r(__buffer: *mut drand48_data, __result: *mut f64) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn erand48_r(
+        __xsubi: *mut ::std::os::raw::c_ushort,
+        __buffer: *mut drand48_data,
+        __result: *mut f64,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn lrand48_r(
+        __buffer: *mut drand48_data,
+        __result: *mut ::std::os::raw::c_long,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn nrand48_r(
+        __xsubi: *mut ::std::os::raw::c_ushort,
+        __buffer: *mut drand48_data,
+        __result: *mut ::std::os::raw::c_long,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn mrand48_r(
+        __buffer: *mut drand48_data,
+        __result: *mut ::std::os::raw::c_long,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn jrand48_r(
+        __xsubi: *mut ::std::os::raw::c_ushort,
+        __buffer: *mut drand48_data,
+        __result: *mut ::std::os::raw::c_long,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn srand48_r(
+        __seedval: ::std::os::raw::c_long,
+        __buffer: *mut drand48_data,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn seed48_r(
+        __seed16v: *mut ::std::os::raw::c_ushort,
+        __buffer: *mut drand48_data,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn lcong48_r(
+        __param: *mut ::std::os::raw::c_ushort,
+        __buffer: *mut drand48_data,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn arc4random() -> __uint32_t;
+}
+unsafe extern "C" {
+    pub fn arc4random_buf(__buf: *mut ::std::os::raw::c_void, __size: usize);
+}
+unsafe extern "C" {
+    pub fn arc4random_uniform(__upper_bound: __uint32_t) -> __uint32_t;
 }
 unsafe extern "C" {
     pub fn malloc(__size: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void;
 }
 unsafe extern "C" {
     pub fn calloc(
-        __count: ::std::os::raw::c_ulong,
+        __nmemb: ::std::os::raw::c_ulong,
         __size: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_void;
-}
-unsafe extern "C" {
-    pub fn free(arg1: *mut ::std::os::raw::c_void);
 }
 unsafe extern "C" {
     pub fn realloc(
@@ -4578,19 +3619,20 @@ unsafe extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 unsafe extern "C" {
-    pub fn reallocf(
+    pub fn free(__ptr: *mut ::std::os::raw::c_void);
+}
+unsafe extern "C" {
+    pub fn reallocarray(
         __ptr: *mut ::std::os::raw::c_void,
+        __nmemb: usize,
         __size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 unsafe extern "C" {
-    pub fn valloc(arg1: usize) -> *mut ::std::os::raw::c_void;
+    pub fn alloca(__size: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void;
 }
 unsafe extern "C" {
-    pub fn aligned_alloc(
-        __alignment: ::std::os::raw::c_ulong,
-        __size: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_void;
+    pub fn valloc(__size: usize) -> *mut ::std::os::raw::c_void;
 }
 unsafe extern "C" {
     pub fn posix_memalign(
@@ -4600,554 +3642,265 @@ unsafe extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn abort() -> !;
-}
-unsafe extern "C" {
-    pub fn abs(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn atexit(arg1: ::std::option::Option<unsafe extern "C" fn()>) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn atof(arg1: *const ::std::os::raw::c_char) -> f64;
-}
-unsafe extern "C" {
-    pub fn atoi(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn atol(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
-}
-unsafe extern "C" {
-    pub fn atoll(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_longlong;
-}
-unsafe extern "C" {
-    pub fn bsearch(
-        __key: *const ::std::os::raw::c_void,
-        __base: *const ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
+    pub fn aligned_alloc(
+        __alignment: ::std::os::raw::c_ulong,
+        __size: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_void;
 }
 unsafe extern "C" {
-    pub fn div(arg1: ::std::os::raw::c_int, arg2: ::std::os::raw::c_int) -> div_t;
+    pub fn abort() -> !;
 }
 unsafe extern "C" {
-    pub fn exit(arg1: ::std::os::raw::c_int) -> !;
+    pub fn atexit(__func: ::std::option::Option<unsafe extern "C" fn()>) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn getenv(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn labs(arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
-}
-unsafe extern "C" {
-    pub fn ldiv(arg1: ::std::os::raw::c_long, arg2: ::std::os::raw::c_long) -> ldiv_t;
-}
-unsafe extern "C" {
-    pub fn llabs(arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_longlong;
-}
-unsafe extern "C" {
-    pub fn lldiv(arg1: ::std::os::raw::c_longlong, arg2: ::std::os::raw::c_longlong) -> lldiv_t;
-}
-unsafe extern "C" {
-    pub fn mblen(__s: *const ::std::os::raw::c_char, __n: usize) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn mbstowcs(arg1: *mut wchar_t, arg2: *const ::std::os::raw::c_char, arg3: usize) -> usize;
-}
-unsafe extern "C" {
-    pub fn mbtowc(
-        arg1: *mut wchar_t,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: usize,
+    pub fn at_quick_exit(
+        __func: ::std::option::Option<unsafe extern "C" fn()>,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn qsort(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: ::std::option::Option<
+    pub fn on_exit(
+        __func: ::std::option::Option<
             unsafe extern "C" fn(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
+                __status: ::std::os::raw::c_int,
+                __arg: *mut ::std::os::raw::c_void,
+            ),
         >,
-    );
-}
-unsafe extern "C" {
-    pub fn rand() -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn srand(arg1: ::std::os::raw::c_uint);
-}
-unsafe extern "C" {
-    pub fn strtod(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *mut *mut ::std::os::raw::c_char,
-    ) -> f64;
-}
-unsafe extern "C" {
-    pub fn strtof(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *mut *mut ::std::os::raw::c_char,
-    ) -> f32;
-}
-unsafe extern "C" {
-    pub fn strtol(
-        __str: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_long;
-}
-unsafe extern "C" {
-    pub fn strtold(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *mut *mut ::std::os::raw::c_char,
-    ) -> f64;
-}
-unsafe extern "C" {
-    pub fn strtoll(
-        __str: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_longlong;
-}
-unsafe extern "C" {
-    pub fn strtoul(
-        __str: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_ulong;
-}
-unsafe extern "C" {
-    pub fn strtoull(
-        __str: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_ulonglong;
-}
-unsafe extern "C" {
-    pub fn system(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn wcstombs(arg1: *mut ::std::os::raw::c_char, arg2: *const wchar_t, arg3: usize) -> usize;
-}
-unsafe extern "C" {
-    pub fn wctomb(arg1: *mut ::std::os::raw::c_char, arg2: wchar_t) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn _Exit(arg1: ::std::os::raw::c_int) -> !;
-}
-unsafe extern "C" {
-    pub fn a64l(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
-}
-unsafe extern "C" {
-    pub fn drand48() -> f64;
-}
-unsafe extern "C" {
-    pub fn ecvt(
-        arg1: f64,
-        arg2: ::std::os::raw::c_int,
-        arg3: *mut ::std::os::raw::c_int,
-        arg4: *mut ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn erand48(arg1: *mut ::std::os::raw::c_ushort) -> f64;
-}
-unsafe extern "C" {
-    pub fn fcvt(
-        arg1: f64,
-        arg2: ::std::os::raw::c_int,
-        arg3: *mut ::std::os::raw::c_int,
-        arg4: *mut ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn gcvt(
-        arg1: f64,
-        arg2: ::std::os::raw::c_int,
-        arg3: *mut ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn getsubopt(
-        arg1: *mut *mut ::std::os::raw::c_char,
-        arg2: *const *mut ::std::os::raw::c_char,
-        arg3: *mut *mut ::std::os::raw::c_char,
+        __arg: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn grantpt(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn exit(__status: ::std::os::raw::c_int) -> !;
 }
 unsafe extern "C" {
-    pub fn initstate(
-        arg1: ::std::os::raw::c_uint,
-        arg2: *mut ::std::os::raw::c_char,
-        arg3: usize,
-    ) -> *mut ::std::os::raw::c_char;
+    pub fn quick_exit(__status: ::std::os::raw::c_int) -> !;
 }
 unsafe extern "C" {
-    pub fn jrand48(arg1: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
+    pub fn _Exit(__status: ::std::os::raw::c_int) -> !;
 }
 unsafe extern "C" {
-    pub fn l64a(arg1: ::std::os::raw::c_long) -> *mut ::std::os::raw::c_char;
+    pub fn getenv(__name: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn lcong48(arg1: *mut ::std::os::raw::c_ushort);
-}
-unsafe extern "C" {
-    pub fn lrand48() -> ::std::os::raw::c_long;
-}
-unsafe extern "C" {
-    pub fn mktemp(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn mkstemp(arg1: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn mrand48() -> ::std::os::raw::c_long;
-}
-unsafe extern "C" {
-    pub fn nrand48(arg1: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
-}
-unsafe extern "C" {
-    pub fn posix_openpt(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn ptsname(arg1: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn ptsname_r(
-        fildes: ::std::os::raw::c_int,
-        buffer: *mut ::std::os::raw::c_char,
-        buflen: usize,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn putenv(arg1: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn random() -> ::std::os::raw::c_long;
-}
-unsafe extern "C" {
-    pub fn rand_r(arg1: *mut ::std::os::raw::c_uint) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    #[link_name = "\u{1}_realpath$DARWIN_EXTSN"]
-    pub fn realpath(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *mut ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn seed48(arg1: *mut ::std::os::raw::c_ushort) -> *mut ::std::os::raw::c_ushort;
+    pub fn putenv(__string: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
     pub fn setenv(
         __name: *const ::std::os::raw::c_char,
         __value: *const ::std::os::raw::c_char,
-        __overwrite: ::std::os::raw::c_int,
+        __replace: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn setkey(arg1: *const ::std::os::raw::c_char);
+    pub fn unsetenv(__name: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn setstate(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+    pub fn clearenv() -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn srand48(arg1: ::std::os::raw::c_long);
+    pub fn mktemp(__template: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn srandom(arg1: ::std::os::raw::c_uint);
+    pub fn mkstemp(__template: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn unlockpt(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn mkstemps(
+        __template: *mut ::std::os::raw::c_char,
+        __suffixlen: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn unsetenv(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-pub type dev_t = __darwin_dev_t;
-pub type mode_t = __darwin_mode_t;
-unsafe extern "C" {
-    pub fn arc4random() -> u32;
+    pub fn mkdtemp(__template: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn arc4random_addrandom(arg1: *mut ::std::os::raw::c_uchar, arg2: ::std::os::raw::c_int);
+    pub fn system(__command: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn arc4random_buf(__buf: *mut ::std::os::raw::c_void, __nbytes: usize);
+    pub fn realpath(
+        __name: *const ::std::os::raw::c_char,
+        __resolved: *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
 }
+pub type __compar_fn_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        arg1: *const ::std::os::raw::c_void,
+        arg2: *const ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int,
+>;
 unsafe extern "C" {
-    pub fn arc4random_stir();
-}
-unsafe extern "C" {
-    pub fn arc4random_uniform(__upper_bound: u32) -> u32;
-}
-unsafe extern "C" {
-    pub fn atexit_b(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn bsearch_b(
+    pub fn bsearch(
         __key: *const ::std::os::raw::c_void,
         __base: *const ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: *mut ::std::os::raw::c_void,
+        __nmemb: usize,
+        __size: usize,
+        __compar: __compar_fn_t,
     ) -> *mut ::std::os::raw::c_void;
 }
 unsafe extern "C" {
-    pub fn cgetcap(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
+    pub fn qsort(
+        __base: *mut ::std::os::raw::c_void,
+        __nmemb: usize,
+        __size: usize,
+        __compar: __compar_fn_t,
+    );
+}
+unsafe extern "C" {
+    pub fn abs(__x: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn labs(__x: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn llabs(__x: ::std::os::raw::c_longlong) -> ::std::os::raw::c_longlong;
+}
+unsafe extern "C" {
+    pub fn div(__numer: ::std::os::raw::c_int, __denom: ::std::os::raw::c_int) -> div_t;
+}
+unsafe extern "C" {
+    pub fn ldiv(__numer: ::std::os::raw::c_long, __denom: ::std::os::raw::c_long) -> ldiv_t;
+}
+unsafe extern "C" {
+    pub fn lldiv(
+        __numer: ::std::os::raw::c_longlong,
+        __denom: ::std::os::raw::c_longlong,
+    ) -> lldiv_t;
+}
+unsafe extern "C" {
+    pub fn ecvt(
+        __value: f64,
+        __ndigit: ::std::os::raw::c_int,
+        __decpt: *mut ::std::os::raw::c_int,
+        __sign: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn cgetclose() -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn cgetent(
-        arg1: *mut *mut ::std::os::raw::c_char,
-        arg2: *mut *mut ::std::os::raw::c_char,
-        arg3: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn cgetfirst(
-        arg1: *mut *mut ::std::os::raw::c_char,
-        arg2: *mut *mut ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn cgetmatch(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn cgetnext(
-        arg1: *mut *mut ::std::os::raw::c_char,
-        arg2: *mut *mut ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn cgetnum(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut ::std::os::raw::c_long,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn cgetset(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn cgetstr(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut *mut ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn cgetustr(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut *mut ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn daemon(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn devname(arg1: dev_t, arg2: mode_t) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn devname_r(
-        arg1: dev_t,
-        arg2: mode_t,
-        buf: *mut ::std::os::raw::c_char,
-        len: ::std::os::raw::c_int,
+    pub fn fcvt(
+        __value: f64,
+        __ndigit: ::std::os::raw::c_int,
+        __decpt: *mut ::std::os::raw::c_int,
+        __sign: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn getbsize(
-        arg1: *mut ::std::os::raw::c_int,
-        arg2: *mut ::std::os::raw::c_long,
+    pub fn gcvt(
+        __value: f64,
+        __ndigit: ::std::os::raw::c_int,
+        __buf: *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn getloadavg(arg1: *mut f64, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn qecvt(
+        __value: u128,
+        __ndigit: ::std::os::raw::c_int,
+        __decpt: *mut ::std::os::raw::c_int,
+        __sign: *mut ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn getprogname() -> *const ::std::os::raw::c_char;
+    pub fn qfcvt(
+        __value: u128,
+        __ndigit: ::std::os::raw::c_int,
+        __decpt: *mut ::std::os::raw::c_int,
+        __sign: *mut ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn setprogname(arg1: *const ::std::os::raw::c_char);
+    pub fn qgcvt(
+        __value: u128,
+        __ndigit: ::std::os::raw::c_int,
+        __buf: *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn heapsort(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
+    pub fn ecvt_r(
+        __value: f64,
+        __ndigit: ::std::os::raw::c_int,
+        __decpt: *mut ::std::os::raw::c_int,
+        __sign: *mut ::std::os::raw::c_int,
+        __buf: *mut ::std::os::raw::c_char,
+        __len: usize,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn heapsort_b(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: *mut ::std::os::raw::c_void,
+    pub fn fcvt_r(
+        __value: f64,
+        __ndigit: ::std::os::raw::c_int,
+        __decpt: *mut ::std::os::raw::c_int,
+        __sign: *mut ::std::os::raw::c_int,
+        __buf: *mut ::std::os::raw::c_char,
+        __len: usize,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn mergesort(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
+    pub fn qecvt_r(
+        __value: u128,
+        __ndigit: ::std::os::raw::c_int,
+        __decpt: *mut ::std::os::raw::c_int,
+        __sign: *mut ::std::os::raw::c_int,
+        __buf: *mut ::std::os::raw::c_char,
+        __len: usize,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn mergesort_b(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: *mut ::std::os::raw::c_void,
+    pub fn qfcvt_r(
+        __value: u128,
+        __ndigit: ::std::os::raw::c_int,
+        __decpt: *mut ::std::os::raw::c_int,
+        __sign: *mut ::std::os::raw::c_int,
+        __buf: *mut ::std::os::raw::c_char,
+        __len: usize,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn psort(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
-    );
+    pub fn mblen(__s: *const ::std::os::raw::c_char, __n: usize) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn psort_b(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: *mut ::std::os::raw::c_void,
-    );
-}
-unsafe extern "C" {
-    pub fn psort_r(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        arg1: *mut ::std::os::raw::c_void,
-        __compar: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-                arg3: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
-    );
-}
-unsafe extern "C" {
-    pub fn qsort_b(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: *mut ::std::os::raw::c_void,
-    );
-}
-unsafe extern "C" {
-    pub fn qsort_r(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        arg1: *mut ::std::os::raw::c_void,
-        __compar: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-                arg3: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
-    );
-}
-unsafe extern "C" {
-    pub fn radixsort(
-        __base: *mut *const ::std::os::raw::c_uchar,
-        __nel: ::std::os::raw::c_int,
-        __table: *const ::std::os::raw::c_uchar,
-        __endbyte: ::std::os::raw::c_uint,
+    pub fn mbtowc(
+        __pwc: *mut wchar_t,
+        __s: *const ::std::os::raw::c_char,
+        __n: usize,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn rpmatch(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+    pub fn wctomb(__s: *mut ::std::os::raw::c_char, __wchar: wchar_t) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn sradixsort(
-        __base: *mut *const ::std::os::raw::c_uchar,
-        __nel: ::std::os::raw::c_int,
-        __table: *const ::std::os::raw::c_uchar,
-        __endbyte: ::std::os::raw::c_uint,
+    pub fn mbstowcs(__pwcs: *mut wchar_t, __s: *const ::std::os::raw::c_char, __n: usize) -> usize;
+}
+unsafe extern "C" {
+    pub fn wcstombs(__s: *mut ::std::os::raw::c_char, __pwcs: *const wchar_t, __n: usize) -> usize;
+}
+unsafe extern "C" {
+    pub fn rpmatch(__response: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn getsubopt(
+        __optionp: *mut *mut ::std::os::raw::c_char,
+        __tokens: *const *mut ::std::os::raw::c_char,
+        __valuep: *mut *mut ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn sranddev();
+    pub fn getloadavg(__loadavg: *mut f64, __nelem: ::std::os::raw::c_int)
+    -> ::std::os::raw::c_int;
 }
-unsafe extern "C" {
-    pub fn srandomdev();
+#[repr(C)]
+#[repr(align(16))]
+#[derive(Debug, Copy, Clone)]
+pub struct max_align_t {
+    pub __clang_max_align_nonce1: ::std::os::raw::c_longlong,
+    pub __bindgen_padding_0: u64,
+    pub __clang_max_align_nonce2: u128,
 }
-unsafe extern "C" {
-    pub fn strtonum(
-        __numstr: *const ::std::os::raw::c_char,
-        __minval: ::std::os::raw::c_longlong,
-        __maxval: ::std::os::raw::c_longlong,
-        __errstrp: *mut *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_longlong;
-}
-unsafe extern "C" {
-    pub fn strtoq(
-        __str: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_longlong;
-}
-unsafe extern "C" {
-    pub fn strtouq(
-        __str: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_ulonglong;
-}
-unsafe extern "C" {
-    pub static mut suboptarg: *mut ::std::os::raw::c_char;
-}
-pub type rsize_t = ::std::os::raw::c_ulong;
-pub type max_align_t = f64;
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of max_align_t"][::std::mem::size_of::<max_align_t>() - 32usize];
+    ["Alignment of max_align_t"][::std::mem::align_of::<max_align_t>() - 16usize];
+    ["Offset of field: max_align_t::__clang_max_align_nonce1"]
+        [::std::mem::offset_of!(max_align_t, __clang_max_align_nonce1) - 0usize];
+    ["Offset of field: max_align_t::__clang_max_align_nonce2"]
+        [::std::mem::offset_of!(max_align_t, __clang_max_align_nonce2) - 16usize];
+};
 unsafe extern "C" {
     #[doc = " allocates array and initializes it with 0; returns NULL if memory allocation failed"]
     pub fn BMSallocClearMemory_call(
@@ -6045,14 +4798,12 @@ pub struct SCIP_ParamSet {
     _unused: [u8; 0],
 }
 pub type SCIP_PARAMSET = SCIP_ParamSet;
-unsafe extern "C" {
-    pub fn imaxabs(j: intmax_t) -> intmax_t;
-}
+pub type __gwchar_t = ::std::os::raw::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct imaxdiv_t {
-    pub quot: intmax_t,
-    pub rem: intmax_t,
+    pub quot: ::std::os::raw::c_long,
+    pub rem: ::std::os::raw::c_long,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
@@ -6061,6 +4812,9 @@ const _: () = {
     ["Offset of field: imaxdiv_t::quot"][::std::mem::offset_of!(imaxdiv_t, quot) - 0usize];
     ["Offset of field: imaxdiv_t::rem"][::std::mem::offset_of!(imaxdiv_t, rem) - 8usize];
 };
+unsafe extern "C" {
+    pub fn imaxabs(__n: intmax_t) -> intmax_t;
+}
 unsafe extern "C" {
     pub fn imaxdiv(__numer: intmax_t, __denom: intmax_t) -> imaxdiv_t;
 }
@@ -6080,15 +4834,15 @@ unsafe extern "C" {
 }
 unsafe extern "C" {
     pub fn wcstoimax(
-        __nptr: *const wchar_t,
-        __endptr: *mut *mut wchar_t,
+        __nptr: *const __gwchar_t,
+        __endptr: *mut *mut __gwchar_t,
         __base: ::std::os::raw::c_int,
     ) -> intmax_t;
 }
 unsafe extern "C" {
     pub fn wcstoumax(
-        __nptr: *const wchar_t,
-        __endptr: *mut *mut wchar_t,
+        __nptr: *const __gwchar_t,
+        __endptr: *mut *mut __gwchar_t,
         __base: ::std::os::raw::c_int,
     ) -> uintmax_t;
 }
@@ -8364,12 +7118,14 @@ unsafe extern "C" {
     pub fn SCIPbanditGetNActions(bandit: *mut SCIP_BANDIT) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " compares two benderss w. r. to their priority"]
     pub fn SCIPbendersComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting benderss w.r.t. to their name"]
     pub fn SCIPbendersCompName(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -8739,12 +7495,14 @@ unsafe extern "C" {
     ) -> ::std::os::raw::c_uint;
 }
 unsafe extern "C" {
+    #[doc = " compares two Benders' decomposition cuts w. r. to their priority"]
     pub fn SCIPbenderscutComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting Benders' decomposition cuts w.r.t. to their name"]
     pub fn SCIPbenderscutCompName(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -8807,12 +7565,14 @@ unsafe extern "C" {
     );
 }
 unsafe extern "C" {
+    #[doc = " compares two branching rules w. r. to their priority"]
     pub fn SCIPbranchruleComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting branching rules w.r.t. to their name"]
     pub fn SCIPbranchruleCompName(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -8916,12 +7676,14 @@ unsafe extern "C" {
     pub fn SCIPbranchruleIsInitialized(branchrule: *mut SCIP_BRANCHRULE) -> ::std::os::raw::c_uint;
 }
 unsafe extern "C" {
+    #[doc = " compares two conflict handlers w. r. to their priority"]
     pub fn SCIPconflicthdlrComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting conflict handler w.r.t. to their name"]
     pub fn SCIPconflicthdlrCompName(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -8973,24 +7735,28 @@ unsafe extern "C" {
     pub fn SCIPconflicthdlrGetTime(conflicthdlr: *mut SCIP_CONFLICTHDLR) -> f64;
 }
 unsafe extern "C" {
+    #[doc = " compares two constraint handlers w.r.t. their separation priority"]
     pub fn SCIPconshdlrCompSepa(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " compares two constraint handlers w.r.t. their enforcing priority"]
     pub fn SCIPconshdlrCompEnfo(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " compares two constraint handlers w.r.t. their feasibility check priority"]
     pub fn SCIPconshdlrCompCheck(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " compares two constraints w.r.t. their feasibility check priority"]
     pub fn SCIPconsCompCheck(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -10566,6 +9332,7 @@ unsafe extern "C" {
     pub fn SCIPexprhdlrHasGetSymData(exprhdlr: *mut SCIP_EXPRHDLR) -> ::std::os::raw::c_uint;
 }
 unsafe extern "C" {
+    #[doc = " compares two expression handler w.r.t. their name"]
     pub fn SCIPexprhdlrComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -11028,18 +9795,21 @@ unsafe extern "C" {
     pub fn SCIPfclose(fp: *mut SCIP_FILE) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " compares two heuristics w.r.t. to their delay positions and priorities"]
     pub fn SCIPheurComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " compares two heuristics w.r.t. to their priority values"]
     pub fn SCIPheurCompPriority(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting heuristics w.r.t. to their name"]
     pub fn SCIPheurCompName(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -11336,12 +10106,14 @@ unsafe extern "C" {
     pub fn SCIPvariableGraphFree(scip: *mut SCIP, vargraph: *mut *mut SCIP_VGRAPH);
 }
 unsafe extern "C" {
+    #[doc = " compares two compressions w. r. to their priority"]
     pub fn SCIPcomprComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting compressions w.r.t. to their name"]
     pub fn SCIPcomprCompName(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -11491,6 +10263,7 @@ unsafe extern "C" {
     pub fn SCIPiisGetSubscip(iis: *mut SCIP_IIS) -> *mut SCIP;
 }
 unsafe extern "C" {
+    #[doc = " compares two IIS finders w. r. to their priority"]
     pub fn SCIPiisfinderComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -11837,6 +10610,7 @@ unsafe extern "C" {
     pub fn SCIPboundtypeOpposite(boundtype: SCIP_BOUNDTYPE) -> SCIP_BOUNDTYPE;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting rows by non-decreasing index"]
     pub fn SCIProwComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -12009,6 +10783,7 @@ pub struct SCIP_LPiExact {
 }
 pub type SCIP_LPIEXACT = SCIP_LPiExact;
 unsafe extern "C" {
+    #[doc = " comparison method for sorting rows by non-decreasing index"]
     pub fn SCIProwExactComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -12420,10 +11195,31 @@ unsafe extern "C" {
         varineq: *mut ::std::os::raw::c_uint,
     ) -> SCIP_RETCODE;
 }
-pub type __gnuc_va_list = __builtin_va_list;
 unsafe extern "C" {
-    pub fn memchr(
-        __s: *const ::std::os::raw::c_void,
+    pub fn memcpy(
+        __dest: *mut ::std::os::raw::c_void,
+        __src: *const ::std::os::raw::c_void,
+        __n: ::std::os::raw::c_ulong,
+    ) -> *mut ::std::os::raw::c_void;
+}
+unsafe extern "C" {
+    pub fn memmove(
+        __dest: *mut ::std::os::raw::c_void,
+        __src: *const ::std::os::raw::c_void,
+        __n: ::std::os::raw::c_ulong,
+    ) -> *mut ::std::os::raw::c_void;
+}
+unsafe extern "C" {
+    pub fn memccpy(
+        __dest: *mut ::std::os::raw::c_void,
+        __src: *const ::std::os::raw::c_void,
+        __c: ::std::os::raw::c_int,
+        __n: ::std::os::raw::c_ulong,
+    ) -> *mut ::std::os::raw::c_void;
+}
+unsafe extern "C" {
+    pub fn memset(
+        __s: *mut ::std::os::raw::c_void,
         __c: ::std::os::raw::c_int,
         __n: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_void;
@@ -12436,36 +11232,43 @@ unsafe extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn memcpy(
-        __dst: *mut ::std::os::raw::c_void,
-        __src: *const ::std::os::raw::c_void,
+    pub fn __memcmpeq(
+        __s1: *const ::std::os::raw::c_void,
+        __s2: *const ::std::os::raw::c_void,
+        __n: usize,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn memchr(
+        __s: *const ::std::os::raw::c_void,
+        __c: ::std::os::raw::c_int,
         __n: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_void;
 }
 unsafe extern "C" {
-    pub fn memmove(
-        __dst: *mut ::std::os::raw::c_void,
-        __src: *const ::std::os::raw::c_void,
-        __len: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_void;
-}
-unsafe extern "C" {
-    pub fn memset(
-        __b: *mut ::std::os::raw::c_void,
-        __c: ::std::os::raw::c_int,
-        __len: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_void;
-}
-unsafe extern "C" {
-    pub fn strcat(
-        __s1: *mut ::std::os::raw::c_char,
-        __s2: *const ::std::os::raw::c_char,
+    pub fn strcpy(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn strchr(
-        __s: *const ::std::os::raw::c_char,
-        __c: ::std::os::raw::c_int,
+    pub fn strncpy(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_ulong,
+    ) -> *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn strcat(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn strncat(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
@@ -12475,37 +11278,6 @@ unsafe extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn strcoll(
-        __s1: *const ::std::os::raw::c_char,
-        __s2: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn strcpy(
-        __dst: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn strcspn(
-        __s: *const ::std::os::raw::c_char,
-        __charset: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_ulong;
-}
-unsafe extern "C" {
-    pub fn strerror(__errnum: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn strlen(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_ulong;
-}
-unsafe extern "C" {
-    pub fn strncat(
-        __s1: *mut ::std::os::raw::c_char,
-        __s2: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
     pub fn strncmp(
         __s1: *const ::std::os::raw::c_char,
         __s2: *const ::std::os::raw::c_char,
@@ -12513,16 +11285,72 @@ unsafe extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn strncpy(
-        __dst: *mut ::std::os::raw::c_char,
+    pub fn strcoll(
+        __s1: *const ::std::os::raw::c_char,
+        __s2: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn strxfrm(
+        __dest: *mut ::std::os::raw::c_char,
         __src: *const ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_ulong;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __locale_struct {
+    pub __locales: [*mut __locale_data; 13usize],
+    pub __ctype_b: *const ::std::os::raw::c_ushort,
+    pub __ctype_tolower: *const ::std::os::raw::c_int,
+    pub __ctype_toupper: *const ::std::os::raw::c_int,
+    pub __names: [*const ::std::os::raw::c_char; 13usize],
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of __locale_struct"][::std::mem::size_of::<__locale_struct>() - 232usize];
+    ["Alignment of __locale_struct"][::std::mem::align_of::<__locale_struct>() - 8usize];
+    ["Offset of field: __locale_struct::__locales"]
+        [::std::mem::offset_of!(__locale_struct, __locales) - 0usize];
+    ["Offset of field: __locale_struct::__ctype_b"]
+        [::std::mem::offset_of!(__locale_struct, __ctype_b) - 104usize];
+    ["Offset of field: __locale_struct::__ctype_tolower"]
+        [::std::mem::offset_of!(__locale_struct, __ctype_tolower) - 112usize];
+    ["Offset of field: __locale_struct::__ctype_toupper"]
+        [::std::mem::offset_of!(__locale_struct, __ctype_toupper) - 120usize];
+    ["Offset of field: __locale_struct::__names"]
+        [::std::mem::offset_of!(__locale_struct, __names) - 128usize];
+};
+pub type __locale_t = *mut __locale_struct;
+pub type locale_t = __locale_t;
+unsafe extern "C" {
+    pub fn strcoll_l(
+        __s1: *const ::std::os::raw::c_char,
+        __s2: *const ::std::os::raw::c_char,
+        __l: locale_t,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn strxfrm_l(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: usize,
+        __l: locale_t,
+    ) -> usize;
+}
+unsafe extern "C" {
+    pub fn strdup(__s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn strndup(
+        __string: *const ::std::os::raw::c_char,
         __n: ::std::os::raw::c_ulong,
     ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn strpbrk(
+    pub fn strchr(
         __s: *const ::std::os::raw::c_char,
-        __charset: *const ::std::os::raw::c_char,
+        __c: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
@@ -12532,147 +11360,174 @@ unsafe extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn strspn(
+    pub fn strchrnul(
         __s: *const ::std::os::raw::c_char,
-        __charset: *const ::std::os::raw::c_char,
+        __c: ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn strcspn(
+        __s: *const ::std::os::raw::c_char,
+        __reject: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_ulong;
 }
 unsafe extern "C" {
+    pub fn strspn(
+        __s: *const ::std::os::raw::c_char,
+        __accept: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_ulong;
+}
+unsafe extern "C" {
+    pub fn strpbrk(
+        __s: *const ::std::os::raw::c_char,
+        __accept: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
     pub fn strstr(
-        __big: *const ::std::os::raw::c_char,
-        __little: *const ::std::os::raw::c_char,
+        __haystack: *const ::std::os::raw::c_char,
+        __needle: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     pub fn strtok(
-        __str: *mut ::std::os::raw::c_char,
-        __sep: *const ::std::os::raw::c_char,
+        __s: *mut ::std::os::raw::c_char,
+        __delim: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn strxfrm(
-        __s1: *mut ::std::os::raw::c_char,
-        __s2: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_ulong;
+    pub fn __strtok_r(
+        __s: *mut ::std::os::raw::c_char,
+        __delim: *const ::std::os::raw::c_char,
+        __save_ptr: *mut *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     pub fn strtok_r(
-        __str: *mut ::std::os::raw::c_char,
-        __sep: *const ::std::os::raw::c_char,
-        __lasts: *mut *mut ::std::os::raw::c_char,
+        __s: *mut ::std::os::raw::c_char,
+        __delim: *const ::std::os::raw::c_char,
+        __save_ptr: *mut *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
+    pub fn strcasestr(
+        __haystack: *const ::std::os::raw::c_char,
+        __needle: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn memmem(
+        __haystack: *const ::std::os::raw::c_void,
+        __haystacklen: usize,
+        __needle: *const ::std::os::raw::c_void,
+        __needlelen: usize,
+    ) -> *mut ::std::os::raw::c_void;
+}
+unsafe extern "C" {
+    pub fn __mempcpy(
+        __dest: *mut ::std::os::raw::c_void,
+        __src: *const ::std::os::raw::c_void,
+        __n: usize,
+    ) -> *mut ::std::os::raw::c_void;
+}
+unsafe extern "C" {
+    pub fn mempcpy(
+        __dest: *mut ::std::os::raw::c_void,
+        __src: *const ::std::os::raw::c_void,
+        __n: ::std::os::raw::c_ulong,
+    ) -> *mut ::std::os::raw::c_void;
+}
+unsafe extern "C" {
+    pub fn strlen(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_ulong;
+}
+unsafe extern "C" {
+    pub fn strnlen(__string: *const ::std::os::raw::c_char, __maxlen: usize) -> usize;
+}
+unsafe extern "C" {
+    pub fn strerror(__errnum: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    #[link_name = "\u{1}__xpg_strerror_r"]
     pub fn strerror_r(
         __errnum: ::std::os::raw::c_int,
-        __strerrbuf: *mut ::std::os::raw::c_char,
+        __buf: *mut ::std::os::raw::c_char,
         __buflen: usize,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn strdup(__s1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+    pub fn strerror_l(
+        __errnum: ::std::os::raw::c_int,
+        __l: locale_t,
+    ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn memccpy(
-        __dst: *mut ::std::os::raw::c_void,
+    pub fn bcmp(
+        __s1: *const ::std::os::raw::c_void,
+        __s2: *const ::std::os::raw::c_void,
+        __n: ::std::os::raw::c_ulong,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn bcopy(
         __src: *const ::std::os::raw::c_void,
+        __dest: *mut ::std::os::raw::c_void,
+        __n: ::std::os::raw::c_ulong,
+    );
+}
+unsafe extern "C" {
+    pub fn bzero(__s: *mut ::std::os::raw::c_void, __n: ::std::os::raw::c_ulong);
+}
+unsafe extern "C" {
+    pub fn index(
+        __s: *const ::std::os::raw::c_char,
         __c: ::std::os::raw::c_int,
-        __n: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_void;
-}
-unsafe extern "C" {
-    pub fn stpcpy(
-        __dst: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn stpncpy(
-        __dst: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
+    pub fn rindex(
+        __s: *const ::std::os::raw::c_char,
+        __c: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn strndup(
+    pub fn ffs(__i: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn ffsl(__l: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn ffsll(__ll: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn strcasecmp(
         __s1: *const ::std::os::raw::c_char,
+        __s2: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn strncasecmp(
+        __s1: *const ::std::os::raw::c_char,
+        __s2: *const ::std::os::raw::c_char,
         __n: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_char;
+    ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn strnlen(__s1: *const ::std::os::raw::c_char, __n: usize) -> usize;
+    pub fn strcasecmp_l(
+        __s1: *const ::std::os::raw::c_char,
+        __s2: *const ::std::os::raw::c_char,
+        __loc: locale_t,
+    ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn strsignal(__sig: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
-}
-pub type errno_t = ::std::os::raw::c_int;
-unsafe extern "C" {
-    pub fn memset_s(
-        __s: *mut ::std::os::raw::c_void,
-        __smax: rsize_t,
-        __c: ::std::os::raw::c_int,
-        __n: rsize_t,
-    ) -> errno_t;
+    pub fn strncasecmp_l(
+        __s1: *const ::std::os::raw::c_char,
+        __s2: *const ::std::os::raw::c_char,
+        __n: usize,
+        __loc: locale_t,
+    ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn memmem(
-        __big: *const ::std::os::raw::c_void,
-        __big_len: usize,
-        __little: *const ::std::os::raw::c_void,
-        __little_len: usize,
-    ) -> *mut ::std::os::raw::c_void;
-}
-unsafe extern "C" {
-    pub fn memset_pattern4(
-        __b: *mut ::std::os::raw::c_void,
-        __pattern4: *const ::std::os::raw::c_void,
-        __len: usize,
-    );
-}
-unsafe extern "C" {
-    pub fn memset_pattern8(
-        __b: *mut ::std::os::raw::c_void,
-        __pattern8: *const ::std::os::raw::c_void,
-        __len: usize,
-    );
-}
-unsafe extern "C" {
-    pub fn memset_pattern16(
-        __b: *mut ::std::os::raw::c_void,
-        __pattern16: *const ::std::os::raw::c_void,
-        __len: usize,
-    );
-}
-unsafe extern "C" {
-    pub fn strcasestr(
-        __big: *const ::std::os::raw::c_char,
-        __little: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn strnstr(
-        __big: *const ::std::os::raw::c_char,
-        __little: *const ::std::os::raw::c_char,
-        __len: usize,
-    ) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn strlcat(
-        __dst: *mut ::std::os::raw::c_char,
-        __source: *const ::std::os::raw::c_char,
-        __size: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_ulong;
-}
-unsafe extern "C" {
-    pub fn strlcpy(
-        __dst: *mut ::std::os::raw::c_char,
-        __source: *const ::std::os::raw::c_char,
-        __size: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_ulong;
-}
-unsafe extern "C" {
-    pub fn strmode(__mode: ::std::os::raw::c_int, __bp: *mut ::std::os::raw::c_char);
+    pub fn explicit_bzero(__s: *mut ::std::os::raw::c_void, __n: usize);
 }
 unsafe extern "C" {
     pub fn strsep(
@@ -12681,85 +11536,47 @@ unsafe extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn swab(
-        arg1: *const ::std::os::raw::c_void,
-        arg2: *mut ::std::os::raw::c_void,
-        arg3: isize,
-    );
+    pub fn strsignal(__sig: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn timingsafe_bcmp(
-        __b1: *const ::std::os::raw::c_void,
-        __b2: *const ::std::os::raw::c_void,
-        __len: usize,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn strsignal_r(
-        __sig: ::std::os::raw::c_int,
-        __strsignalbuf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn bcmp(
-        arg1: *const ::std::os::raw::c_void,
-        arg2: *const ::std::os::raw::c_void,
-        arg3: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn bcopy(
-        arg1: *const ::std::os::raw::c_void,
-        arg2: *mut ::std::os::raw::c_void,
-        arg3: usize,
-    );
-}
-unsafe extern "C" {
-    pub fn bzero(arg1: *mut ::std::os::raw::c_void, arg2: ::std::os::raw::c_ulong);
-}
-unsafe extern "C" {
-    pub fn index(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
+    pub fn __stpcpy(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn rindex(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
+    pub fn stpcpy(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn ffs(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn __stpncpy(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: usize,
+    ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn strcasecmp(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
+    pub fn stpncpy(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: ::std::os::raw::c_ulong,
+    ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn strncasecmp(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_int;
+    pub fn strlcpy(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: usize,
+    ) -> usize;
 }
 unsafe extern "C" {
-    pub fn ffsl(arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn ffsll(arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn fls(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn flsl(arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn flsll(arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int;
+    pub fn strlcat(
+        __dest: *mut ::std::os::raw::c_char,
+        __src: *const ::std::os::raw::c_char,
+        __n: usize,
+    ) -> usize;
 }
 unsafe extern "C" {
     #[doc = " Creates and captures a message handler which deals with warning, information, and dialog (interactive shell) methods.\n\n  Use SCIPsetMessagehdlr() to make SCIP aware of the created message handler.\n  @note The message handler does not handle error messages. For that see SCIPmessageSetErrorPrinting()\n  @note Creating a message handler automatically captures it."]
@@ -12836,7 +11653,7 @@ unsafe extern "C" {
     pub fn SCIPmessageVPrintInfo(
         messagehdlr: *mut SCIP_MESSAGEHDLR,
         formatstr: *const ::std::os::raw::c_char,
-        ap: va_list,
+        ap: *mut __va_list_tag,
     );
 }
 unsafe extern "C" {
@@ -12853,7 +11670,7 @@ unsafe extern "C" {
         messagehdlr: *mut SCIP_MESSAGEHDLR,
         file: *mut FILE,
         formatstr: *const ::std::os::raw::c_char,
-        ap: va_list,
+        ap: *mut __va_list_tag,
     );
 }
 unsafe extern "C" {
@@ -12868,7 +11685,7 @@ unsafe extern "C" {
     pub fn SCIPmessageVPrintWarning(
         messagehdlr: *mut SCIP_MESSAGEHDLR,
         formatstr: *const ::std::os::raw::c_char,
-        ap: va_list,
+        ap: *mut __va_list_tag,
     );
 }
 unsafe extern "C" {
@@ -12883,7 +11700,7 @@ unsafe extern "C" {
     pub fn SCIPmessageVFPrintWarning(
         messagehdlr: *mut SCIP_MESSAGEHDLR,
         formatstr: *const ::std::os::raw::c_char,
-        ap: va_list,
+        ap: *mut __va_list_tag,
     );
 }
 unsafe extern "C" {
@@ -12898,7 +11715,7 @@ unsafe extern "C" {
     pub fn SCIPmessageVPrintDialog(
         messagehdlr: *mut SCIP_MESSAGEHDLR,
         formatstr: *const ::std::os::raw::c_char,
-        ap: va_list,
+        ap: *mut __va_list_tag,
     );
 }
 unsafe extern "C" {
@@ -12915,7 +11732,7 @@ unsafe extern "C" {
         messagehdlr: *mut SCIP_MESSAGEHDLR,
         file: *mut FILE,
         formatstr: *const ::std::os::raw::c_char,
-        ap: va_list,
+        ap: *mut __va_list_tag,
     );
 }
 unsafe extern "C" {
@@ -12934,7 +11751,7 @@ unsafe extern "C" {
         verblevel: SCIP_VERBLEVEL,
         msgverblevel: SCIP_VERBLEVEL,
         formatstr: *const ::std::os::raw::c_char,
-        ap: va_list,
+        ap: *mut __va_list_tag,
     );
 }
 unsafe extern "C" {
@@ -12955,7 +11772,7 @@ unsafe extern "C" {
         msgverblevel: SCIP_VERBLEVEL,
         file: *mut FILE,
         formatstr: *const ::std::os::raw::c_char,
-        ap: va_list,
+        ap: *mut __va_list_tag,
     );
 }
 unsafe extern "C" {
@@ -12970,7 +11787,7 @@ unsafe extern "C" {
 }
 unsafe extern "C" {
     #[doc = " prints an error message, acting like the vprintf() command using the static message handler"]
-    pub fn SCIPmessageVPrintError(formatstr: *const ::std::os::raw::c_char, ap: va_list);
+    pub fn SCIPmessageVPrintError(formatstr: *const ::std::os::raw::c_char, ap: *mut __va_list_tag);
 }
 unsafe extern "C" {
     #[doc = " Method to set the error printing method. Setting the error printing method to NULL will suspend all error methods.\n\n  @note The error printing method is a static variable. This means that all occurring errors are handled via this method."]
@@ -16230,12 +15047,14 @@ unsafe extern "C" {
     );
 }
 unsafe extern "C" {
+    #[doc = " default comparer for integers"]
     pub fn SCIPsortCompInt(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " implements argsort\n\n The data pointer is a lookup array of integers."]
     pub fn SCIPsortArgsortInt(
         dataptr: *mut ::std::os::raw::c_void,
         ind1: ::std::os::raw::c_int,
@@ -16243,6 +15062,7 @@ unsafe extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " implements argsort\n\n The data pointer is a lookup array, which are pointer arrays."]
     pub fn SCIPsortArgsortPtr(
         dataptr: *mut ::std::os::raw::c_void,
         ind1: ::std::os::raw::c_int,
@@ -21944,6 +20764,7 @@ unsafe extern "C" {
     );
 }
 unsafe extern "C" {
+    #[doc = " standard hash key comparator for string keys"]
     pub fn SCIPhashKeyEqString(
         userptr: *mut ::std::os::raw::c_void,
         key1: *mut ::std::os::raw::c_void,
@@ -21951,18 +20772,21 @@ unsafe extern "C" {
     ) -> ::std::os::raw::c_uint;
 }
 unsafe extern "C" {
+    #[doc = " standard hashing function for string keys"]
     pub fn SCIPhashKeyValString(
         userptr: *mut ::std::os::raw::c_void,
         key: *mut ::std::os::raw::c_void,
     ) -> u64;
 }
 unsafe extern "C" {
+    #[doc = " gets the element as the key"]
     pub fn SCIPhashGetKeyStandard(
         userptr: *mut ::std::os::raw::c_void,
         elem: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 unsafe extern "C" {
+    #[doc = " returns TRUE iff both keys(pointer) are equal"]
     pub fn SCIPhashKeyEqPtr(
         userptr: *mut ::std::os::raw::c_void,
         key1: *mut ::std::os::raw::c_void,
@@ -21970,6 +20794,7 @@ unsafe extern "C" {
     ) -> ::std::os::raw::c_uint;
 }
 unsafe extern "C" {
+    #[doc = " returns the hash value of the key"]
     pub fn SCIPhashKeyValPtr(
         userptr: *mut ::std::os::raw::c_void,
         key: *mut ::std::os::raw::c_void,
@@ -23082,12 +21907,14 @@ unsafe extern "C" {
     pub fn SCIPparamIsDefault(param: *mut SCIP_PARAM) -> ::std::os::raw::c_uint;
 }
 unsafe extern "C" {
+    #[doc = " compares two presolvers w. r. to their priority"]
     pub fn SCIPpresolComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting presolvers w.r.t. to their name"]
     pub fn SCIPpresolCompName(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -23186,12 +22013,14 @@ unsafe extern "C" {
     pub fn SCIPpresolGetNCalls(presol: *mut SCIP_PRESOL) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " compares two pricers w. r. to their priority"]
     pub fn SCIPpricerComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting pricers w.r.t. to their name"]
     pub fn SCIPpricerCompName(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -23282,12 +22111,14 @@ unsafe extern "C" {
     pub fn SCIPreaderCanWrite(reader: *mut SCIP_READER) -> ::std::os::raw::c_uint;
 }
 unsafe extern "C" {
+    #[doc = " compares two relaxation handlers w. r. to their priority"]
     pub fn SCIPrelaxComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting relaxators w.r.t. to their name"]
     pub fn SCIPrelaxCompName(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -23460,12 +22291,14 @@ unsafe extern "C" {
     pub fn SCIPreoptGetNTotalInfNodes(reopt: *mut SCIP_REOPT) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " compares two separators w. r. to their priority"]
     pub fn SCIPsepaComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting separators w.r.t. to their name"]
     pub fn SCIPsepaCompName(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -23664,24 +22497,28 @@ unsafe extern "C" {
     pub fn SCIPcutselGetNLocalCutsFiltered(cutsel: *mut SCIP_CUTSEL) -> ::std::os::raw::c_longlong;
 }
 unsafe extern "C" {
+    #[doc = " compares two cut selectors w. r. to their priority"]
     pub fn SCIPcutselComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " compares two propagators w. r. to their priority"]
     pub fn SCIPpropComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " compares two propagators w. r. to their presolving priority"]
     pub fn SCIPpropCompPresol(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting propagators w.r.t. to their name"]
     pub fn SCIPpropCompName(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -23940,6 +22777,7 @@ unsafe extern "C" {
     pub fn SCIPsolGetRelConsViolation(sol: *mut SCIP_SOL) -> f64;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting solution by decreasing objective value (best solution will be sorted to the end)"]
     pub fn SCIPsolComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -23978,6 +22816,7 @@ unsafe extern "C" {
     pub fn SCIPtableIsInitialized(table: *mut SCIP_TABLE) -> ::std::os::raw::c_uint;
 }
 unsafe extern "C" {
+    #[doc = " node comparator for best lower bound"]
     pub fn SCIPnodeCompLowerbound(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -24168,6 +23007,7 @@ unsafe extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting active and negated variables by non-decreasing index, active and negated\n  variables are handled as the same variables"]
     pub fn SCIPvarCompActiveAndNegated(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -24178,24 +23018,28 @@ unsafe extern "C" {
     pub fn SCIPvarCompare(var1: *mut SCIP_VAR, var2: *mut SCIP_VAR) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting variables by non-decreasing index"]
     pub fn SCIPvarComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting variables by non-decreasing objective coefficient"]
     pub fn SCIPvarCompObj(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " hash key retrieval function for variables"]
     pub fn SCIPvarGetHashkey(
         userptr: *mut ::std::os::raw::c_void,
         elem: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 unsafe extern "C" {
+    #[doc = " returns TRUE iff the indices of both variables are equal"]
     pub fn SCIPvarIsHashkeyEq(
         userptr: *mut ::std::os::raw::c_void,
         key1: *mut ::std::os::raw::c_void,
@@ -24203,6 +23047,7 @@ unsafe extern "C" {
     ) -> ::std::os::raw::c_uint;
 }
 unsafe extern "C" {
+    #[doc = " returns the hash value of the key"]
     pub fn SCIPvarGetHashkeyVal(
         userptr: *mut ::std::os::raw::c_void,
         key: *mut ::std::os::raw::c_void,
@@ -25937,7 +24782,9 @@ pub struct SCIP_AggrRow {
     pub slacksign: *mut ::std::os::raw::c_int,
     #[doc = "< weights of rows that have been added to the cutrow"]
     pub rowweights: *mut f64,
+    #[doc = "< right hand side of the cut row"]
     pub rhshi: f64,
+    #[doc = "< right hand side of the cut row"]
     pub rhslo: f64,
     #[doc = "< number of non-zeros in the cut row"]
     pub nnz: ::std::os::raw::c_int,
@@ -31471,6 +30318,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " calls the print callback for an expression\n\n @see SCIP_DECL_EXPRPRINT"]
     pub fn SCIPcallExprPrint(
         scip: *mut SCIP,
         expr: *mut SCIP_EXPR,
@@ -31481,6 +30329,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " calls the curvature callback for an expression\n\n @see SCIP_DECL_EXPRCURVATURE\n\n Returns unknown curvature if callback not implemented."]
     pub fn SCIPcallExprCurvature(
         scip: *mut SCIP,
         expr: *mut SCIP_EXPR,
@@ -31490,6 +30339,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " calls the monotonicity callback for an expression\n\n @see SCIP_DECL_EXPRMONOTONICITY\n\n Returns unknown monotonicity if callback not implemented."]
     pub fn SCIPcallExprMonotonicity(
         scip: *mut SCIP,
         expr: *mut SCIP_EXPR,
@@ -31518,6 +30368,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " calls the interval evaluation callback for an expression\n\n @see SCIP_DECL_EXPRINTEVAL\n\n Returns entire interval if callback not implemented."]
     pub fn SCIPcallExprInteval(
         scip: *mut SCIP,
         expr: *mut SCIP_EXPR,
@@ -31533,6 +30384,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " calls the estimate callback for an expression\n\n @see SCIP_DECL_EXPRESTIMATE\n\n Returns without success if callback not implemented."]
     pub fn SCIPcallExprEstimate(
         scip: *mut SCIP,
         expr: *mut SCIP_EXPR,
@@ -31549,6 +30401,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " calls the initial estimators callback for an expression\n\n @see SCIP_DECL_EXPRINITESTIMATES\n\n Returns no estimators if callback not implemented."]
     pub fn SCIPcallExprInitestimates(
         scip: *mut SCIP,
         expr: *mut SCIP_EXPR,
@@ -31560,6 +30413,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " calls the simplify callback for an expression\n\n @see SCIP_DECL_EXPRSIMPLIFY\n\n Returns unmodified expression if simplify callback not implemented.\n\n Does not simplify descendants (children, etc). Use SCIPsimplifyExpr() for that."]
     pub fn SCIPcallExprSimplify(
         scip: *mut SCIP,
         expr: *mut SCIP_EXPR,
@@ -31598,6 +30452,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " calls the reverse propagation callback for an expression\n\n @see SCIP_DECL_EXPRREVERSEPROP\n\n Returns unmodified `childrenbounds` if reverseprop callback not implemented."]
     pub fn SCIPcallExprReverseprop(
         scip: *mut SCIP,
         expr: *mut SCIP_EXPR,
@@ -31607,6 +30462,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " calls the symmetry information callback for an expression\n\n Returns NULL pointer if not implemented."]
     pub fn SCIPcallExprGetSymData(
         scip: *mut SCIP,
         expr: *mut SCIP_EXPR,
@@ -33122,6 +31978,7 @@ unsafe extern "C" {
     -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " compares two NLPIs w.r.t. their priority"]
     pub fn SCIPnlpiComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -33418,6 +32275,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " gets internal pointer to NLP solver\n\n Depending on the solver interface, a solver pointer may exist for every NLP problem instance.\n For this case, a NLPI problem can be passed in as well."]
     pub fn SCIPgetNlpiSolverPointer(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33425,6 +32283,7 @@ unsafe extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 unsafe extern "C" {
+    #[doc = " creates an empty problem instance"]
     pub fn SCIPcreateNlpiProblem(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33433,6 +32292,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " frees a problem instance"]
     pub fn SCIPfreeNlpiProblem(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33440,6 +32300,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " gets internal pointer to solver-internal problem instance"]
     pub fn SCIPgetNlpiProblemPointer(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33447,6 +32308,7 @@ unsafe extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 unsafe extern "C" {
+    #[doc = " add variables to nlpi"]
     pub fn SCIPaddNlpiVars(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33458,6 +32320,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " add constraints to nlpi"]
     pub fn SCIPaddNlpiConstraints(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33473,6 +32336,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " sets or overwrites objective, a minimization problem is expected"]
     pub fn SCIPsetNlpiObjective(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33485,6 +32349,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " change variable bounds"]
     pub fn SCIPchgNlpiVarBounds(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33496,6 +32361,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " change constraint sides"]
     pub fn SCIPchgNlpiConsSides(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33507,6 +32373,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " delete a set of variables"]
     pub fn SCIPdelNlpiVarSet(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33516,6 +32383,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " delete a set of constraints"]
     pub fn SCIPdelNlpiConsSet(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33525,6 +32393,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " changes or adds linear coefficients in a constraint or objective"]
     pub fn SCIPchgNlpiLinearCoefs(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33536,6 +32405,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " change the expression in the nonlinear part"]
     pub fn SCIPchgNlpiExpr(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33545,6 +32415,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " change the constant offset in the objective"]
     pub fn SCIPchgNlpiObjConstant(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33553,6 +32424,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " sets initial guess"]
     pub fn SCIPsetNlpiInitialGuess(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33564,6 +32436,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " try to solve NLP with all parameters given as SCIP_NLPPARAM struct\n\n Typical use is\n\n     SCIP_NLPPARAM nlparam = { SCIP_NLPPARAM_DEFAULT(scip); }\n     nlpparam.iterlimit = 42;\n     SCIP_CALL( SCIPsolveNlpiParam(scip, nlpi, nlpiproblem, nlpparam) );\n\n or, in \"one\" line:\n\n     SCIP_CALL( SCIPsolveNlpiParam(scip, nlpi, nlpiproblem,\n        (SCIP_NLPPARAM){ SCIP_NLPPARAM_DEFAULT(scip), .iterlimit = 42 }) );\n\n To get the latter, also \\ref SCIPsolveNlpi can be used."]
     pub fn SCIPsolveNlpiParam(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33572,6 +32445,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " gives solution status"]
     pub fn SCIPgetNlpiSolstat(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33579,6 +32453,7 @@ unsafe extern "C" {
     ) -> SCIP_NLPSOLSTAT;
 }
 unsafe extern "C" {
+    #[doc = " gives termination reason"]
     pub fn SCIPgetNlpiTermstat(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33586,6 +32461,7 @@ unsafe extern "C" {
     ) -> SCIP_NLPTERMSTAT;
 }
 unsafe extern "C" {
+    #[doc = " gives primal and dual solution\n for a ranged constraint, the dual variable is positive if the right hand side is active and negative if the left hand side is active"]
     pub fn SCIPgetNlpiSolution(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33598,6 +32474,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " gives solve statistics"]
     pub fn SCIPgetNlpiStatistics(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -40782,6 +39659,7 @@ unsafe extern "C" {
     pub fn SCIPincludeConshdlrCountsols(scip: *mut SCIP) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the count command"]
     pub fn SCIPdialogExecCountPresolve(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -40790,6 +39668,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the count command"]
     pub fn SCIPdialogExecCount(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -40798,6 +39677,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " execution method of dialog for writing all solutions"]
     pub fn SCIPdialogExecWriteAllsolutions(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55019,6 +53899,7 @@ unsafe extern "C" {
     pub fn SCIPgetSlackConsSuperindicator(cons: *mut SCIP_CONS) -> *mut SCIP_CONS;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the SCIPtransformMinUC() command"]
     pub fn SCIPdialogExecChangeMinUC(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55241,6 +54122,7 @@ unsafe extern "C" {
     pub fn SCIPincludeDispDefault(scip: *mut SCIP) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " standard menu dialog execution method, that displays it's help screen if the remaining command line is empty"]
     pub fn SCIPdialogExecMenu(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55249,6 +54131,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " standard menu dialog execution method, that doesn't display it's help screen"]
     pub fn SCIPdialogExecMenuLazy(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55257,6 +54140,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the change add constraint"]
     pub fn SCIPdialogExecChangeAddCons(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55265,6 +54149,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the change bounds command"]
     pub fn SCIPdialogExecChangeBounds(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55273,6 +54158,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the freetransproblem command"]
     pub fn SCIPdialogExecChangeFreetransproblem(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55281,6 +54167,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the changing the objective sense"]
     pub fn SCIPdialogExecChangeObjSense(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55289,6 +54176,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the checksol command"]
     pub fn SCIPdialogExecChecksol(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55297,6 +54185,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the cliquegraph command"]
     pub fn SCIPdialogExecCliquegraph(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55305,6 +54194,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display benders command"]
     pub fn SCIPdialogExecDisplayBenders(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55313,6 +54203,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display branching command"]
     pub fn SCIPdialogExecDisplayBranching(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55321,6 +54212,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display compression command"]
     pub fn SCIPdialogExecDisplayCompression(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55329,6 +54221,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display conflict command"]
     pub fn SCIPdialogExecDisplayConflict(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55337,6 +54230,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display conshdlrs command"]
     pub fn SCIPdialogExecDisplayConshdlrs(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55345,6 +54239,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display displaycols command"]
     pub fn SCIPdialogExecDisplayDisplaycols(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55353,6 +54248,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display exprhdlrs command"]
     pub fn SCIPdialogExecDisplayExprhdlrs(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55361,6 +54257,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display cutselectors command"]
     pub fn SCIPdialogExecDisplayCutselectors(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55369,6 +54266,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display heuristics command"]
     pub fn SCIPdialogExecDisplayHeuristics(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55377,6 +54275,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display IIS command"]
     pub fn SCIPdialogExecDisplayIIS(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55385,6 +54284,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display memory command"]
     pub fn SCIPdialogExecDisplayMemory(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55393,6 +54293,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display nodeselectors command"]
     pub fn SCIPdialogExecDisplayNodeselectors(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55401,6 +54302,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display nlpi command"]
     pub fn SCIPdialogExecDisplayNlpi(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55409,6 +54311,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display parameters command"]
     pub fn SCIPdialogExecDisplayParameters(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55417,6 +54320,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display presolvers command"]
     pub fn SCIPdialogExecDisplayPresolvers(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55425,6 +54329,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display pricer command"]
     pub fn SCIPdialogExecDisplayPricers(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55433,6 +54338,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display problem command"]
     pub fn SCIPdialogExecDisplayProblem(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55441,6 +54347,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display propagators command"]
     pub fn SCIPdialogExecDisplayPropagators(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55449,6 +54356,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display readers command"]
     pub fn SCIPdialogExecDisplayReaders(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55457,6 +54365,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display relaxators command"]
     pub fn SCIPdialogExecDisplayRelaxators(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55465,6 +54374,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display separators command"]
     pub fn SCIPdialogExecDisplaySeparators(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55473,6 +54383,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display solution command"]
     pub fn SCIPdialogExecDisplaySolution(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55481,6 +54392,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display finitesolution command"]
     pub fn SCIPdialogExecDisplayFiniteSolution(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55489,6 +54401,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display dual solution command"]
     pub fn SCIPdialogExecDisplayDualSolution(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55497,6 +54410,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display of solutions in the pool command"]
     pub fn SCIPdialogExecDisplaySolutionPool(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55505,6 +54419,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display subproblem command"]
     pub fn SCIPdialogExecDisplaySubproblem(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55513,6 +54428,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display subsolution command"]
     pub fn SCIPdialogExecDisplaySubSolution(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55521,6 +54437,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display statistics command"]
     pub fn SCIPdialogExecDisplayStatistics(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55529,6 +54446,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display symmetry command"]
     pub fn SCIPdialogExecDisplaySymmetry(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55537,6 +54455,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display reoptstatistics command"]
     pub fn SCIPdialogExecDisplayReoptStatistics(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55545,6 +54464,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display transproblem command"]
     pub fn SCIPdialogExecDisplayTransproblem(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55553,6 +54473,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display value command"]
     pub fn SCIPdialogExecDisplayValue(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55561,6 +54482,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display varbranchstatistics command"]
     pub fn SCIPdialogExecDisplayVarbranchstatistics(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55569,6 +54491,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display LP solution quality command"]
     pub fn SCIPdialogExecDisplayLPSolutionQuality(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55577,6 +54500,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display transsolution command"]
     pub fn SCIPdialogExecDisplayTranssolution(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55585,6 +54509,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the help command"]
     pub fn SCIPdialogExecHelp(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55593,6 +54518,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the free command"]
     pub fn SCIPdialogExecFree(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55601,6 +54527,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the newstart command"]
     pub fn SCIPdialogExecNewstart(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55609,6 +54536,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the transform command"]
     pub fn SCIPdialogExecTransform(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55617,6 +54545,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the optimize command"]
     pub fn SCIPdialogExecOptimize(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55625,6 +54554,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the parallelopt command"]
     pub fn SCIPdialogExecConcurrentOpt(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55633,6 +54563,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the presolve command"]
     pub fn SCIPdialogExecPresolve(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55641,6 +54572,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the iis command"]
     pub fn SCIPdialogExecIIS(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55649,6 +54581,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the quit command"]
     pub fn SCIPdialogExecQuit(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55657,6 +54590,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the read command"]
     pub fn SCIPdialogExecRead(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55665,6 +54599,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set default command"]
     pub fn SCIPdialogExecSetDefault(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55673,6 +54608,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set load command"]
     pub fn SCIPdialogExecSetLoad(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55681,6 +54617,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set save command"]
     pub fn SCIPdialogExecSetSave(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55689,6 +54626,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set diffsave command"]
     pub fn SCIPdialogExecSetDiffsave(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55697,6 +54635,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set parameter command"]
     pub fn SCIPdialogExecSetParam(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55705,9 +54644,11 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog description method for the set parameter command"]
     pub fn SCIPdialogDescSetParam(scip: *mut SCIP, dialog: *mut SCIP_DIALOG) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the fix parameter command"]
     pub fn SCIPdialogExecFixParam(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55716,9 +54657,11 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog description method for the fix parameter command"]
     pub fn SCIPdialogDescFixParam(scip: *mut SCIP, dialog: *mut SCIP_DIALOG) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set branching direction command"]
     pub fn SCIPdialogExecSetBranchingDirection(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55727,6 +54670,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set branching priority command"]
     pub fn SCIPdialogExecSetBranchingPriority(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55735,6 +54679,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set heuristics aggressive command"]
     pub fn SCIPdialogExecSetHeuristicsAggressive(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55743,6 +54688,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set heuristics default command"]
     pub fn SCIPdialogExecSetHeuristicsDefault(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55751,6 +54697,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set heuristics fast command"]
     pub fn SCIPdialogExecSetHeuristicsFast(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55759,6 +54706,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set heuristics off command"]
     pub fn SCIPdialogExecSetHeuristicsOff(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55767,6 +54715,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set presolving aggressive command"]
     pub fn SCIPdialogExecSetPresolvingAggressive(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55775,6 +54724,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set presolving default command"]
     pub fn SCIPdialogExecSetPresolvingDefault(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55783,6 +54733,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set presolving fast command"]
     pub fn SCIPdialogExecSetPresolvingFast(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55791,6 +54742,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set presolving off command"]
     pub fn SCIPdialogExecSetPresolvingOff(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55799,6 +54751,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set separating aggressive command"]
     pub fn SCIPdialogExecSetSeparatingAggressive(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55807,6 +54760,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set separating default command"]
     pub fn SCIPdialogExecSetSeparatingDefault(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55815,6 +54769,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set separating fast command"]
     pub fn SCIPdialogExecSetSeparatingFast(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55823,6 +54778,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set separating off command"]
     pub fn SCIPdialogExecSetSeparatingOff(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55831,6 +54787,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set emphasis counter command"]
     pub fn SCIPdialogExecSetEmphasisCounter(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55839,6 +54796,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set emphasis cpsolver command"]
     pub fn SCIPdialogExecSetEmphasisCpsolver(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55847,6 +54805,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set emphasis easy CIP command"]
     pub fn SCIPdialogExecSetEmphasisEasycip(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55855,6 +54814,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set emphasis feasibility command"]
     pub fn SCIPdialogExecSetEmphasisFeasibility(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55863,6 +54823,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set emphasis hard LP command"]
     pub fn SCIPdialogExecSetEmphasisHardlp(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55871,6 +54832,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set emphasis optimality command"]
     pub fn SCIPdialogExecSetEmphasisOptimality(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55879,6 +54841,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set emphasis numerics command"]
     pub fn SCIPdialogExecSetEmphasisNumerics(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55887,6 +54850,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set emphasis benchmark command"]
     pub fn SCIPdialogExecSetEmphasisBenchmark(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55895,6 +54859,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set limits objective command"]
     pub fn SCIPdialogExecSetLimitsObjective(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55903,6 +54868,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for linear constraint type classification"]
     pub fn SCIPdialogExecDisplayLinearConsClassification(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -57242,6 +56208,7 @@ unsafe extern "C" {
     pub fn SCIPnlhdlrHasSollinearize(nlhdlr: *mut SCIP_NLHDLR) -> ::std::os::raw::c_uint;
 }
 unsafe extern "C" {
+    #[doc = " compares two nonlinear handlers by detection priority\n\n if handlers have same detection priority, then compare by name"]
     pub fn SCIPnlhdlrComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -58682,5 +57649,30 @@ unsafe extern "C" {
     #[doc = " includes default plugins into SCIP with respect to priorities"]
     pub fn SCIPincludeDefaultPlugins(scip: *mut SCIP) -> SCIP_RETCODE;
 }
-pub type __builtin_va_list = *mut ::std::os::raw::c_char;
-pub type __uint128_t = u128;
+pub type __builtin_va_list = [__va_list_tag; 1usize];
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __va_list_tag {
+    pub gp_offset: ::std::os::raw::c_uint,
+    pub fp_offset: ::std::os::raw::c_uint,
+    pub overflow_arg_area: *mut ::std::os::raw::c_void,
+    pub reg_save_area: *mut ::std::os::raw::c_void,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of __va_list_tag"][::std::mem::size_of::<__va_list_tag>() - 24usize];
+    ["Alignment of __va_list_tag"][::std::mem::align_of::<__va_list_tag>() - 8usize];
+    ["Offset of field: __va_list_tag::gp_offset"]
+        [::std::mem::offset_of!(__va_list_tag, gp_offset) - 0usize];
+    ["Offset of field: __va_list_tag::fp_offset"]
+        [::std::mem::offset_of!(__va_list_tag, fp_offset) - 4usize];
+    ["Offset of field: __va_list_tag::overflow_arg_area"]
+        [::std::mem::offset_of!(__va_list_tag, overflow_arg_area) - 8usize];
+    ["Offset of field: __va_list_tag::reg_save_area"]
+        [::std::mem::offset_of!(__va_list_tag, reg_save_area) - 16usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __locale_data {
+    pub _address: u8,
+}

--- a/src/bindings/macos-intel.rs
+++ b/src/bindings/macos-intel.rs
@@ -136,14 +136,19 @@ where
         }
     }
 }
+#[derive(PartialEq, Copy, Clone, Hash, Debug, Default)]
+#[repr(transparent)]
+pub struct __BindgenFloat16(pub u16);
 pub const __has_safe_buffers: u32 = 1;
-pub const __DARWIN_ONLY_64_BIT_INO_T: u32 = 1;
+pub const __DARWIN_ONLY_64_BIT_INO_T: u32 = 0;
 pub const __DARWIN_ONLY_UNIX_CONFORMANCE: u32 = 1;
-pub const __DARWIN_ONLY_VERS_1050: u32 = 1;
+pub const __DARWIN_ONLY_VERS_1050: u32 = 0;
 pub const __DARWIN_UNIX03: u32 = 1;
 pub const __DARWIN_64_BIT_INO_T: u32 = 1;
 pub const __DARWIN_VERS_1050: u32 = 1;
 pub const __DARWIN_NON_CANCELABLE: u32 = 0;
+pub const __DARWIN_SUF_64_BIT_INO_T: &[u8; 9] = b"$INODE64\0";
+pub const __DARWIN_SUF_1050: &[u8; 6] = b"$1050\0";
 pub const __DARWIN_SUF_EXTSN: &[u8; 14] = b"$DARWIN_EXTSN\0";
 pub const __DARWIN_C_ANSI: u32 = 4096;
 pub const __DARWIN_C_FULL: u32 = 900000;
@@ -151,19 +156,25 @@ pub const __DARWIN_C_LEVEL: u32 = 900000;
 pub const __STDC_WANT_LIB_EXT1__: u32 = 1;
 pub const __DARWIN_NO_LONG_LONG: u32 = 0;
 pub const _DARWIN_FEATURE_64_BIT_INODE: u32 = 1;
-pub const _DARWIN_FEATURE_ONLY_64_BIT_INODE: u32 = 1;
-pub const _DARWIN_FEATURE_ONLY_VERS_1050: u32 = 1;
 pub const _DARWIN_FEATURE_ONLY_UNIX_CONFORMANCE: u32 = 1;
 pub const _DARWIN_FEATURE_UNIX_CONFORMANCE: u32 = 3;
 pub const __has_ptrcheck: u32 = 0;
+pub const __has_bounds_safety_attributes: u32 = 0;
 pub const __API_TO_BE_DEPRECATED: u32 = 100000;
 pub const __API_TO_BE_DEPRECATED_MACOS: u32 = 100000;
+pub const __API_TO_BE_DEPRECATED_MACOSAPPLICATIONEXTENSION: u32 = 100000;
 pub const __API_TO_BE_DEPRECATED_IOS: u32 = 100000;
+pub const __API_TO_BE_DEPRECATED_IOSAPPLICATIONEXTENSION: u32 = 100000;
 pub const __API_TO_BE_DEPRECATED_MACCATALYST: u32 = 100000;
+pub const __API_TO_BE_DEPRECATED_MACCATALYSTAPPLICATIONEXTENSION: u32 = 100000;
 pub const __API_TO_BE_DEPRECATED_WATCHOS: u32 = 100000;
+pub const __API_TO_BE_DEPRECATED_WATCHOSAPPLICATIONEXTENSION: u32 = 100000;
 pub const __API_TO_BE_DEPRECATED_TVOS: u32 = 100000;
+pub const __API_TO_BE_DEPRECATED_TVOSAPPLICATIONEXTENSION: u32 = 100000;
 pub const __API_TO_BE_DEPRECATED_DRIVERKIT: u32 = 100000;
 pub const __API_TO_BE_DEPRECATED_VISIONOS: u32 = 100000;
+pub const __API_TO_BE_DEPRECATED_VISIONOSAPPLICATIONEXTENSION: u32 = 100000;
+pub const __API_TO_BE_DEPRECATED_KERNELKIT: u32 = 100000;
 pub const __MAC_10_0: u32 = 1000;
 pub const __MAC_10_1: u32 = 1010;
 pub const __MAC_10_2: u32 = 1020;
@@ -219,12 +230,21 @@ pub const __MAC_13_3: u32 = 130300;
 pub const __MAC_13_4: u32 = 130400;
 pub const __MAC_13_5: u32 = 130500;
 pub const __MAC_13_6: u32 = 130600;
+pub const __MAC_13_7: u32 = 130700;
 pub const __MAC_14_0: u32 = 140000;
 pub const __MAC_14_1: u32 = 140100;
 pub const __MAC_14_2: u32 = 140200;
 pub const __MAC_14_3: u32 = 140300;
 pub const __MAC_14_4: u32 = 140400;
 pub const __MAC_14_5: u32 = 140500;
+pub const __MAC_14_6: u32 = 140600;
+pub const __MAC_14_7: u32 = 140700;
+pub const __MAC_15_0: u32 = 150000;
+pub const __MAC_15_1: u32 = 150100;
+pub const __MAC_15_2: u32 = 150200;
+pub const __MAC_15_3: u32 = 150300;
+pub const __MAC_15_4: u32 = 150400;
+pub const __MAC_15_5: u32 = 150500;
 pub const __IPHONE_2_0: u32 = 20000;
 pub const __IPHONE_2_1: u32 = 20100;
 pub const __IPHONE_2_2: u32 = 20200;
@@ -304,6 +324,14 @@ pub const __IPHONE_17_2: u32 = 170200;
 pub const __IPHONE_17_3: u32 = 170300;
 pub const __IPHONE_17_4: u32 = 170400;
 pub const __IPHONE_17_5: u32 = 170500;
+pub const __IPHONE_17_6: u32 = 170600;
+pub const __IPHONE_17_7: u32 = 170700;
+pub const __IPHONE_18_0: u32 = 180000;
+pub const __IPHONE_18_1: u32 = 180100;
+pub const __IPHONE_18_2: u32 = 180200;
+pub const __IPHONE_18_3: u32 = 180300;
+pub const __IPHONE_18_4: u32 = 180400;
+pub const __IPHONE_18_5: u32 = 180500;
 pub const __WATCHOS_1_0: u32 = 10000;
 pub const __WATCHOS_2_0: u32 = 20000;
 pub const __WATCHOS_2_1: u32 = 20100;
@@ -351,6 +379,14 @@ pub const __WATCHOS_10_2: u32 = 100200;
 pub const __WATCHOS_10_3: u32 = 100300;
 pub const __WATCHOS_10_4: u32 = 100400;
 pub const __WATCHOS_10_5: u32 = 100500;
+pub const __WATCHOS_10_6: u32 = 100600;
+pub const __WATCHOS_10_7: u32 = 100700;
+pub const __WATCHOS_11_0: u32 = 110000;
+pub const __WATCHOS_11_1: u32 = 110100;
+pub const __WATCHOS_11_2: u32 = 110200;
+pub const __WATCHOS_11_3: u32 = 110300;
+pub const __WATCHOS_11_4: u32 = 110400;
+pub const __WATCHOS_11_5: u32 = 110500;
 pub const __TVOS_9_0: u32 = 90000;
 pub const __TVOS_9_1: u32 = 90100;
 pub const __TVOS_9_2: u32 = 90200;
@@ -399,6 +435,13 @@ pub const __TVOS_17_2: u32 = 170200;
 pub const __TVOS_17_3: u32 = 170300;
 pub const __TVOS_17_4: u32 = 170400;
 pub const __TVOS_17_5: u32 = 170500;
+pub const __TVOS_17_6: u32 = 170600;
+pub const __TVOS_18_0: u32 = 180000;
+pub const __TVOS_18_1: u32 = 180100;
+pub const __TVOS_18_2: u32 = 180200;
+pub const __TVOS_18_3: u32 = 180300;
+pub const __TVOS_18_4: u32 = 180400;
+pub const __TVOS_18_5: u32 = 180500;
 pub const __BRIDGEOS_2_0: u32 = 20000;
 pub const __BRIDGEOS_3_0: u32 = 30000;
 pub const __BRIDGEOS_3_1: u32 = 30100;
@@ -425,6 +468,13 @@ pub const __BRIDGEOS_8_2: u32 = 80200;
 pub const __BRIDGEOS_8_3: u32 = 80300;
 pub const __BRIDGEOS_8_4: u32 = 80400;
 pub const __BRIDGEOS_8_5: u32 = 80500;
+pub const __BRIDGEOS_8_6: u32 = 80600;
+pub const __BRIDGEOS_9_0: u32 = 90000;
+pub const __BRIDGEOS_9_1: u32 = 90100;
+pub const __BRIDGEOS_9_2: u32 = 90200;
+pub const __BRIDGEOS_9_3: u32 = 90300;
+pub const __BRIDGEOS_9_4: u32 = 90400;
+pub const __BRIDGEOS_9_5: u32 = 90500;
 pub const __DRIVERKIT_19_0: u32 = 190000;
 pub const __DRIVERKIT_20_0: u32 = 200000;
 pub const __DRIVERKIT_21_0: u32 = 210000;
@@ -438,9 +488,23 @@ pub const __DRIVERKIT_23_2: u32 = 230200;
 pub const __DRIVERKIT_23_3: u32 = 230300;
 pub const __DRIVERKIT_23_4: u32 = 230400;
 pub const __DRIVERKIT_23_5: u32 = 230500;
+pub const __DRIVERKIT_23_6: u32 = 230600;
+pub const __DRIVERKIT_24_0: u32 = 240000;
+pub const __DRIVERKIT_24_1: u32 = 240100;
+pub const __DRIVERKIT_24_2: u32 = 240200;
+pub const __DRIVERKIT_24_3: u32 = 240300;
+pub const __DRIVERKIT_24_4: u32 = 240400;
+pub const __DRIVERKIT_24_5: u32 = 240500;
 pub const __VISIONOS_1_0: u32 = 10000;
 pub const __VISIONOS_1_1: u32 = 10100;
 pub const __VISIONOS_1_2: u32 = 10200;
+pub const __VISIONOS_1_3: u32 = 10300;
+pub const __VISIONOS_2_0: u32 = 20000;
+pub const __VISIONOS_2_1: u32 = 20100;
+pub const __VISIONOS_2_2: u32 = 20200;
+pub const __VISIONOS_2_3: u32 = 20300;
+pub const __VISIONOS_2_4: u32 = 20400;
+pub const __VISIONOS_2_5: u32 = 20500;
 pub const MAC_OS_X_VERSION_10_0: u32 = 1000;
 pub const MAC_OS_X_VERSION_10_1: u32 = 1010;
 pub const MAC_OS_X_VERSION_10_2: u32 = 1020;
@@ -496,14 +560,27 @@ pub const MAC_OS_VERSION_13_3: u32 = 130300;
 pub const MAC_OS_VERSION_13_4: u32 = 130400;
 pub const MAC_OS_VERSION_13_5: u32 = 130500;
 pub const MAC_OS_VERSION_13_6: u32 = 130600;
+pub const MAC_OS_VERSION_13_7: u32 = 130700;
 pub const MAC_OS_VERSION_14_0: u32 = 140000;
 pub const MAC_OS_VERSION_14_1: u32 = 140100;
 pub const MAC_OS_VERSION_14_2: u32 = 140200;
 pub const MAC_OS_VERSION_14_3: u32 = 140300;
 pub const MAC_OS_VERSION_14_4: u32 = 140400;
 pub const MAC_OS_VERSION_14_5: u32 = 140500;
-pub const __MAC_OS_X_VERSION_MAX_ALLOWED: u32 = 140500;
+pub const MAC_OS_VERSION_14_6: u32 = 140600;
+pub const MAC_OS_VERSION_14_7: u32 = 140700;
+pub const MAC_OS_VERSION_15_0: u32 = 150000;
+pub const MAC_OS_VERSION_15_1: u32 = 150100;
+pub const MAC_OS_VERSION_15_2: u32 = 150200;
+pub const MAC_OS_VERSION_15_3: u32 = 150300;
+pub const MAC_OS_VERSION_15_4: u32 = 150400;
+pub const MAC_OS_VERSION_15_5: u32 = 150500;
+pub const __AVAILABILITY_VERSIONS_VERSION_HASH: u32 = 93585900;
+pub const __AVAILABILITY_VERSIONS_VERSION_STRING: &[u8; 6] = b"Local\0";
+pub const __AVAILABILITY_FILE: &[u8; 23] = b"AvailabilityVersions.h\0";
+pub const __MAC_OS_X_VERSION_MAX_ALLOWED: u32 = 150500;
 pub const __ENABLE_LEGACY_MAC_AVAILABILITY: u32 = 1;
+pub const USE_CLANG_TYPES: u32 = 0;
 pub const __PTHREAD_SIZE__: u32 = 8176;
 pub const __PTHREAD_ATTR_SIZE__: u32 = 56;
 pub const __PTHREAD_MUTEXATTR_SIZE__: u32 = 8;
@@ -515,6 +592,8 @@ pub const __PTHREAD_RWLOCK_SIZE__: u32 = 192;
 pub const __PTHREAD_RWLOCKATTR_SIZE__: u32 = 16;
 pub const __DARWIN_WCHAR_MIN: i32 = -2147483648;
 pub const _FORTIFY_SOURCE: u32 = 2;
+pub const USE_CLANG_STDARG: u32 = 0;
+pub const USE_CLANG_STDDEF: u32 = 0;
 pub const RENAME_SECLUDE: u32 = 1;
 pub const RENAME_SWAP: u32 = 2;
 pub const RENAME_EXCL: u32 = 4;
@@ -600,9 +679,6 @@ pub const WINT_MAX: u32 = 2147483647;
 pub const SIG_ATOMIC_MIN: i32 = -2147483648;
 pub const SIG_ATOMIC_MAX: u32 = 2147483647;
 pub const FP_SUPERNORMAL: u32 = 6;
-pub const FP_FAST_FMA: u32 = 1;
-pub const FP_FAST_FMAF: u32 = 1;
-pub const FP_FAST_FMAL: u32 = 1;
 pub const FP_ILOGB0: i32 = -2147483648;
 pub const FP_ILOGBNAN: i32 = -2147483648;
 pub const MATH_ERRNO: u32 = 1;
@@ -629,6 +705,7 @@ pub const UNDERFLOW: u32 = 4;
 pub const TLOSS: u32 = 5;
 pub const PLOSS: u32 = 6;
 pub const __DARWIN_CLK_TCK: u32 = 100;
+pub const USE_CLANG_LIMITS: u32 = 0;
 pub const MB_LEN_MAX: u32 = 6;
 pub const CLK_TCK: u32 = 100;
 pub const CHAR_BIT: u32 = 8;
@@ -716,7 +793,7 @@ pub const _POSIX_THREAD_KEYS_MAX: u32 = 128;
 pub const _POSIX_THREAD_THREADS_MAX: u32 = 64;
 pub const PTHREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
 pub const PTHREAD_KEYS_MAX: u32 = 512;
-pub const PTHREAD_STACK_MIN: u32 = 16384;
+pub const PTHREAD_STACK_MIN: u32 = 8192;
 pub const _POSIX_HOST_NAME_MAX: u32 = 255;
 pub const _POSIX_LOGIN_NAME_MAX: u32 = 9;
 pub const _POSIX_SS_REPL_MAX: u32 = 4;
@@ -797,7 +874,7 @@ pub const SCIP_MAXTREEDEPTH: u32 = 1073741822;
 pub const SCIP_PROBINGSCORE_PENALTYRATIO: u32 = 2;
 pub const __DARWIN_NSIG: u32 = 32;
 pub const NSIG: u32 = 32;
-pub const _ARM_SIGNAL_: u32 = 1;
+pub const _I386_SIGNAL_H_: u32 = 1;
 pub const SIGHUP: u32 = 1;
 pub const SIGINT: u32 = 2;
 pub const SIGQUIT: u32 = 3;
@@ -830,7 +907,17 @@ pub const SIGWINCH: u32 = 28;
 pub const SIGINFO: u32 = 29;
 pub const SIGUSR1: u32 = 30;
 pub const SIGUSR2: u32 = 31;
-pub const __DARWIN_OPAQUE_ARM_THREAD_STATE64: u32 = 0;
+pub const FP_PREC_24B: u32 = 0;
+pub const FP_PREC_53B: u32 = 2;
+pub const FP_PREC_64B: u32 = 3;
+pub const FP_RND_NEAR: u32 = 0;
+pub const FP_RND_DOWN: u32 = 1;
+pub const FP_RND_UP: u32 = 2;
+pub const FP_CHOP: u32 = 3;
+pub const FP_STATE_BYTES: u32 = 512;
+pub const _X86_INSTRUCTION_STATE_MAX_INSN_BYTES: u32 = 2380;
+pub const _X86_INSTRUCTION_STATE_CACHELINE_SIZE: u32 = 64;
+pub const __LASTBRANCH_MAX: u32 = 32;
 pub const SIGEV_NONE: u32 = 0;
 pub const SIGEV_SIGNAL: u32 = 1;
 pub const SIGEV_THREAD: u32 = 3;
@@ -981,6 +1068,7 @@ pub const IOPOL_VFS_IGNORE_PERMISSIONS_OFF: u32 = 0;
 pub const IOPOL_VFS_IGNORE_PERMISSIONS_ON: u32 = 1;
 pub const IOPOL_VFS_SKIP_MTIME_UPDATE_OFF: u32 = 0;
 pub const IOPOL_VFS_SKIP_MTIME_UPDATE_ON: u32 = 1;
+pub const IOPOL_VFS_SKIP_MTIME_UPDATE_IGNORE: u32 = 2;
 pub const IOPOL_VFS_ALLOW_LOW_SPACE_WRITES_OFF: u32 = 0;
 pub const IOPOL_VFS_ALLOW_LOW_SPACE_WRITES_ON: u32 = 1;
 pub const IOPOL_VFS_DISALLOW_RW_FOR_O_EVTONLY_DEFAULT: u32 = 0;
@@ -1002,10 +1090,10 @@ pub const _QUAD_LOWWORD: u32 = 0;
 pub const __DARWIN_LITTLE_ENDIAN: u32 = 1234;
 pub const __DARWIN_BIG_ENDIAN: u32 = 4321;
 pub const __DARWIN_PDP_ENDIAN: u32 = 3412;
-pub const __DARWIN_BYTE_ORDER: u32 = 1234;
 pub const LITTLE_ENDIAN: u32 = 1234;
 pub const BIG_ENDIAN: u32 = 4321;
 pub const PDP_ENDIAN: u32 = 3412;
+pub const __DARWIN_BYTE_ORDER: u32 = 1234;
 pub const BYTE_ORDER: u32 = 1234;
 pub const EXIT_FAILURE: u32 = 1;
 pub const EXIT_SUCCESS: u32 = 0;
@@ -1231,7 +1319,6 @@ pub const SCIP_EXPRPRINT_ALL: u32 = 255;
 pub const SCIP_NLPPARAM_DEFAULT_VERBLEVEL: u32 = 0;
 pub const SCIP_DECOMP_LINKVAR: i32 = -1;
 pub const SCIP_DECOMP_LINKCONS: i32 = -2;
-pub const __GNUC_VA_LIST: u32 = 1;
 pub const __HAS_FIXED_CHK_PROTOTYPES: u32 = 1;
 pub const QUAD_EPSILON: f64 = 0.000000000001;
 pub const __bool_true_false_are_defined: u32 = 1;
@@ -1529,6 +1616,9 @@ unsafe extern "C" {
         arg5: ::std::os::raw::c_uint,
     ) -> ::std::os::raw::c_int;
 }
+unsafe extern "C" {
+    pub fn printf(arg1: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
+}
 pub type fpos_t = __darwin_off_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1566,7 +1656,7 @@ pub struct __sFILE {
         unsafe extern "C" fn(
             arg1: *mut ::std::os::raw::c_void,
             arg2: *mut ::std::os::raw::c_char,
-            arg3: ::std::os::raw::c_int,
+            __n: ::std::os::raw::c_int,
         ) -> ::std::os::raw::c_int,
     >,
     pub _seek: ::std::option::Option<
@@ -1580,7 +1670,7 @@ pub struct __sFILE {
         unsafe extern "C" fn(
             arg1: *mut ::std::os::raw::c_void,
             arg2: *const ::std::os::raw::c_char,
-            arg3: ::std::os::raw::c_int,
+            __n: ::std::os::raw::c_int,
         ) -> ::std::os::raw::c_int,
     >,
     pub _ub: __sbuf,
@@ -1651,8 +1741,8 @@ unsafe extern "C" {
 unsafe extern "C" {
     pub fn fgets(
         arg1: *mut ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
-        arg3: *mut FILE,
+        __size: ::std::os::raw::c_int,
+        arg2: *mut FILE,
     ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
@@ -1730,9 +1820,6 @@ unsafe extern "C" {
     pub fn perror(arg1: *const ::std::os::raw::c_char);
 }
 unsafe extern "C" {
-    pub fn printf(arg1: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
     pub fn putc(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
@@ -1764,7 +1851,7 @@ unsafe extern "C" {
         arg1: *mut FILE,
         arg2: *mut ::std::os::raw::c_char,
         arg3: ::std::os::raw::c_int,
-        arg4: usize,
+        __size: usize,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
@@ -1794,20 +1881,20 @@ unsafe extern "C" {
     pub fn vfprintf(
         arg1: *mut FILE,
         arg2: *const ::std::os::raw::c_char,
-        arg3: __builtin_va_list,
+        arg3: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
     pub fn vprintf(
         arg1: *const ::std::os::raw::c_char,
-        arg2: __builtin_va_list,
+        arg2: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
     pub fn vsprintf(
         arg1: *mut ::std::os::raw::c_char,
         arg2: *const ::std::os::raw::c_char,
-        arg3: __builtin_va_list,
+        arg3: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
@@ -1835,7 +1922,7 @@ unsafe extern "C" {
     pub fn __svfscanf(
         arg1: *mut FILE,
         arg2: *const ::std::os::raw::c_char,
-        arg3: va_list,
+        arg3: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
@@ -1897,13 +1984,13 @@ unsafe extern "C" {
     pub fn vfscanf(
         __stream: *mut FILE,
         __format: *const ::std::os::raw::c_char,
-        arg1: __builtin_va_list,
+        arg1: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
     pub fn vscanf(
         __format: *const ::std::os::raw::c_char,
-        arg1: __builtin_va_list,
+        arg1: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
@@ -1911,14 +1998,14 @@ unsafe extern "C" {
         __str: *mut ::std::os::raw::c_char,
         __size: ::std::os::raw::c_ulong,
         __format: *const ::std::os::raw::c_char,
-        arg1: __builtin_va_list,
+        arg1: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
     pub fn vsscanf(
         __str: *const ::std::os::raw::c_char,
         __format: *const ::std::os::raw::c_char,
-        arg1: __builtin_va_list,
+        arg1: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
@@ -1932,7 +2019,7 @@ unsafe extern "C" {
     pub fn vdprintf(
         arg1: ::std::os::raw::c_int,
         arg2: *const ::std::os::raw::c_char,
-        arg3: va_list,
+        arg3: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
@@ -1980,7 +2067,7 @@ unsafe extern "C" {
     pub fn ctermid_r(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn fgetln(arg1: *mut FILE, arg2: *mut usize) -> *mut ::std::os::raw::c_char;
+    pub fn fgetln(arg1: *mut FILE, __len: *mut usize) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     pub fn fmtcheck(
@@ -1995,7 +2082,7 @@ unsafe extern "C" {
     pub fn setbuffer(
         arg1: *mut FILE,
         arg2: *mut ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
+        __size: ::std::os::raw::c_int,
     );
 }
 unsafe extern "C" {
@@ -2005,7 +2092,7 @@ unsafe extern "C" {
     pub fn vasprintf(
         arg1: *mut *mut ::std::os::raw::c_char,
         arg2: *const ::std::os::raw::c_char,
-        arg3: va_list,
+        arg3: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
@@ -2015,14 +2102,14 @@ unsafe extern "C" {
             unsafe extern "C" fn(
                 arg1: *mut ::std::os::raw::c_void,
                 arg2: *mut ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
+                __n: ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int,
         >,
         arg3: ::std::option::Option<
             unsafe extern "C" fn(
                 arg1: *mut ::std::os::raw::c_void,
                 arg2: *const ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
+                __n: ::std::os::raw::c_int,
             ) -> ::std::os::raw::c_int,
         >,
         arg4: ::std::option::Option<
@@ -2049,10 +2136,10 @@ unsafe extern "C" {
 unsafe extern "C" {
     pub fn __snprintf_chk(
         arg1: *mut ::std::os::raw::c_char,
-        arg2: usize,
-        arg3: ::std::os::raw::c_int,
-        arg4: usize,
-        arg5: *const ::std::os::raw::c_char,
+        __maxlen: usize,
+        arg2: ::std::os::raw::c_int,
+        arg3: usize,
+        arg4: *const ::std::os::raw::c_char,
         ...
     ) -> ::std::os::raw::c_int;
 }
@@ -2062,17 +2149,17 @@ unsafe extern "C" {
         arg2: ::std::os::raw::c_int,
         arg3: usize,
         arg4: *const ::std::os::raw::c_char,
-        arg5: va_list,
+        arg5: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
     pub fn __vsnprintf_chk(
         arg1: *mut ::std::os::raw::c_char,
-        arg2: usize,
-        arg3: ::std::os::raw::c_int,
-        arg4: usize,
-        arg5: *const ::std::os::raw::c_char,
-        arg6: va_list,
+        __maxlen: usize,
+        arg2: ::std::os::raw::c_int,
+        arg3: usize,
+        arg4: *const ::std::os::raw::c_char,
+        arg5: *mut __va_list_tag,
     ) -> ::std::os::raw::c_int;
 }
 pub type int_least8_t = i8;
@@ -2105,7 +2192,7 @@ unsafe extern "C" {
     pub fn __fpclassifyd(arg1: f64) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn __fpclassifyl(arg1: f64) -> ::std::os::raw::c_int;
+    pub fn __fpclassifyl(arg1: u128) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
     pub fn acosf(arg1: f32) -> f32;
@@ -2114,7 +2201,7 @@ unsafe extern "C" {
     pub fn acos(arg1: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn acosl(arg1: f64) -> f64;
+    pub fn acosl(arg1: u128) -> u128;
 }
 unsafe extern "C" {
     pub fn asinf(arg1: f32) -> f32;
@@ -2123,7 +2210,7 @@ unsafe extern "C" {
     pub fn asin(arg1: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn asinl(arg1: f64) -> f64;
+    pub fn asinl(arg1: u128) -> u128;
 }
 unsafe extern "C" {
     pub fn atanf(arg1: f32) -> f32;
@@ -2132,7 +2219,7 @@ unsafe extern "C" {
     pub fn atan(arg1: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn atanl(arg1: f64) -> f64;
+    pub fn atanl(arg1: u128) -> u128;
 }
 unsafe extern "C" {
     pub fn atan2f(arg1: f32, arg2: f32) -> f32;
@@ -2141,7 +2228,7 @@ unsafe extern "C" {
     pub fn atan2(arg1: f64, arg2: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn atan2l(arg1: f64, arg2: f64) -> f64;
+    pub fn atan2l(arg1: u128, arg2: u128) -> u128;
 }
 unsafe extern "C" {
     pub fn cosf(arg1: f32) -> f32;
@@ -2150,7 +2237,7 @@ unsafe extern "C" {
     pub fn cos(arg1: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn cosl(arg1: f64) -> f64;
+    pub fn cosl(arg1: u128) -> u128;
 }
 unsafe extern "C" {
     pub fn sinf(arg1: f32) -> f32;
@@ -2159,7 +2246,7 @@ unsafe extern "C" {
     pub fn sin(arg1: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn sinl(arg1: f64) -> f64;
+    pub fn sinl(arg1: u128) -> u128;
 }
 unsafe extern "C" {
     pub fn tanf(arg1: f32) -> f32;
@@ -2168,7 +2255,7 @@ unsafe extern "C" {
     pub fn tan(arg1: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn tanl(arg1: f64) -> f64;
+    pub fn tanl(arg1: u128) -> u128;
 }
 unsafe extern "C" {
     pub fn acoshf(arg1: f32) -> f32;
@@ -2177,7 +2264,7 @@ unsafe extern "C" {
     pub fn acosh(arg1: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn acoshl(arg1: f64) -> f64;
+    pub fn acoshl(arg1: u128) -> u128;
 }
 unsafe extern "C" {
     pub fn asinhf(arg1: f32) -> f32;
@@ -2186,7 +2273,7 @@ unsafe extern "C" {
     pub fn asinh(arg1: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn asinhl(arg1: f64) -> f64;
+    pub fn asinhl(arg1: u128) -> u128;
 }
 unsafe extern "C" {
     pub fn atanhf(arg1: f32) -> f32;
@@ -2195,7 +2282,7 @@ unsafe extern "C" {
     pub fn atanh(arg1: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn atanhl(arg1: f64) -> f64;
+    pub fn atanhl(arg1: u128) -> u128;
 }
 unsafe extern "C" {
     pub fn coshf(arg1: f32) -> f32;
@@ -2204,7 +2291,7 @@ unsafe extern "C" {
     pub fn cosh(arg1: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn coshl(arg1: f64) -> f64;
+    pub fn coshl(arg1: u128) -> u128;
 }
 unsafe extern "C" {
     pub fn sinhf(arg1: f32) -> f32;
@@ -2213,7 +2300,7 @@ unsafe extern "C" {
     pub fn sinh(arg1: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn sinhl(arg1: f64) -> f64;
+    pub fn sinhl(arg1: u128) -> u128;
 }
 unsafe extern "C" {
     pub fn tanhf(arg1: f32) -> f32;
@@ -2222,7 +2309,7 @@ unsafe extern "C" {
     pub fn tanh(arg1: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn tanhl(arg1: f64) -> f64;
+    pub fn tanhl(arg1: u128) -> u128;
 }
 unsafe extern "C" {
     pub fn expf(arg1: f32) -> f32;
@@ -2231,7 +2318,7 @@ unsafe extern "C" {
     pub fn exp(arg1: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn expl(arg1: f64) -> f64;
+    pub fn expl(arg1: u128) -> u128;
 }
 unsafe extern "C" {
     pub fn exp2f(arg1: f32) -> f32;
@@ -2240,7 +2327,7 @@ unsafe extern "C" {
     pub fn exp2(arg1: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn exp2l(arg1: f64) -> f64;
+    pub fn exp2l(arg1: u128) -> u128;
 }
 unsafe extern "C" {
     pub fn expm1f(arg1: f32) -> f32;
@@ -2249,7 +2336,7 @@ unsafe extern "C" {
     pub fn expm1(arg1: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn expm1l(arg1: f64) -> f64;
+    pub fn expm1l(arg1: u128) -> u128;
 }
 unsafe extern "C" {
     pub fn logf(arg1: f32) -> f32;
@@ -2258,7 +2345,7 @@ unsafe extern "C" {
     pub fn log(arg1: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn logl(arg1: f64) -> f64;
+    pub fn logl(arg1: u128) -> u128;
 }
 unsafe extern "C" {
     pub fn log10f(arg1: f32) -> f32;
@@ -2267,7 +2354,7 @@ unsafe extern "C" {
     pub fn log10(arg1: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn log10l(arg1: f64) -> f64;
+    pub fn log10l(arg1: u128) -> u128;
 }
 unsafe extern "C" {
     pub fn log2f(arg1: f32) -> f32;
@@ -2276,7 +2363,7 @@ unsafe extern "C" {
     pub fn log2(arg1: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn log2l(arg1: f64) -> f64;
+    pub fn log2l(arg1: u128) -> u128;
 }
 unsafe extern "C" {
     pub fn log1pf(arg1: f32) -> f32;
@@ -2285,7 +2372,7 @@ unsafe extern "C" {
     pub fn log1p(arg1: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn log1pl(arg1: f64) -> f64;
+    pub fn log1pl(arg1: u128) -> u128;
 }
 unsafe extern "C" {
     pub fn logbf(arg1: f32) -> f32;
@@ -2294,7 +2381,7 @@ unsafe extern "C" {
     pub fn logb(arg1: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn logbl(arg1: f64) -> f64;
+    pub fn logbl(arg1: u128) -> u128;
 }
 unsafe extern "C" {
     pub fn modff(arg1: f32, arg2: *mut f32) -> f32;
@@ -2303,7 +2390,7 @@ unsafe extern "C" {
     pub fn modf(arg1: f64, arg2: *mut f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn modfl(arg1: f64, arg2: *mut f64) -> f64;
+    pub fn modfl(arg1: u128, arg2: *mut u128) -> u128;
 }
 unsafe extern "C" {
     pub fn ldexpf(arg1: f32, arg2: ::std::os::raw::c_int) -> f32;
@@ -2312,7 +2399,7 @@ unsafe extern "C" {
     pub fn ldexp(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
 }
 unsafe extern "C" {
-    pub fn ldexpl(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
+    pub fn ldexpl(arg1: u128, arg2: ::std::os::raw::c_int) -> u128;
 }
 unsafe extern "C" {
     pub fn frexpf(arg1: f32, arg2: *mut ::std::os::raw::c_int) -> f32;
@@ -2321,7 +2408,7 @@ unsafe extern "C" {
     pub fn frexp(arg1: f64, arg2: *mut ::std::os::raw::c_int) -> f64;
 }
 unsafe extern "C" {
-    pub fn frexpl(arg1: f64, arg2: *mut ::std::os::raw::c_int) -> f64;
+    pub fn frexpl(arg1: u128, arg2: *mut ::std::os::raw::c_int) -> u128;
 }
 unsafe extern "C" {
     pub fn ilogbf(arg1: f32) -> ::std::os::raw::c_int;
@@ -2330,7 +2417,7 @@ unsafe extern "C" {
     pub fn ilogb(arg1: f64) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn ilogbl(arg1: f64) -> ::std::os::raw::c_int;
+    pub fn ilogbl(arg1: u128) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
     pub fn scalbnf(arg1: f32, arg2: ::std::os::raw::c_int) -> f32;
@@ -2339,7 +2426,7 @@ unsafe extern "C" {
     pub fn scalbn(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
 }
 unsafe extern "C" {
-    pub fn scalbnl(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
+    pub fn scalbnl(arg1: u128, arg2: ::std::os::raw::c_int) -> u128;
 }
 unsafe extern "C" {
     pub fn scalblnf(arg1: f32, arg2: ::std::os::raw::c_long) -> f32;
@@ -2348,7 +2435,7 @@ unsafe extern "C" {
     pub fn scalbln(arg1: f64, arg2: ::std::os::raw::c_long) -> f64;
 }
 unsafe extern "C" {
-    pub fn scalblnl(arg1: f64, arg2: ::std::os::raw::c_long) -> f64;
+    pub fn scalblnl(arg1: u128, arg2: ::std::os::raw::c_long) -> u128;
 }
 unsafe extern "C" {
     pub fn fabsf(arg1: f32) -> f32;
@@ -2357,7 +2444,7 @@ unsafe extern "C" {
     pub fn fabs(arg1: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn fabsl(arg1: f64) -> f64;
+    pub fn fabsl(arg1: u128) -> u128;
 }
 unsafe extern "C" {
     pub fn cbrtf(arg1: f32) -> f32;
@@ -2366,7 +2453,7 @@ unsafe extern "C" {
     pub fn cbrt(arg1: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn cbrtl(arg1: f64) -> f64;
+    pub fn cbrtl(arg1: u128) -> u128;
 }
 unsafe extern "C" {
     pub fn hypotf(arg1: f32, arg2: f32) -> f32;
@@ -2375,7 +2462,7 @@ unsafe extern "C" {
     pub fn hypot(arg1: f64, arg2: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn hypotl(arg1: f64, arg2: f64) -> f64;
+    pub fn hypotl(arg1: u128, arg2: u128) -> u128;
 }
 unsafe extern "C" {
     pub fn powf(arg1: f32, arg2: f32) -> f32;
@@ -2384,7 +2471,7 @@ unsafe extern "C" {
     pub fn pow(arg1: f64, arg2: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn powl(arg1: f64, arg2: f64) -> f64;
+    pub fn powl(arg1: u128, arg2: u128) -> u128;
 }
 unsafe extern "C" {
     pub fn sqrtf(arg1: f32) -> f32;
@@ -2393,7 +2480,7 @@ unsafe extern "C" {
     pub fn sqrt(arg1: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn sqrtl(arg1: f64) -> f64;
+    pub fn sqrtl(arg1: u128) -> u128;
 }
 unsafe extern "C" {
     pub fn erff(arg1: f32) -> f32;
@@ -2402,7 +2489,7 @@ unsafe extern "C" {
     pub fn erf(arg1: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn erfl(arg1: f64) -> f64;
+    pub fn erfl(arg1: u128) -> u128;
 }
 unsafe extern "C" {
     pub fn erfcf(arg1: f32) -> f32;
@@ -2411,7 +2498,7 @@ unsafe extern "C" {
     pub fn erfc(arg1: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn erfcl(arg1: f64) -> f64;
+    pub fn erfcl(arg1: u128) -> u128;
 }
 unsafe extern "C" {
     pub fn lgammaf(arg1: f32) -> f32;
@@ -2420,7 +2507,7 @@ unsafe extern "C" {
     pub fn lgamma(arg1: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn lgammal(arg1: f64) -> f64;
+    pub fn lgammal(arg1: u128) -> u128;
 }
 unsafe extern "C" {
     pub fn tgammaf(arg1: f32) -> f32;
@@ -2429,7 +2516,7 @@ unsafe extern "C" {
     pub fn tgamma(arg1: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn tgammal(arg1: f64) -> f64;
+    pub fn tgammal(arg1: u128) -> u128;
 }
 unsafe extern "C" {
     pub fn ceilf(arg1: f32) -> f32;
@@ -2438,7 +2525,7 @@ unsafe extern "C" {
     pub fn ceil(arg1: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn ceill(arg1: f64) -> f64;
+    pub fn ceill(arg1: u128) -> u128;
 }
 unsafe extern "C" {
     pub fn floorf(arg1: f32) -> f32;
@@ -2447,7 +2534,7 @@ unsafe extern "C" {
     pub fn floor(arg1: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn floorl(arg1: f64) -> f64;
+    pub fn floorl(arg1: u128) -> u128;
 }
 unsafe extern "C" {
     pub fn nearbyintf(arg1: f32) -> f32;
@@ -2456,7 +2543,7 @@ unsafe extern "C" {
     pub fn nearbyint(arg1: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn nearbyintl(arg1: f64) -> f64;
+    pub fn nearbyintl(arg1: u128) -> u128;
 }
 unsafe extern "C" {
     pub fn rintf(arg1: f32) -> f32;
@@ -2465,7 +2552,7 @@ unsafe extern "C" {
     pub fn rint(arg1: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn rintl(arg1: f64) -> f64;
+    pub fn rintl(arg1: u128) -> u128;
 }
 unsafe extern "C" {
     pub fn lrintf(arg1: f32) -> ::std::os::raw::c_long;
@@ -2474,7 +2561,7 @@ unsafe extern "C" {
     pub fn lrint(arg1: f64) -> ::std::os::raw::c_long;
 }
 unsafe extern "C" {
-    pub fn lrintl(arg1: f64) -> ::std::os::raw::c_long;
+    pub fn lrintl(arg1: u128) -> ::std::os::raw::c_long;
 }
 unsafe extern "C" {
     pub fn roundf(arg1: f32) -> f32;
@@ -2483,7 +2570,7 @@ unsafe extern "C" {
     pub fn round(arg1: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn roundl(arg1: f64) -> f64;
+    pub fn roundl(arg1: u128) -> u128;
 }
 unsafe extern "C" {
     pub fn lroundf(arg1: f32) -> ::std::os::raw::c_long;
@@ -2492,7 +2579,7 @@ unsafe extern "C" {
     pub fn lround(arg1: f64) -> ::std::os::raw::c_long;
 }
 unsafe extern "C" {
-    pub fn lroundl(arg1: f64) -> ::std::os::raw::c_long;
+    pub fn lroundl(arg1: u128) -> ::std::os::raw::c_long;
 }
 unsafe extern "C" {
     pub fn llrintf(arg1: f32) -> ::std::os::raw::c_longlong;
@@ -2501,7 +2588,7 @@ unsafe extern "C" {
     pub fn llrint(arg1: f64) -> ::std::os::raw::c_longlong;
 }
 unsafe extern "C" {
-    pub fn llrintl(arg1: f64) -> ::std::os::raw::c_longlong;
+    pub fn llrintl(arg1: u128) -> ::std::os::raw::c_longlong;
 }
 unsafe extern "C" {
     pub fn llroundf(arg1: f32) -> ::std::os::raw::c_longlong;
@@ -2510,7 +2597,7 @@ unsafe extern "C" {
     pub fn llround(arg1: f64) -> ::std::os::raw::c_longlong;
 }
 unsafe extern "C" {
-    pub fn llroundl(arg1: f64) -> ::std::os::raw::c_longlong;
+    pub fn llroundl(arg1: u128) -> ::std::os::raw::c_longlong;
 }
 unsafe extern "C" {
     pub fn truncf(arg1: f32) -> f32;
@@ -2519,7 +2606,7 @@ unsafe extern "C" {
     pub fn trunc(arg1: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn truncl(arg1: f64) -> f64;
+    pub fn truncl(arg1: u128) -> u128;
 }
 unsafe extern "C" {
     pub fn fmodf(arg1: f32, arg2: f32) -> f32;
@@ -2528,7 +2615,7 @@ unsafe extern "C" {
     pub fn fmod(arg1: f64, arg2: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn fmodl(arg1: f64, arg2: f64) -> f64;
+    pub fn fmodl(arg1: u128, arg2: u128) -> u128;
 }
 unsafe extern "C" {
     pub fn remainderf(arg1: f32, arg2: f32) -> f32;
@@ -2537,7 +2624,7 @@ unsafe extern "C" {
     pub fn remainder(arg1: f64, arg2: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn remainderl(arg1: f64, arg2: f64) -> f64;
+    pub fn remainderl(arg1: u128, arg2: u128) -> u128;
 }
 unsafe extern "C" {
     pub fn remquof(arg1: f32, arg2: f32, arg3: *mut ::std::os::raw::c_int) -> f32;
@@ -2546,7 +2633,7 @@ unsafe extern "C" {
     pub fn remquo(arg1: f64, arg2: f64, arg3: *mut ::std::os::raw::c_int) -> f64;
 }
 unsafe extern "C" {
-    pub fn remquol(arg1: f64, arg2: f64, arg3: *mut ::std::os::raw::c_int) -> f64;
+    pub fn remquol(arg1: u128, arg2: u128, arg3: *mut ::std::os::raw::c_int) -> u128;
 }
 unsafe extern "C" {
     pub fn copysignf(arg1: f32, arg2: f32) -> f32;
@@ -2555,7 +2642,7 @@ unsafe extern "C" {
     pub fn copysign(arg1: f64, arg2: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn copysignl(arg1: f64, arg2: f64) -> f64;
+    pub fn copysignl(arg1: u128, arg2: u128) -> u128;
 }
 unsafe extern "C" {
     pub fn nanf(arg1: *const ::std::os::raw::c_char) -> f32;
@@ -2564,7 +2651,7 @@ unsafe extern "C" {
     pub fn nan(arg1: *const ::std::os::raw::c_char) -> f64;
 }
 unsafe extern "C" {
-    pub fn nanl(arg1: *const ::std::os::raw::c_char) -> f64;
+    pub fn nanl(arg1: *const ::std::os::raw::c_char) -> u128;
 }
 unsafe extern "C" {
     pub fn nextafterf(arg1: f32, arg2: f32) -> f32;
@@ -2573,16 +2660,16 @@ unsafe extern "C" {
     pub fn nextafter(arg1: f64, arg2: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn nextafterl(arg1: f64, arg2: f64) -> f64;
+    pub fn nextafterl(arg1: u128, arg2: u128) -> u128;
 }
 unsafe extern "C" {
-    pub fn nexttoward(arg1: f64, arg2: f64) -> f64;
+    pub fn nexttoward(arg1: f64, arg2: u128) -> f64;
 }
 unsafe extern "C" {
-    pub fn nexttowardf(arg1: f32, arg2: f64) -> f32;
+    pub fn nexttowardf(arg1: f32, arg2: u128) -> f32;
 }
 unsafe extern "C" {
-    pub fn nexttowardl(arg1: f64, arg2: f64) -> f64;
+    pub fn nexttowardl(arg1: u128, arg2: u128) -> u128;
 }
 unsafe extern "C" {
     pub fn fdimf(arg1: f32, arg2: f32) -> f32;
@@ -2591,7 +2678,7 @@ unsafe extern "C" {
     pub fn fdim(arg1: f64, arg2: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn fdiml(arg1: f64, arg2: f64) -> f64;
+    pub fn fdiml(arg1: u128, arg2: u128) -> u128;
 }
 unsafe extern "C" {
     pub fn fmaxf(arg1: f32, arg2: f32) -> f32;
@@ -2600,7 +2687,7 @@ unsafe extern "C" {
     pub fn fmax(arg1: f64, arg2: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn fmaxl(arg1: f64, arg2: f64) -> f64;
+    pub fn fmaxl(arg1: u128, arg2: u128) -> u128;
 }
 unsafe extern "C" {
     pub fn fminf(arg1: f32, arg2: f32) -> f32;
@@ -2609,7 +2696,7 @@ unsafe extern "C" {
     pub fn fmin(arg1: f64, arg2: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn fminl(arg1: f64, arg2: f64) -> f64;
+    pub fn fminl(arg1: u128, arg2: u128) -> u128;
 }
 unsafe extern "C" {
     pub fn fmaf(arg1: f32, arg2: f32, arg3: f32) -> f32;
@@ -2618,7 +2705,19 @@ unsafe extern "C" {
     pub fn fma(arg1: f64, arg2: f64, arg3: f64) -> f64;
 }
 unsafe extern "C" {
-    pub fn fmal(arg1: f64, arg2: f64, arg3: f64) -> f64;
+    pub fn fmal(arg1: u128, arg2: u128, arg3: u128) -> u128;
+}
+unsafe extern "C" {
+    pub fn __inff() -> f32;
+}
+unsafe extern "C" {
+    pub fn __inf() -> f64;
+}
+unsafe extern "C" {
+    pub fn __infl() -> u128;
+}
+unsafe extern "C" {
+    pub fn __nan() -> f32;
 }
 unsafe extern "C" {
     pub fn __exp10f(arg1: f32) -> f32;
@@ -2643,6 +2742,49 @@ unsafe extern "C" {
 }
 unsafe extern "C" {
     pub fn __tanpi(arg1: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn __fabsf16(arg1: __BindgenFloat16) -> __BindgenFloat16;
+}
+unsafe extern "C" {
+    pub fn __hypotf16(arg1: __BindgenFloat16, arg2: __BindgenFloat16) -> __BindgenFloat16;
+}
+unsafe extern "C" {
+    pub fn __sqrtf16(arg1: __BindgenFloat16) -> __BindgenFloat16;
+}
+unsafe extern "C" {
+    pub fn __ceilf16(arg1: __BindgenFloat16) -> __BindgenFloat16;
+}
+unsafe extern "C" {
+    pub fn __floorf16(arg1: __BindgenFloat16) -> __BindgenFloat16;
+}
+unsafe extern "C" {
+    pub fn __rintf16(arg1: __BindgenFloat16) -> __BindgenFloat16;
+}
+unsafe extern "C" {
+    pub fn __roundf16(arg1: __BindgenFloat16) -> __BindgenFloat16;
+}
+unsafe extern "C" {
+    pub fn __truncf16(arg1: __BindgenFloat16) -> __BindgenFloat16;
+}
+unsafe extern "C" {
+    pub fn __copysignf16(arg1: __BindgenFloat16, arg2: __BindgenFloat16) -> __BindgenFloat16;
+}
+unsafe extern "C" {
+    pub fn __nextafterf16(arg1: __BindgenFloat16, arg2: __BindgenFloat16) -> __BindgenFloat16;
+}
+unsafe extern "C" {
+    pub fn __fmaxf16(arg1: __BindgenFloat16, arg2: __BindgenFloat16) -> __BindgenFloat16;
+}
+unsafe extern "C" {
+    pub fn __fminf16(arg1: __BindgenFloat16, arg2: __BindgenFloat16) -> __BindgenFloat16;
+}
+unsafe extern "C" {
+    pub fn __fmaf16(
+        arg1: __BindgenFloat16,
+        arg2: __BindgenFloat16,
+        arg3: __BindgenFloat16,
+    ) -> __BindgenFloat16;
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2706,6 +2848,24 @@ unsafe extern "C" {
 unsafe extern "C" {
     pub static mut signgam: ::std::os::raw::c_int;
 }
+unsafe extern "C" {
+    pub fn rinttol(arg1: f64) -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn roundtol(arg1: f64) -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn drem(arg1: f64, arg2: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn finite(arg1: f64) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn gamma(arg1: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn significand(arg1: f64) -> f64;
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct exception {
@@ -2742,297 +2902,2841 @@ pub type id_t = __darwin_id_t;
 pub type sig_atomic_t = ::std::os::raw::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct __darwin_arm_exception_state {
-    pub __exception: __uint32_t,
-    pub __fsr: __uint32_t,
-    pub __far: __uint32_t,
+pub struct __darwin_i386_thread_state {
+    pub __eax: ::std::os::raw::c_uint,
+    pub __ebx: ::std::os::raw::c_uint,
+    pub __ecx: ::std::os::raw::c_uint,
+    pub __edx: ::std::os::raw::c_uint,
+    pub __edi: ::std::os::raw::c_uint,
+    pub __esi: ::std::os::raw::c_uint,
+    pub __ebp: ::std::os::raw::c_uint,
+    pub __esp: ::std::os::raw::c_uint,
+    pub __ss: ::std::os::raw::c_uint,
+    pub __eflags: ::std::os::raw::c_uint,
+    pub __eip: ::std::os::raw::c_uint,
+    pub __cs: ::std::os::raw::c_uint,
+    pub __ds: ::std::os::raw::c_uint,
+    pub __es: ::std::os::raw::c_uint,
+    pub __fs: ::std::os::raw::c_uint,
+    pub __gs: ::std::os::raw::c_uint,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of __darwin_arm_exception_state"]
-        [::std::mem::size_of::<__darwin_arm_exception_state>() - 12usize];
-    ["Alignment of __darwin_arm_exception_state"]
-        [::std::mem::align_of::<__darwin_arm_exception_state>() - 4usize];
-    ["Offset of field: __darwin_arm_exception_state::__exception"]
-        [::std::mem::offset_of!(__darwin_arm_exception_state, __exception) - 0usize];
-    ["Offset of field: __darwin_arm_exception_state::__fsr"]
-        [::std::mem::offset_of!(__darwin_arm_exception_state, __fsr) - 4usize];
-    ["Offset of field: __darwin_arm_exception_state::__far"]
-        [::std::mem::offset_of!(__darwin_arm_exception_state, __far) - 8usize];
+    ["Size of __darwin_i386_thread_state"]
+        [::std::mem::size_of::<__darwin_i386_thread_state>() - 64usize];
+    ["Alignment of __darwin_i386_thread_state"]
+        [::std::mem::align_of::<__darwin_i386_thread_state>() - 4usize];
+    ["Offset of field: __darwin_i386_thread_state::__eax"]
+        [::std::mem::offset_of!(__darwin_i386_thread_state, __eax) - 0usize];
+    ["Offset of field: __darwin_i386_thread_state::__ebx"]
+        [::std::mem::offset_of!(__darwin_i386_thread_state, __ebx) - 4usize];
+    ["Offset of field: __darwin_i386_thread_state::__ecx"]
+        [::std::mem::offset_of!(__darwin_i386_thread_state, __ecx) - 8usize];
+    ["Offset of field: __darwin_i386_thread_state::__edx"]
+        [::std::mem::offset_of!(__darwin_i386_thread_state, __edx) - 12usize];
+    ["Offset of field: __darwin_i386_thread_state::__edi"]
+        [::std::mem::offset_of!(__darwin_i386_thread_state, __edi) - 16usize];
+    ["Offset of field: __darwin_i386_thread_state::__esi"]
+        [::std::mem::offset_of!(__darwin_i386_thread_state, __esi) - 20usize];
+    ["Offset of field: __darwin_i386_thread_state::__ebp"]
+        [::std::mem::offset_of!(__darwin_i386_thread_state, __ebp) - 24usize];
+    ["Offset of field: __darwin_i386_thread_state::__esp"]
+        [::std::mem::offset_of!(__darwin_i386_thread_state, __esp) - 28usize];
+    ["Offset of field: __darwin_i386_thread_state::__ss"]
+        [::std::mem::offset_of!(__darwin_i386_thread_state, __ss) - 32usize];
+    ["Offset of field: __darwin_i386_thread_state::__eflags"]
+        [::std::mem::offset_of!(__darwin_i386_thread_state, __eflags) - 36usize];
+    ["Offset of field: __darwin_i386_thread_state::__eip"]
+        [::std::mem::offset_of!(__darwin_i386_thread_state, __eip) - 40usize];
+    ["Offset of field: __darwin_i386_thread_state::__cs"]
+        [::std::mem::offset_of!(__darwin_i386_thread_state, __cs) - 44usize];
+    ["Offset of field: __darwin_i386_thread_state::__ds"]
+        [::std::mem::offset_of!(__darwin_i386_thread_state, __ds) - 48usize];
+    ["Offset of field: __darwin_i386_thread_state::__es"]
+        [::std::mem::offset_of!(__darwin_i386_thread_state, __es) - 52usize];
+    ["Offset of field: __darwin_i386_thread_state::__fs"]
+        [::std::mem::offset_of!(__darwin_i386_thread_state, __fs) - 56usize];
+    ["Offset of field: __darwin_i386_thread_state::__gs"]
+        [::std::mem::offset_of!(__darwin_i386_thread_state, __gs) - 60usize];
 };
 #[repr(C)]
+#[repr(align(2))]
 #[derive(Debug, Copy, Clone)]
-pub struct __darwin_arm_exception_state64 {
-    pub __far: __uint64_t,
-    pub __esr: __uint32_t,
-    pub __exception: __uint32_t,
+pub struct __darwin_fp_control {
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of __darwin_arm_exception_state64"]
-        [::std::mem::size_of::<__darwin_arm_exception_state64>() - 16usize];
-    ["Alignment of __darwin_arm_exception_state64"]
-        [::std::mem::align_of::<__darwin_arm_exception_state64>() - 8usize];
-    ["Offset of field: __darwin_arm_exception_state64::__far"]
-        [::std::mem::offset_of!(__darwin_arm_exception_state64, __far) - 0usize];
-    ["Offset of field: __darwin_arm_exception_state64::__esr"]
-        [::std::mem::offset_of!(__darwin_arm_exception_state64, __esr) - 8usize];
-    ["Offset of field: __darwin_arm_exception_state64::__exception"]
-        [::std::mem::offset_of!(__darwin_arm_exception_state64, __exception) - 12usize];
+    ["Size of __darwin_fp_control"][::std::mem::size_of::<__darwin_fp_control>() - 2usize];
+    ["Alignment of __darwin_fp_control"][::std::mem::align_of::<__darwin_fp_control>() - 2usize];
 };
+impl __darwin_fp_control {
+    #[inline]
+    pub fn __invalid(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___invalid(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn __invalid_raw(this: *const Self) -> ::std::os::raw::c_ushort {
+        unsafe {
+            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 2usize]>>::raw_get(
+                ::std::ptr::addr_of!((*this)._bitfield_1),
+                0usize,
+                1u8,
+            ) as u16)
+        }
+    }
+    #[inline]
+    pub unsafe fn set___invalid_raw(this: *mut Self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<[u8; 2usize]>>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                0usize,
+                1u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
+    pub fn __denorm(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___denorm(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(1usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn __denorm_raw(this: *const Self) -> ::std::os::raw::c_ushort {
+        unsafe {
+            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 2usize]>>::raw_get(
+                ::std::ptr::addr_of!((*this)._bitfield_1),
+                1usize,
+                1u8,
+            ) as u16)
+        }
+    }
+    #[inline]
+    pub unsafe fn set___denorm_raw(this: *mut Self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<[u8; 2usize]>>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                1usize,
+                1u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
+    pub fn __zdiv(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___zdiv(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(2usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn __zdiv_raw(this: *const Self) -> ::std::os::raw::c_ushort {
+        unsafe {
+            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 2usize]>>::raw_get(
+                ::std::ptr::addr_of!((*this)._bitfield_1),
+                2usize,
+                1u8,
+            ) as u16)
+        }
+    }
+    #[inline]
+    pub unsafe fn set___zdiv_raw(this: *mut Self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<[u8; 2usize]>>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                2usize,
+                1u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
+    pub fn __ovrfl(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(3usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___ovrfl(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(3usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn __ovrfl_raw(this: *const Self) -> ::std::os::raw::c_ushort {
+        unsafe {
+            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 2usize]>>::raw_get(
+                ::std::ptr::addr_of!((*this)._bitfield_1),
+                3usize,
+                1u8,
+            ) as u16)
+        }
+    }
+    #[inline]
+    pub unsafe fn set___ovrfl_raw(this: *mut Self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<[u8; 2usize]>>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                3usize,
+                1u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
+    pub fn __undfl(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(4usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___undfl(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(4usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn __undfl_raw(this: *const Self) -> ::std::os::raw::c_ushort {
+        unsafe {
+            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 2usize]>>::raw_get(
+                ::std::ptr::addr_of!((*this)._bitfield_1),
+                4usize,
+                1u8,
+            ) as u16)
+        }
+    }
+    #[inline]
+    pub unsafe fn set___undfl_raw(this: *mut Self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<[u8; 2usize]>>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                4usize,
+                1u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
+    pub fn __precis(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(5usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___precis(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(5usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn __precis_raw(this: *const Self) -> ::std::os::raw::c_ushort {
+        unsafe {
+            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 2usize]>>::raw_get(
+                ::std::ptr::addr_of!((*this)._bitfield_1),
+                5usize,
+                1u8,
+            ) as u16)
+        }
+    }
+    #[inline]
+    pub unsafe fn set___precis_raw(this: *mut Self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<[u8; 2usize]>>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                5usize,
+                1u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
+    pub fn __pc(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 2u8) as u16) }
+    }
+    #[inline]
+    pub fn set___pc(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(8usize, 2u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn __pc_raw(this: *const Self) -> ::std::os::raw::c_ushort {
+        unsafe {
+            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 2usize]>>::raw_get(
+                ::std::ptr::addr_of!((*this)._bitfield_1),
+                8usize,
+                2u8,
+            ) as u16)
+        }
+    }
+    #[inline]
+    pub unsafe fn set___pc_raw(this: *mut Self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<[u8; 2usize]>>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                8usize,
+                2u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
+    pub fn __rc(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(10usize, 2u8) as u16) }
+    }
+    #[inline]
+    pub fn set___rc(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(10usize, 2u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn __rc_raw(this: *const Self) -> ::std::os::raw::c_ushort {
+        unsafe {
+            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 2usize]>>::raw_get(
+                ::std::ptr::addr_of!((*this)._bitfield_1),
+                10usize,
+                2u8,
+            ) as u16)
+        }
+    }
+    #[inline]
+    pub unsafe fn set___rc_raw(this: *mut Self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<[u8; 2usize]>>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                10usize,
+                2u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
+    pub fn new_bitfield_1(
+        __invalid: ::std::os::raw::c_ushort,
+        __denorm: ::std::os::raw::c_ushort,
+        __zdiv: ::std::os::raw::c_ushort,
+        __ovrfl: ::std::os::raw::c_ushort,
+        __undfl: ::std::os::raw::c_ushort,
+        __precis: ::std::os::raw::c_ushort,
+        __pc: ::std::os::raw::c_ushort,
+        __rc: ::std::os::raw::c_ushort,
+    ) -> __BindgenBitfieldUnit<[u8; 2usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> = Default::default();
+        __bindgen_bitfield_unit.set(0usize, 1u8, {
+            let __invalid: u16 = unsafe { ::std::mem::transmute(__invalid) };
+            __invalid as u64
+        });
+        __bindgen_bitfield_unit.set(1usize, 1u8, {
+            let __denorm: u16 = unsafe { ::std::mem::transmute(__denorm) };
+            __denorm as u64
+        });
+        __bindgen_bitfield_unit.set(2usize, 1u8, {
+            let __zdiv: u16 = unsafe { ::std::mem::transmute(__zdiv) };
+            __zdiv as u64
+        });
+        __bindgen_bitfield_unit.set(3usize, 1u8, {
+            let __ovrfl: u16 = unsafe { ::std::mem::transmute(__ovrfl) };
+            __ovrfl as u64
+        });
+        __bindgen_bitfield_unit.set(4usize, 1u8, {
+            let __undfl: u16 = unsafe { ::std::mem::transmute(__undfl) };
+            __undfl as u64
+        });
+        __bindgen_bitfield_unit.set(5usize, 1u8, {
+            let __precis: u16 = unsafe { ::std::mem::transmute(__precis) };
+            __precis as u64
+        });
+        __bindgen_bitfield_unit.set(8usize, 2u8, {
+            let __pc: u16 = unsafe { ::std::mem::transmute(__pc) };
+            __pc as u64
+        });
+        __bindgen_bitfield_unit.set(10usize, 2u8, {
+            let __rc: u16 = unsafe { ::std::mem::transmute(__rc) };
+            __rc as u64
+        });
+        __bindgen_bitfield_unit
+    }
+}
+pub type __darwin_fp_control_t = __darwin_fp_control;
 #[repr(C)]
+#[repr(align(2))]
 #[derive(Debug, Copy, Clone)]
-pub struct __darwin_arm_thread_state {
-    pub __r: [__uint32_t; 13usize],
-    pub __sp: __uint32_t,
-    pub __lr: __uint32_t,
-    pub __pc: __uint32_t,
-    pub __cpsr: __uint32_t,
+pub struct __darwin_fp_status {
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of __darwin_arm_thread_state"]
-        [::std::mem::size_of::<__darwin_arm_thread_state>() - 68usize];
-    ["Alignment of __darwin_arm_thread_state"]
-        [::std::mem::align_of::<__darwin_arm_thread_state>() - 4usize];
-    ["Offset of field: __darwin_arm_thread_state::__r"]
-        [::std::mem::offset_of!(__darwin_arm_thread_state, __r) - 0usize];
-    ["Offset of field: __darwin_arm_thread_state::__sp"]
-        [::std::mem::offset_of!(__darwin_arm_thread_state, __sp) - 52usize];
-    ["Offset of field: __darwin_arm_thread_state::__lr"]
-        [::std::mem::offset_of!(__darwin_arm_thread_state, __lr) - 56usize];
-    ["Offset of field: __darwin_arm_thread_state::__pc"]
-        [::std::mem::offset_of!(__darwin_arm_thread_state, __pc) - 60usize];
-    ["Offset of field: __darwin_arm_thread_state::__cpsr"]
-        [::std::mem::offset_of!(__darwin_arm_thread_state, __cpsr) - 64usize];
+    ["Size of __darwin_fp_status"][::std::mem::size_of::<__darwin_fp_status>() - 2usize];
+    ["Alignment of __darwin_fp_status"][::std::mem::align_of::<__darwin_fp_status>() - 2usize];
 };
+impl __darwin_fp_status {
+    #[inline]
+    pub fn __invalid(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___invalid(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn __invalid_raw(this: *const Self) -> ::std::os::raw::c_ushort {
+        unsafe {
+            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 2usize]>>::raw_get(
+                ::std::ptr::addr_of!((*this)._bitfield_1),
+                0usize,
+                1u8,
+            ) as u16)
+        }
+    }
+    #[inline]
+    pub unsafe fn set___invalid_raw(this: *mut Self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<[u8; 2usize]>>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                0usize,
+                1u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
+    pub fn __denorm(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___denorm(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(1usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn __denorm_raw(this: *const Self) -> ::std::os::raw::c_ushort {
+        unsafe {
+            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 2usize]>>::raw_get(
+                ::std::ptr::addr_of!((*this)._bitfield_1),
+                1usize,
+                1u8,
+            ) as u16)
+        }
+    }
+    #[inline]
+    pub unsafe fn set___denorm_raw(this: *mut Self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<[u8; 2usize]>>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                1usize,
+                1u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
+    pub fn __zdiv(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___zdiv(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(2usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn __zdiv_raw(this: *const Self) -> ::std::os::raw::c_ushort {
+        unsafe {
+            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 2usize]>>::raw_get(
+                ::std::ptr::addr_of!((*this)._bitfield_1),
+                2usize,
+                1u8,
+            ) as u16)
+        }
+    }
+    #[inline]
+    pub unsafe fn set___zdiv_raw(this: *mut Self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<[u8; 2usize]>>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                2usize,
+                1u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
+    pub fn __ovrfl(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(3usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___ovrfl(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(3usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn __ovrfl_raw(this: *const Self) -> ::std::os::raw::c_ushort {
+        unsafe {
+            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 2usize]>>::raw_get(
+                ::std::ptr::addr_of!((*this)._bitfield_1),
+                3usize,
+                1u8,
+            ) as u16)
+        }
+    }
+    #[inline]
+    pub unsafe fn set___ovrfl_raw(this: *mut Self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<[u8; 2usize]>>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                3usize,
+                1u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
+    pub fn __undfl(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(4usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___undfl(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(4usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn __undfl_raw(this: *const Self) -> ::std::os::raw::c_ushort {
+        unsafe {
+            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 2usize]>>::raw_get(
+                ::std::ptr::addr_of!((*this)._bitfield_1),
+                4usize,
+                1u8,
+            ) as u16)
+        }
+    }
+    #[inline]
+    pub unsafe fn set___undfl_raw(this: *mut Self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<[u8; 2usize]>>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                4usize,
+                1u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
+    pub fn __precis(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(5usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___precis(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(5usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn __precis_raw(this: *const Self) -> ::std::os::raw::c_ushort {
+        unsafe {
+            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 2usize]>>::raw_get(
+                ::std::ptr::addr_of!((*this)._bitfield_1),
+                5usize,
+                1u8,
+            ) as u16)
+        }
+    }
+    #[inline]
+    pub unsafe fn set___precis_raw(this: *mut Self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<[u8; 2usize]>>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                5usize,
+                1u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
+    pub fn __stkflt(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(6usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___stkflt(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(6usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn __stkflt_raw(this: *const Self) -> ::std::os::raw::c_ushort {
+        unsafe {
+            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 2usize]>>::raw_get(
+                ::std::ptr::addr_of!((*this)._bitfield_1),
+                6usize,
+                1u8,
+            ) as u16)
+        }
+    }
+    #[inline]
+    pub unsafe fn set___stkflt_raw(this: *mut Self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<[u8; 2usize]>>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                6usize,
+                1u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
+    pub fn __errsumm(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(7usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___errsumm(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(7usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn __errsumm_raw(this: *const Self) -> ::std::os::raw::c_ushort {
+        unsafe {
+            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 2usize]>>::raw_get(
+                ::std::ptr::addr_of!((*this)._bitfield_1),
+                7usize,
+                1u8,
+            ) as u16)
+        }
+    }
+    #[inline]
+    pub unsafe fn set___errsumm_raw(this: *mut Self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<[u8; 2usize]>>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                7usize,
+                1u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
+    pub fn __c0(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___c0(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(8usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn __c0_raw(this: *const Self) -> ::std::os::raw::c_ushort {
+        unsafe {
+            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 2usize]>>::raw_get(
+                ::std::ptr::addr_of!((*this)._bitfield_1),
+                8usize,
+                1u8,
+            ) as u16)
+        }
+    }
+    #[inline]
+    pub unsafe fn set___c0_raw(this: *mut Self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<[u8; 2usize]>>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                8usize,
+                1u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
+    pub fn __c1(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(9usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___c1(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(9usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn __c1_raw(this: *const Self) -> ::std::os::raw::c_ushort {
+        unsafe {
+            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 2usize]>>::raw_get(
+                ::std::ptr::addr_of!((*this)._bitfield_1),
+                9usize,
+                1u8,
+            ) as u16)
+        }
+    }
+    #[inline]
+    pub unsafe fn set___c1_raw(this: *mut Self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<[u8; 2usize]>>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                9usize,
+                1u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
+    pub fn __c2(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(10usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___c2(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(10usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn __c2_raw(this: *const Self) -> ::std::os::raw::c_ushort {
+        unsafe {
+            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 2usize]>>::raw_get(
+                ::std::ptr::addr_of!((*this)._bitfield_1),
+                10usize,
+                1u8,
+            ) as u16)
+        }
+    }
+    #[inline]
+    pub unsafe fn set___c2_raw(this: *mut Self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<[u8; 2usize]>>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                10usize,
+                1u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
+    pub fn __tos(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(11usize, 3u8) as u16) }
+    }
+    #[inline]
+    pub fn set___tos(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(11usize, 3u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn __tos_raw(this: *const Self) -> ::std::os::raw::c_ushort {
+        unsafe {
+            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 2usize]>>::raw_get(
+                ::std::ptr::addr_of!((*this)._bitfield_1),
+                11usize,
+                3u8,
+            ) as u16)
+        }
+    }
+    #[inline]
+    pub unsafe fn set___tos_raw(this: *mut Self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<[u8; 2usize]>>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                11usize,
+                3u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
+    pub fn __c3(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(14usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___c3(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(14usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn __c3_raw(this: *const Self) -> ::std::os::raw::c_ushort {
+        unsafe {
+            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 2usize]>>::raw_get(
+                ::std::ptr::addr_of!((*this)._bitfield_1),
+                14usize,
+                1u8,
+            ) as u16)
+        }
+    }
+    #[inline]
+    pub unsafe fn set___c3_raw(this: *mut Self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<[u8; 2usize]>>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                14usize,
+                1u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
+    pub fn __busy(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(15usize, 1u8) as u16) }
+    }
+    #[inline]
+    pub fn set___busy(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(15usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn __busy_raw(this: *const Self) -> ::std::os::raw::c_ushort {
+        unsafe {
+            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 2usize]>>::raw_get(
+                ::std::ptr::addr_of!((*this)._bitfield_1),
+                15usize,
+                1u8,
+            ) as u16)
+        }
+    }
+    #[inline]
+    pub unsafe fn set___busy_raw(this: *mut Self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<[u8; 2usize]>>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                15usize,
+                1u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
+    pub fn new_bitfield_1(
+        __invalid: ::std::os::raw::c_ushort,
+        __denorm: ::std::os::raw::c_ushort,
+        __zdiv: ::std::os::raw::c_ushort,
+        __ovrfl: ::std::os::raw::c_ushort,
+        __undfl: ::std::os::raw::c_ushort,
+        __precis: ::std::os::raw::c_ushort,
+        __stkflt: ::std::os::raw::c_ushort,
+        __errsumm: ::std::os::raw::c_ushort,
+        __c0: ::std::os::raw::c_ushort,
+        __c1: ::std::os::raw::c_ushort,
+        __c2: ::std::os::raw::c_ushort,
+        __tos: ::std::os::raw::c_ushort,
+        __c3: ::std::os::raw::c_ushort,
+        __busy: ::std::os::raw::c_ushort,
+    ) -> __BindgenBitfieldUnit<[u8; 2usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> = Default::default();
+        __bindgen_bitfield_unit.set(0usize, 1u8, {
+            let __invalid: u16 = unsafe { ::std::mem::transmute(__invalid) };
+            __invalid as u64
+        });
+        __bindgen_bitfield_unit.set(1usize, 1u8, {
+            let __denorm: u16 = unsafe { ::std::mem::transmute(__denorm) };
+            __denorm as u64
+        });
+        __bindgen_bitfield_unit.set(2usize, 1u8, {
+            let __zdiv: u16 = unsafe { ::std::mem::transmute(__zdiv) };
+            __zdiv as u64
+        });
+        __bindgen_bitfield_unit.set(3usize, 1u8, {
+            let __ovrfl: u16 = unsafe { ::std::mem::transmute(__ovrfl) };
+            __ovrfl as u64
+        });
+        __bindgen_bitfield_unit.set(4usize, 1u8, {
+            let __undfl: u16 = unsafe { ::std::mem::transmute(__undfl) };
+            __undfl as u64
+        });
+        __bindgen_bitfield_unit.set(5usize, 1u8, {
+            let __precis: u16 = unsafe { ::std::mem::transmute(__precis) };
+            __precis as u64
+        });
+        __bindgen_bitfield_unit.set(6usize, 1u8, {
+            let __stkflt: u16 = unsafe { ::std::mem::transmute(__stkflt) };
+            __stkflt as u64
+        });
+        __bindgen_bitfield_unit.set(7usize, 1u8, {
+            let __errsumm: u16 = unsafe { ::std::mem::transmute(__errsumm) };
+            __errsumm as u64
+        });
+        __bindgen_bitfield_unit.set(8usize, 1u8, {
+            let __c0: u16 = unsafe { ::std::mem::transmute(__c0) };
+            __c0 as u64
+        });
+        __bindgen_bitfield_unit.set(9usize, 1u8, {
+            let __c1: u16 = unsafe { ::std::mem::transmute(__c1) };
+            __c1 as u64
+        });
+        __bindgen_bitfield_unit.set(10usize, 1u8, {
+            let __c2: u16 = unsafe { ::std::mem::transmute(__c2) };
+            __c2 as u64
+        });
+        __bindgen_bitfield_unit.set(11usize, 3u8, {
+            let __tos: u16 = unsafe { ::std::mem::transmute(__tos) };
+            __tos as u64
+        });
+        __bindgen_bitfield_unit.set(14usize, 1u8, {
+            let __c3: u16 = unsafe { ::std::mem::transmute(__c3) };
+            __c3 as u64
+        });
+        __bindgen_bitfield_unit.set(15usize, 1u8, {
+            let __busy: u16 = unsafe { ::std::mem::transmute(__busy) };
+            __busy as u64
+        });
+        __bindgen_bitfield_unit
+    }
+}
+pub type __darwin_fp_status_t = __darwin_fp_status;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct __darwin_arm_thread_state64 {
-    pub __x: [__uint64_t; 29usize],
-    pub __fp: __uint64_t,
-    pub __lr: __uint64_t,
-    pub __sp: __uint64_t,
-    pub __pc: __uint64_t,
-    pub __cpsr: __uint32_t,
-    pub __pad: __uint32_t,
+pub struct __darwin_mmst_reg {
+    pub __mmst_reg: [::std::os::raw::c_char; 10usize],
+    pub __mmst_rsrv: [::std::os::raw::c_char; 6usize],
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of __darwin_arm_thread_state64"]
-        [::std::mem::size_of::<__darwin_arm_thread_state64>() - 272usize];
-    ["Alignment of __darwin_arm_thread_state64"]
-        [::std::mem::align_of::<__darwin_arm_thread_state64>() - 8usize];
-    ["Offset of field: __darwin_arm_thread_state64::__x"]
-        [::std::mem::offset_of!(__darwin_arm_thread_state64, __x) - 0usize];
-    ["Offset of field: __darwin_arm_thread_state64::__fp"]
-        [::std::mem::offset_of!(__darwin_arm_thread_state64, __fp) - 232usize];
-    ["Offset of field: __darwin_arm_thread_state64::__lr"]
-        [::std::mem::offset_of!(__darwin_arm_thread_state64, __lr) - 240usize];
-    ["Offset of field: __darwin_arm_thread_state64::__sp"]
-        [::std::mem::offset_of!(__darwin_arm_thread_state64, __sp) - 248usize];
-    ["Offset of field: __darwin_arm_thread_state64::__pc"]
-        [::std::mem::offset_of!(__darwin_arm_thread_state64, __pc) - 256usize];
-    ["Offset of field: __darwin_arm_thread_state64::__cpsr"]
-        [::std::mem::offset_of!(__darwin_arm_thread_state64, __cpsr) - 264usize];
-    ["Offset of field: __darwin_arm_thread_state64::__pad"]
-        [::std::mem::offset_of!(__darwin_arm_thread_state64, __pad) - 268usize];
+    ["Size of __darwin_mmst_reg"][::std::mem::size_of::<__darwin_mmst_reg>() - 16usize];
+    ["Alignment of __darwin_mmst_reg"][::std::mem::align_of::<__darwin_mmst_reg>() - 1usize];
+    ["Offset of field: __darwin_mmst_reg::__mmst_reg"]
+        [::std::mem::offset_of!(__darwin_mmst_reg, __mmst_reg) - 0usize];
+    ["Offset of field: __darwin_mmst_reg::__mmst_rsrv"]
+        [::std::mem::offset_of!(__darwin_mmst_reg, __mmst_rsrv) - 10usize];
 };
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct __darwin_arm_vfp_state {
-    pub __r: [__uint32_t; 64usize],
-    pub __fpscr: __uint32_t,
+pub struct __darwin_xmm_reg {
+    pub __xmm_reg: [::std::os::raw::c_char; 16usize],
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of __darwin_arm_vfp_state"][::std::mem::size_of::<__darwin_arm_vfp_state>() - 260usize];
-    ["Alignment of __darwin_arm_vfp_state"]
-        [::std::mem::align_of::<__darwin_arm_vfp_state>() - 4usize];
-    ["Offset of field: __darwin_arm_vfp_state::__r"]
-        [::std::mem::offset_of!(__darwin_arm_vfp_state, __r) - 0usize];
-    ["Offset of field: __darwin_arm_vfp_state::__fpscr"]
-        [::std::mem::offset_of!(__darwin_arm_vfp_state, __fpscr) - 256usize];
+    ["Size of __darwin_xmm_reg"][::std::mem::size_of::<__darwin_xmm_reg>() - 16usize];
+    ["Alignment of __darwin_xmm_reg"][::std::mem::align_of::<__darwin_xmm_reg>() - 1usize];
+    ["Offset of field: __darwin_xmm_reg::__xmm_reg"]
+        [::std::mem::offset_of!(__darwin_xmm_reg, __xmm_reg) - 0usize];
 };
 #[repr(C)]
-#[repr(align(16))]
 #[derive(Debug, Copy, Clone)]
-pub struct __darwin_arm_neon_state64 {
-    pub __v: [__uint128_t; 32usize],
-    pub __fpsr: __uint32_t,
-    pub __fpcr: __uint32_t,
+pub struct __darwin_ymm_reg {
+    pub __ymm_reg: [::std::os::raw::c_char; 32usize],
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of __darwin_arm_neon_state64"]
-        [::std::mem::size_of::<__darwin_arm_neon_state64>() - 528usize];
-    ["Alignment of __darwin_arm_neon_state64"]
-        [::std::mem::align_of::<__darwin_arm_neon_state64>() - 16usize];
-    ["Offset of field: __darwin_arm_neon_state64::__v"]
-        [::std::mem::offset_of!(__darwin_arm_neon_state64, __v) - 0usize];
-    ["Offset of field: __darwin_arm_neon_state64::__fpsr"]
-        [::std::mem::offset_of!(__darwin_arm_neon_state64, __fpsr) - 512usize];
-    ["Offset of field: __darwin_arm_neon_state64::__fpcr"]
-        [::std::mem::offset_of!(__darwin_arm_neon_state64, __fpcr) - 516usize];
+    ["Size of __darwin_ymm_reg"][::std::mem::size_of::<__darwin_ymm_reg>() - 32usize];
+    ["Alignment of __darwin_ymm_reg"][::std::mem::align_of::<__darwin_ymm_reg>() - 1usize];
+    ["Offset of field: __darwin_ymm_reg::__ymm_reg"]
+        [::std::mem::offset_of!(__darwin_ymm_reg, __ymm_reg) - 0usize];
 };
 #[repr(C)]
-#[repr(align(16))]
 #[derive(Debug, Copy, Clone)]
-pub struct __darwin_arm_neon_state {
-    pub __v: [__uint128_t; 16usize],
-    pub __fpsr: __uint32_t,
-    pub __fpcr: __uint32_t,
+pub struct __darwin_zmm_reg {
+    pub __zmm_reg: [::std::os::raw::c_char; 64usize],
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of __darwin_arm_neon_state"]
-        [::std::mem::size_of::<__darwin_arm_neon_state>() - 272usize];
-    ["Alignment of __darwin_arm_neon_state"]
-        [::std::mem::align_of::<__darwin_arm_neon_state>() - 16usize];
-    ["Offset of field: __darwin_arm_neon_state::__v"]
-        [::std::mem::offset_of!(__darwin_arm_neon_state, __v) - 0usize];
-    ["Offset of field: __darwin_arm_neon_state::__fpsr"]
-        [::std::mem::offset_of!(__darwin_arm_neon_state, __fpsr) - 256usize];
-    ["Offset of field: __darwin_arm_neon_state::__fpcr"]
-        [::std::mem::offset_of!(__darwin_arm_neon_state, __fpcr) - 260usize];
+    ["Size of __darwin_zmm_reg"][::std::mem::size_of::<__darwin_zmm_reg>() - 64usize];
+    ["Alignment of __darwin_zmm_reg"][::std::mem::align_of::<__darwin_zmm_reg>() - 1usize];
+    ["Offset of field: __darwin_zmm_reg::__zmm_reg"]
+        [::std::mem::offset_of!(__darwin_zmm_reg, __zmm_reg) - 0usize];
 };
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct __arm_pagein_state {
+pub struct __darwin_opmask_reg {
+    pub __opmask_reg: [::std::os::raw::c_char; 8usize],
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of __darwin_opmask_reg"][::std::mem::size_of::<__darwin_opmask_reg>() - 8usize];
+    ["Alignment of __darwin_opmask_reg"][::std::mem::align_of::<__darwin_opmask_reg>() - 1usize];
+    ["Offset of field: __darwin_opmask_reg::__opmask_reg"]
+        [::std::mem::offset_of!(__darwin_opmask_reg, __opmask_reg) - 0usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __darwin_i386_float_state {
+    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
+    pub __fpu_fcw: __darwin_fp_control,
+    pub __fpu_fsw: __darwin_fp_status,
+    pub __fpu_ftw: __uint8_t,
+    pub __fpu_rsrv1: __uint8_t,
+    pub __fpu_fop: __uint16_t,
+    pub __fpu_ip: __uint32_t,
+    pub __fpu_cs: __uint16_t,
+    pub __fpu_rsrv2: __uint16_t,
+    pub __fpu_dp: __uint32_t,
+    pub __fpu_ds: __uint16_t,
+    pub __fpu_rsrv3: __uint16_t,
+    pub __fpu_mxcsr: __uint32_t,
+    pub __fpu_mxcsrmask: __uint32_t,
+    pub __fpu_stmm0: __darwin_mmst_reg,
+    pub __fpu_stmm1: __darwin_mmst_reg,
+    pub __fpu_stmm2: __darwin_mmst_reg,
+    pub __fpu_stmm3: __darwin_mmst_reg,
+    pub __fpu_stmm4: __darwin_mmst_reg,
+    pub __fpu_stmm5: __darwin_mmst_reg,
+    pub __fpu_stmm6: __darwin_mmst_reg,
+    pub __fpu_stmm7: __darwin_mmst_reg,
+    pub __fpu_xmm0: __darwin_xmm_reg,
+    pub __fpu_xmm1: __darwin_xmm_reg,
+    pub __fpu_xmm2: __darwin_xmm_reg,
+    pub __fpu_xmm3: __darwin_xmm_reg,
+    pub __fpu_xmm4: __darwin_xmm_reg,
+    pub __fpu_xmm5: __darwin_xmm_reg,
+    pub __fpu_xmm6: __darwin_xmm_reg,
+    pub __fpu_xmm7: __darwin_xmm_reg,
+    pub __fpu_rsrv4: [::std::os::raw::c_char; 224usize],
+    pub __fpu_reserved1: ::std::os::raw::c_int,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of __darwin_i386_float_state"]
+        [::std::mem::size_of::<__darwin_i386_float_state>() - 524usize];
+    ["Alignment of __darwin_i386_float_state"]
+        [::std::mem::align_of::<__darwin_i386_float_state>() - 4usize];
+    ["Offset of field: __darwin_i386_float_state::__fpu_reserved"]
+        [::std::mem::offset_of!(__darwin_i386_float_state, __fpu_reserved) - 0usize];
+    ["Offset of field: __darwin_i386_float_state::__fpu_fcw"]
+        [::std::mem::offset_of!(__darwin_i386_float_state, __fpu_fcw) - 8usize];
+    ["Offset of field: __darwin_i386_float_state::__fpu_fsw"]
+        [::std::mem::offset_of!(__darwin_i386_float_state, __fpu_fsw) - 10usize];
+    ["Offset of field: __darwin_i386_float_state::__fpu_ftw"]
+        [::std::mem::offset_of!(__darwin_i386_float_state, __fpu_ftw) - 12usize];
+    ["Offset of field: __darwin_i386_float_state::__fpu_rsrv1"]
+        [::std::mem::offset_of!(__darwin_i386_float_state, __fpu_rsrv1) - 13usize];
+    ["Offset of field: __darwin_i386_float_state::__fpu_fop"]
+        [::std::mem::offset_of!(__darwin_i386_float_state, __fpu_fop) - 14usize];
+    ["Offset of field: __darwin_i386_float_state::__fpu_ip"]
+        [::std::mem::offset_of!(__darwin_i386_float_state, __fpu_ip) - 16usize];
+    ["Offset of field: __darwin_i386_float_state::__fpu_cs"]
+        [::std::mem::offset_of!(__darwin_i386_float_state, __fpu_cs) - 20usize];
+    ["Offset of field: __darwin_i386_float_state::__fpu_rsrv2"]
+        [::std::mem::offset_of!(__darwin_i386_float_state, __fpu_rsrv2) - 22usize];
+    ["Offset of field: __darwin_i386_float_state::__fpu_dp"]
+        [::std::mem::offset_of!(__darwin_i386_float_state, __fpu_dp) - 24usize];
+    ["Offset of field: __darwin_i386_float_state::__fpu_ds"]
+        [::std::mem::offset_of!(__darwin_i386_float_state, __fpu_ds) - 28usize];
+    ["Offset of field: __darwin_i386_float_state::__fpu_rsrv3"]
+        [::std::mem::offset_of!(__darwin_i386_float_state, __fpu_rsrv3) - 30usize];
+    ["Offset of field: __darwin_i386_float_state::__fpu_mxcsr"]
+        [::std::mem::offset_of!(__darwin_i386_float_state, __fpu_mxcsr) - 32usize];
+    ["Offset of field: __darwin_i386_float_state::__fpu_mxcsrmask"]
+        [::std::mem::offset_of!(__darwin_i386_float_state, __fpu_mxcsrmask) - 36usize];
+    ["Offset of field: __darwin_i386_float_state::__fpu_stmm0"]
+        [::std::mem::offset_of!(__darwin_i386_float_state, __fpu_stmm0) - 40usize];
+    ["Offset of field: __darwin_i386_float_state::__fpu_stmm1"]
+        [::std::mem::offset_of!(__darwin_i386_float_state, __fpu_stmm1) - 56usize];
+    ["Offset of field: __darwin_i386_float_state::__fpu_stmm2"]
+        [::std::mem::offset_of!(__darwin_i386_float_state, __fpu_stmm2) - 72usize];
+    ["Offset of field: __darwin_i386_float_state::__fpu_stmm3"]
+        [::std::mem::offset_of!(__darwin_i386_float_state, __fpu_stmm3) - 88usize];
+    ["Offset of field: __darwin_i386_float_state::__fpu_stmm4"]
+        [::std::mem::offset_of!(__darwin_i386_float_state, __fpu_stmm4) - 104usize];
+    ["Offset of field: __darwin_i386_float_state::__fpu_stmm5"]
+        [::std::mem::offset_of!(__darwin_i386_float_state, __fpu_stmm5) - 120usize];
+    ["Offset of field: __darwin_i386_float_state::__fpu_stmm6"]
+        [::std::mem::offset_of!(__darwin_i386_float_state, __fpu_stmm6) - 136usize];
+    ["Offset of field: __darwin_i386_float_state::__fpu_stmm7"]
+        [::std::mem::offset_of!(__darwin_i386_float_state, __fpu_stmm7) - 152usize];
+    ["Offset of field: __darwin_i386_float_state::__fpu_xmm0"]
+        [::std::mem::offset_of!(__darwin_i386_float_state, __fpu_xmm0) - 168usize];
+    ["Offset of field: __darwin_i386_float_state::__fpu_xmm1"]
+        [::std::mem::offset_of!(__darwin_i386_float_state, __fpu_xmm1) - 184usize];
+    ["Offset of field: __darwin_i386_float_state::__fpu_xmm2"]
+        [::std::mem::offset_of!(__darwin_i386_float_state, __fpu_xmm2) - 200usize];
+    ["Offset of field: __darwin_i386_float_state::__fpu_xmm3"]
+        [::std::mem::offset_of!(__darwin_i386_float_state, __fpu_xmm3) - 216usize];
+    ["Offset of field: __darwin_i386_float_state::__fpu_xmm4"]
+        [::std::mem::offset_of!(__darwin_i386_float_state, __fpu_xmm4) - 232usize];
+    ["Offset of field: __darwin_i386_float_state::__fpu_xmm5"]
+        [::std::mem::offset_of!(__darwin_i386_float_state, __fpu_xmm5) - 248usize];
+    ["Offset of field: __darwin_i386_float_state::__fpu_xmm6"]
+        [::std::mem::offset_of!(__darwin_i386_float_state, __fpu_xmm6) - 264usize];
+    ["Offset of field: __darwin_i386_float_state::__fpu_xmm7"]
+        [::std::mem::offset_of!(__darwin_i386_float_state, __fpu_xmm7) - 280usize];
+    ["Offset of field: __darwin_i386_float_state::__fpu_rsrv4"]
+        [::std::mem::offset_of!(__darwin_i386_float_state, __fpu_rsrv4) - 296usize];
+    ["Offset of field: __darwin_i386_float_state::__fpu_reserved1"]
+        [::std::mem::offset_of!(__darwin_i386_float_state, __fpu_reserved1) - 520usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __darwin_i386_avx_state {
+    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
+    pub __fpu_fcw: __darwin_fp_control,
+    pub __fpu_fsw: __darwin_fp_status,
+    pub __fpu_ftw: __uint8_t,
+    pub __fpu_rsrv1: __uint8_t,
+    pub __fpu_fop: __uint16_t,
+    pub __fpu_ip: __uint32_t,
+    pub __fpu_cs: __uint16_t,
+    pub __fpu_rsrv2: __uint16_t,
+    pub __fpu_dp: __uint32_t,
+    pub __fpu_ds: __uint16_t,
+    pub __fpu_rsrv3: __uint16_t,
+    pub __fpu_mxcsr: __uint32_t,
+    pub __fpu_mxcsrmask: __uint32_t,
+    pub __fpu_stmm0: __darwin_mmst_reg,
+    pub __fpu_stmm1: __darwin_mmst_reg,
+    pub __fpu_stmm2: __darwin_mmst_reg,
+    pub __fpu_stmm3: __darwin_mmst_reg,
+    pub __fpu_stmm4: __darwin_mmst_reg,
+    pub __fpu_stmm5: __darwin_mmst_reg,
+    pub __fpu_stmm6: __darwin_mmst_reg,
+    pub __fpu_stmm7: __darwin_mmst_reg,
+    pub __fpu_xmm0: __darwin_xmm_reg,
+    pub __fpu_xmm1: __darwin_xmm_reg,
+    pub __fpu_xmm2: __darwin_xmm_reg,
+    pub __fpu_xmm3: __darwin_xmm_reg,
+    pub __fpu_xmm4: __darwin_xmm_reg,
+    pub __fpu_xmm5: __darwin_xmm_reg,
+    pub __fpu_xmm6: __darwin_xmm_reg,
+    pub __fpu_xmm7: __darwin_xmm_reg,
+    pub __fpu_rsrv4: [::std::os::raw::c_char; 224usize],
+    pub __fpu_reserved1: ::std::os::raw::c_int,
+    pub __avx_reserved1: [::std::os::raw::c_char; 64usize],
+    pub __fpu_ymmh0: __darwin_xmm_reg,
+    pub __fpu_ymmh1: __darwin_xmm_reg,
+    pub __fpu_ymmh2: __darwin_xmm_reg,
+    pub __fpu_ymmh3: __darwin_xmm_reg,
+    pub __fpu_ymmh4: __darwin_xmm_reg,
+    pub __fpu_ymmh5: __darwin_xmm_reg,
+    pub __fpu_ymmh6: __darwin_xmm_reg,
+    pub __fpu_ymmh7: __darwin_xmm_reg,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of __darwin_i386_avx_state"]
+        [::std::mem::size_of::<__darwin_i386_avx_state>() - 716usize];
+    ["Alignment of __darwin_i386_avx_state"]
+        [::std::mem::align_of::<__darwin_i386_avx_state>() - 4usize];
+    ["Offset of field: __darwin_i386_avx_state::__fpu_reserved"]
+        [::std::mem::offset_of!(__darwin_i386_avx_state, __fpu_reserved) - 0usize];
+    ["Offset of field: __darwin_i386_avx_state::__fpu_fcw"]
+        [::std::mem::offset_of!(__darwin_i386_avx_state, __fpu_fcw) - 8usize];
+    ["Offset of field: __darwin_i386_avx_state::__fpu_fsw"]
+        [::std::mem::offset_of!(__darwin_i386_avx_state, __fpu_fsw) - 10usize];
+    ["Offset of field: __darwin_i386_avx_state::__fpu_ftw"]
+        [::std::mem::offset_of!(__darwin_i386_avx_state, __fpu_ftw) - 12usize];
+    ["Offset of field: __darwin_i386_avx_state::__fpu_rsrv1"]
+        [::std::mem::offset_of!(__darwin_i386_avx_state, __fpu_rsrv1) - 13usize];
+    ["Offset of field: __darwin_i386_avx_state::__fpu_fop"]
+        [::std::mem::offset_of!(__darwin_i386_avx_state, __fpu_fop) - 14usize];
+    ["Offset of field: __darwin_i386_avx_state::__fpu_ip"]
+        [::std::mem::offset_of!(__darwin_i386_avx_state, __fpu_ip) - 16usize];
+    ["Offset of field: __darwin_i386_avx_state::__fpu_cs"]
+        [::std::mem::offset_of!(__darwin_i386_avx_state, __fpu_cs) - 20usize];
+    ["Offset of field: __darwin_i386_avx_state::__fpu_rsrv2"]
+        [::std::mem::offset_of!(__darwin_i386_avx_state, __fpu_rsrv2) - 22usize];
+    ["Offset of field: __darwin_i386_avx_state::__fpu_dp"]
+        [::std::mem::offset_of!(__darwin_i386_avx_state, __fpu_dp) - 24usize];
+    ["Offset of field: __darwin_i386_avx_state::__fpu_ds"]
+        [::std::mem::offset_of!(__darwin_i386_avx_state, __fpu_ds) - 28usize];
+    ["Offset of field: __darwin_i386_avx_state::__fpu_rsrv3"]
+        [::std::mem::offset_of!(__darwin_i386_avx_state, __fpu_rsrv3) - 30usize];
+    ["Offset of field: __darwin_i386_avx_state::__fpu_mxcsr"]
+        [::std::mem::offset_of!(__darwin_i386_avx_state, __fpu_mxcsr) - 32usize];
+    ["Offset of field: __darwin_i386_avx_state::__fpu_mxcsrmask"]
+        [::std::mem::offset_of!(__darwin_i386_avx_state, __fpu_mxcsrmask) - 36usize];
+    ["Offset of field: __darwin_i386_avx_state::__fpu_stmm0"]
+        [::std::mem::offset_of!(__darwin_i386_avx_state, __fpu_stmm0) - 40usize];
+    ["Offset of field: __darwin_i386_avx_state::__fpu_stmm1"]
+        [::std::mem::offset_of!(__darwin_i386_avx_state, __fpu_stmm1) - 56usize];
+    ["Offset of field: __darwin_i386_avx_state::__fpu_stmm2"]
+        [::std::mem::offset_of!(__darwin_i386_avx_state, __fpu_stmm2) - 72usize];
+    ["Offset of field: __darwin_i386_avx_state::__fpu_stmm3"]
+        [::std::mem::offset_of!(__darwin_i386_avx_state, __fpu_stmm3) - 88usize];
+    ["Offset of field: __darwin_i386_avx_state::__fpu_stmm4"]
+        [::std::mem::offset_of!(__darwin_i386_avx_state, __fpu_stmm4) - 104usize];
+    ["Offset of field: __darwin_i386_avx_state::__fpu_stmm5"]
+        [::std::mem::offset_of!(__darwin_i386_avx_state, __fpu_stmm5) - 120usize];
+    ["Offset of field: __darwin_i386_avx_state::__fpu_stmm6"]
+        [::std::mem::offset_of!(__darwin_i386_avx_state, __fpu_stmm6) - 136usize];
+    ["Offset of field: __darwin_i386_avx_state::__fpu_stmm7"]
+        [::std::mem::offset_of!(__darwin_i386_avx_state, __fpu_stmm7) - 152usize];
+    ["Offset of field: __darwin_i386_avx_state::__fpu_xmm0"]
+        [::std::mem::offset_of!(__darwin_i386_avx_state, __fpu_xmm0) - 168usize];
+    ["Offset of field: __darwin_i386_avx_state::__fpu_xmm1"]
+        [::std::mem::offset_of!(__darwin_i386_avx_state, __fpu_xmm1) - 184usize];
+    ["Offset of field: __darwin_i386_avx_state::__fpu_xmm2"]
+        [::std::mem::offset_of!(__darwin_i386_avx_state, __fpu_xmm2) - 200usize];
+    ["Offset of field: __darwin_i386_avx_state::__fpu_xmm3"]
+        [::std::mem::offset_of!(__darwin_i386_avx_state, __fpu_xmm3) - 216usize];
+    ["Offset of field: __darwin_i386_avx_state::__fpu_xmm4"]
+        [::std::mem::offset_of!(__darwin_i386_avx_state, __fpu_xmm4) - 232usize];
+    ["Offset of field: __darwin_i386_avx_state::__fpu_xmm5"]
+        [::std::mem::offset_of!(__darwin_i386_avx_state, __fpu_xmm5) - 248usize];
+    ["Offset of field: __darwin_i386_avx_state::__fpu_xmm6"]
+        [::std::mem::offset_of!(__darwin_i386_avx_state, __fpu_xmm6) - 264usize];
+    ["Offset of field: __darwin_i386_avx_state::__fpu_xmm7"]
+        [::std::mem::offset_of!(__darwin_i386_avx_state, __fpu_xmm7) - 280usize];
+    ["Offset of field: __darwin_i386_avx_state::__fpu_rsrv4"]
+        [::std::mem::offset_of!(__darwin_i386_avx_state, __fpu_rsrv4) - 296usize];
+    ["Offset of field: __darwin_i386_avx_state::__fpu_reserved1"]
+        [::std::mem::offset_of!(__darwin_i386_avx_state, __fpu_reserved1) - 520usize];
+    ["Offset of field: __darwin_i386_avx_state::__avx_reserved1"]
+        [::std::mem::offset_of!(__darwin_i386_avx_state, __avx_reserved1) - 524usize];
+    ["Offset of field: __darwin_i386_avx_state::__fpu_ymmh0"]
+        [::std::mem::offset_of!(__darwin_i386_avx_state, __fpu_ymmh0) - 588usize];
+    ["Offset of field: __darwin_i386_avx_state::__fpu_ymmh1"]
+        [::std::mem::offset_of!(__darwin_i386_avx_state, __fpu_ymmh1) - 604usize];
+    ["Offset of field: __darwin_i386_avx_state::__fpu_ymmh2"]
+        [::std::mem::offset_of!(__darwin_i386_avx_state, __fpu_ymmh2) - 620usize];
+    ["Offset of field: __darwin_i386_avx_state::__fpu_ymmh3"]
+        [::std::mem::offset_of!(__darwin_i386_avx_state, __fpu_ymmh3) - 636usize];
+    ["Offset of field: __darwin_i386_avx_state::__fpu_ymmh4"]
+        [::std::mem::offset_of!(__darwin_i386_avx_state, __fpu_ymmh4) - 652usize];
+    ["Offset of field: __darwin_i386_avx_state::__fpu_ymmh5"]
+        [::std::mem::offset_of!(__darwin_i386_avx_state, __fpu_ymmh5) - 668usize];
+    ["Offset of field: __darwin_i386_avx_state::__fpu_ymmh6"]
+        [::std::mem::offset_of!(__darwin_i386_avx_state, __fpu_ymmh6) - 684usize];
+    ["Offset of field: __darwin_i386_avx_state::__fpu_ymmh7"]
+        [::std::mem::offset_of!(__darwin_i386_avx_state, __fpu_ymmh7) - 700usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __darwin_i386_avx512_state {
+    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
+    pub __fpu_fcw: __darwin_fp_control,
+    pub __fpu_fsw: __darwin_fp_status,
+    pub __fpu_ftw: __uint8_t,
+    pub __fpu_rsrv1: __uint8_t,
+    pub __fpu_fop: __uint16_t,
+    pub __fpu_ip: __uint32_t,
+    pub __fpu_cs: __uint16_t,
+    pub __fpu_rsrv2: __uint16_t,
+    pub __fpu_dp: __uint32_t,
+    pub __fpu_ds: __uint16_t,
+    pub __fpu_rsrv3: __uint16_t,
+    pub __fpu_mxcsr: __uint32_t,
+    pub __fpu_mxcsrmask: __uint32_t,
+    pub __fpu_stmm0: __darwin_mmst_reg,
+    pub __fpu_stmm1: __darwin_mmst_reg,
+    pub __fpu_stmm2: __darwin_mmst_reg,
+    pub __fpu_stmm3: __darwin_mmst_reg,
+    pub __fpu_stmm4: __darwin_mmst_reg,
+    pub __fpu_stmm5: __darwin_mmst_reg,
+    pub __fpu_stmm6: __darwin_mmst_reg,
+    pub __fpu_stmm7: __darwin_mmst_reg,
+    pub __fpu_xmm0: __darwin_xmm_reg,
+    pub __fpu_xmm1: __darwin_xmm_reg,
+    pub __fpu_xmm2: __darwin_xmm_reg,
+    pub __fpu_xmm3: __darwin_xmm_reg,
+    pub __fpu_xmm4: __darwin_xmm_reg,
+    pub __fpu_xmm5: __darwin_xmm_reg,
+    pub __fpu_xmm6: __darwin_xmm_reg,
+    pub __fpu_xmm7: __darwin_xmm_reg,
+    pub __fpu_rsrv4: [::std::os::raw::c_char; 224usize],
+    pub __fpu_reserved1: ::std::os::raw::c_int,
+    pub __avx_reserved1: [::std::os::raw::c_char; 64usize],
+    pub __fpu_ymmh0: __darwin_xmm_reg,
+    pub __fpu_ymmh1: __darwin_xmm_reg,
+    pub __fpu_ymmh2: __darwin_xmm_reg,
+    pub __fpu_ymmh3: __darwin_xmm_reg,
+    pub __fpu_ymmh4: __darwin_xmm_reg,
+    pub __fpu_ymmh5: __darwin_xmm_reg,
+    pub __fpu_ymmh6: __darwin_xmm_reg,
+    pub __fpu_ymmh7: __darwin_xmm_reg,
+    pub __fpu_k0: __darwin_opmask_reg,
+    pub __fpu_k1: __darwin_opmask_reg,
+    pub __fpu_k2: __darwin_opmask_reg,
+    pub __fpu_k3: __darwin_opmask_reg,
+    pub __fpu_k4: __darwin_opmask_reg,
+    pub __fpu_k5: __darwin_opmask_reg,
+    pub __fpu_k6: __darwin_opmask_reg,
+    pub __fpu_k7: __darwin_opmask_reg,
+    pub __fpu_zmmh0: __darwin_ymm_reg,
+    pub __fpu_zmmh1: __darwin_ymm_reg,
+    pub __fpu_zmmh2: __darwin_ymm_reg,
+    pub __fpu_zmmh3: __darwin_ymm_reg,
+    pub __fpu_zmmh4: __darwin_ymm_reg,
+    pub __fpu_zmmh5: __darwin_ymm_reg,
+    pub __fpu_zmmh6: __darwin_ymm_reg,
+    pub __fpu_zmmh7: __darwin_ymm_reg,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of __darwin_i386_avx512_state"]
+        [::std::mem::size_of::<__darwin_i386_avx512_state>() - 1036usize];
+    ["Alignment of __darwin_i386_avx512_state"]
+        [::std::mem::align_of::<__darwin_i386_avx512_state>() - 4usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_reserved"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_reserved) - 0usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_fcw"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_fcw) - 8usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_fsw"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_fsw) - 10usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_ftw"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_ftw) - 12usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_rsrv1"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_rsrv1) - 13usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_fop"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_fop) - 14usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_ip"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_ip) - 16usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_cs"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_cs) - 20usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_rsrv2"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_rsrv2) - 22usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_dp"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_dp) - 24usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_ds"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_ds) - 28usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_rsrv3"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_rsrv3) - 30usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_mxcsr"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_mxcsr) - 32usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_mxcsrmask"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_mxcsrmask) - 36usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_stmm0"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_stmm0) - 40usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_stmm1"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_stmm1) - 56usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_stmm2"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_stmm2) - 72usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_stmm3"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_stmm3) - 88usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_stmm4"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_stmm4) - 104usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_stmm5"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_stmm5) - 120usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_stmm6"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_stmm6) - 136usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_stmm7"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_stmm7) - 152usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_xmm0"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_xmm0) - 168usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_xmm1"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_xmm1) - 184usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_xmm2"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_xmm2) - 200usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_xmm3"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_xmm3) - 216usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_xmm4"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_xmm4) - 232usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_xmm5"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_xmm5) - 248usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_xmm6"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_xmm6) - 264usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_xmm7"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_xmm7) - 280usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_rsrv4"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_rsrv4) - 296usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_reserved1"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_reserved1) - 520usize];
+    ["Offset of field: __darwin_i386_avx512_state::__avx_reserved1"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __avx_reserved1) - 524usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_ymmh0"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_ymmh0) - 588usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_ymmh1"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_ymmh1) - 604usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_ymmh2"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_ymmh2) - 620usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_ymmh3"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_ymmh3) - 636usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_ymmh4"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_ymmh4) - 652usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_ymmh5"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_ymmh5) - 668usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_ymmh6"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_ymmh6) - 684usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_ymmh7"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_ymmh7) - 700usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_k0"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_k0) - 716usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_k1"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_k1) - 724usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_k2"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_k2) - 732usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_k3"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_k3) - 740usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_k4"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_k4) - 748usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_k5"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_k5) - 756usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_k6"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_k6) - 764usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_k7"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_k7) - 772usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_zmmh0"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_zmmh0) - 780usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_zmmh1"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_zmmh1) - 812usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_zmmh2"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_zmmh2) - 844usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_zmmh3"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_zmmh3) - 876usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_zmmh4"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_zmmh4) - 908usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_zmmh5"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_zmmh5) - 940usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_zmmh6"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_zmmh6) - 972usize];
+    ["Offset of field: __darwin_i386_avx512_state::__fpu_zmmh7"]
+        [::std::mem::offset_of!(__darwin_i386_avx512_state, __fpu_zmmh7) - 1004usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __darwin_i386_exception_state {
+    pub __trapno: __uint16_t,
+    pub __cpu: __uint16_t,
+    pub __err: __uint32_t,
+    pub __faultvaddr: __uint32_t,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of __darwin_i386_exception_state"]
+        [::std::mem::size_of::<__darwin_i386_exception_state>() - 12usize];
+    ["Alignment of __darwin_i386_exception_state"]
+        [::std::mem::align_of::<__darwin_i386_exception_state>() - 4usize];
+    ["Offset of field: __darwin_i386_exception_state::__trapno"]
+        [::std::mem::offset_of!(__darwin_i386_exception_state, __trapno) - 0usize];
+    ["Offset of field: __darwin_i386_exception_state::__cpu"]
+        [::std::mem::offset_of!(__darwin_i386_exception_state, __cpu) - 2usize];
+    ["Offset of field: __darwin_i386_exception_state::__err"]
+        [::std::mem::offset_of!(__darwin_i386_exception_state, __err) - 4usize];
+    ["Offset of field: __darwin_i386_exception_state::__faultvaddr"]
+        [::std::mem::offset_of!(__darwin_i386_exception_state, __faultvaddr) - 8usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __darwin_x86_debug_state32 {
+    pub __dr0: ::std::os::raw::c_uint,
+    pub __dr1: ::std::os::raw::c_uint,
+    pub __dr2: ::std::os::raw::c_uint,
+    pub __dr3: ::std::os::raw::c_uint,
+    pub __dr4: ::std::os::raw::c_uint,
+    pub __dr5: ::std::os::raw::c_uint,
+    pub __dr6: ::std::os::raw::c_uint,
+    pub __dr7: ::std::os::raw::c_uint,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of __darwin_x86_debug_state32"]
+        [::std::mem::size_of::<__darwin_x86_debug_state32>() - 32usize];
+    ["Alignment of __darwin_x86_debug_state32"]
+        [::std::mem::align_of::<__darwin_x86_debug_state32>() - 4usize];
+    ["Offset of field: __darwin_x86_debug_state32::__dr0"]
+        [::std::mem::offset_of!(__darwin_x86_debug_state32, __dr0) - 0usize];
+    ["Offset of field: __darwin_x86_debug_state32::__dr1"]
+        [::std::mem::offset_of!(__darwin_x86_debug_state32, __dr1) - 4usize];
+    ["Offset of field: __darwin_x86_debug_state32::__dr2"]
+        [::std::mem::offset_of!(__darwin_x86_debug_state32, __dr2) - 8usize];
+    ["Offset of field: __darwin_x86_debug_state32::__dr3"]
+        [::std::mem::offset_of!(__darwin_x86_debug_state32, __dr3) - 12usize];
+    ["Offset of field: __darwin_x86_debug_state32::__dr4"]
+        [::std::mem::offset_of!(__darwin_x86_debug_state32, __dr4) - 16usize];
+    ["Offset of field: __darwin_x86_debug_state32::__dr5"]
+        [::std::mem::offset_of!(__darwin_x86_debug_state32, __dr5) - 20usize];
+    ["Offset of field: __darwin_x86_debug_state32::__dr6"]
+        [::std::mem::offset_of!(__darwin_x86_debug_state32, __dr6) - 24usize];
+    ["Offset of field: __darwin_x86_debug_state32::__dr7"]
+        [::std::mem::offset_of!(__darwin_x86_debug_state32, __dr7) - 28usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __x86_instruction_state {
+    pub __insn_stream_valid_bytes: ::std::os::raw::c_int,
+    pub __insn_offset: ::std::os::raw::c_int,
+    pub __out_of_synch: ::std::os::raw::c_int,
+    pub __insn_bytes: [__uint8_t; 2380usize],
+    pub __insn_cacheline: [__uint8_t; 64usize],
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of __x86_instruction_state"]
+        [::std::mem::size_of::<__x86_instruction_state>() - 2456usize];
+    ["Alignment of __x86_instruction_state"]
+        [::std::mem::align_of::<__x86_instruction_state>() - 4usize];
+    ["Offset of field: __x86_instruction_state::__insn_stream_valid_bytes"]
+        [::std::mem::offset_of!(__x86_instruction_state, __insn_stream_valid_bytes) - 0usize];
+    ["Offset of field: __x86_instruction_state::__insn_offset"]
+        [::std::mem::offset_of!(__x86_instruction_state, __insn_offset) - 4usize];
+    ["Offset of field: __x86_instruction_state::__out_of_synch"]
+        [::std::mem::offset_of!(__x86_instruction_state, __out_of_synch) - 8usize];
+    ["Offset of field: __x86_instruction_state::__insn_bytes"]
+        [::std::mem::offset_of!(__x86_instruction_state, __insn_bytes) - 12usize];
+    ["Offset of field: __x86_instruction_state::__insn_cacheline"]
+        [::std::mem::offset_of!(__x86_instruction_state, __insn_cacheline) - 2392usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __last_branch_record {
+    pub __from_ip: __uint64_t,
+    pub __to_ip: __uint64_t,
+    pub _bitfield_align_1: [u16; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+    pub __bindgen_padding_0: u32,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of __last_branch_record"][::std::mem::size_of::<__last_branch_record>() - 24usize];
+    ["Alignment of __last_branch_record"][::std::mem::align_of::<__last_branch_record>() - 8usize];
+    ["Offset of field: __last_branch_record::__from_ip"]
+        [::std::mem::offset_of!(__last_branch_record, __from_ip) - 0usize];
+    ["Offset of field: __last_branch_record::__to_ip"]
+        [::std::mem::offset_of!(__last_branch_record, __to_ip) - 8usize];
+};
+impl __last_branch_record {
+    #[inline]
+    pub fn __mispredict(&self) -> __uint32_t {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+    }
+    #[inline]
+    pub fn set___mispredict(&mut self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn __mispredict_raw(this: *const Self) -> __uint32_t {
+        unsafe {
+            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 4usize]>>::raw_get(
+                ::std::ptr::addr_of!((*this)._bitfield_1),
+                0usize,
+                1u8,
+            ) as u32)
+        }
+    }
+    #[inline]
+    pub unsafe fn set___mispredict_raw(this: *mut Self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<[u8; 4usize]>>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                0usize,
+                1u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
+    pub fn __tsx_abort(&self) -> __uint32_t {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+    }
+    #[inline]
+    pub fn set___tsx_abort(&mut self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(1usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn __tsx_abort_raw(this: *const Self) -> __uint32_t {
+        unsafe {
+            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 4usize]>>::raw_get(
+                ::std::ptr::addr_of!((*this)._bitfield_1),
+                1usize,
+                1u8,
+            ) as u32)
+        }
+    }
+    #[inline]
+    pub unsafe fn set___tsx_abort_raw(this: *mut Self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<[u8; 4usize]>>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                1usize,
+                1u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
+    pub fn __in_tsx(&self) -> __uint32_t {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u32) }
+    }
+    #[inline]
+    pub fn set___in_tsx(&mut self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(2usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn __in_tsx_raw(this: *const Self) -> __uint32_t {
+        unsafe {
+            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 4usize]>>::raw_get(
+                ::std::ptr::addr_of!((*this)._bitfield_1),
+                2usize,
+                1u8,
+            ) as u32)
+        }
+    }
+    #[inline]
+    pub unsafe fn set___in_tsx_raw(this: *mut Self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<[u8; 4usize]>>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                2usize,
+                1u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
+    pub fn __cycle_count(&self) -> __uint32_t {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(3usize, 16u8) as u32) }
+    }
+    #[inline]
+    pub fn set___cycle_count(&mut self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(3usize, 16u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn __cycle_count_raw(this: *const Self) -> __uint32_t {
+        unsafe {
+            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 4usize]>>::raw_get(
+                ::std::ptr::addr_of!((*this)._bitfield_1),
+                3usize,
+                16u8,
+            ) as u32)
+        }
+    }
+    #[inline]
+    pub unsafe fn set___cycle_count_raw(this: *mut Self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<[u8; 4usize]>>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                3usize,
+                16u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
+    pub fn __reserved(&self) -> __uint32_t {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(19usize, 13u8) as u32) }
+    }
+    #[inline]
+    pub fn set___reserved(&mut self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(19usize, 13u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn __reserved_raw(this: *const Self) -> __uint32_t {
+        unsafe {
+            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 4usize]>>::raw_get(
+                ::std::ptr::addr_of!((*this)._bitfield_1),
+                19usize,
+                13u8,
+            ) as u32)
+        }
+    }
+    #[inline]
+    pub unsafe fn set___reserved_raw(this: *mut Self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<[u8; 4usize]>>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                19usize,
+                13u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
+    pub fn new_bitfield_1(
+        __mispredict: __uint32_t,
+        __tsx_abort: __uint32_t,
+        __in_tsx: __uint32_t,
+        __cycle_count: __uint32_t,
+        __reserved: __uint32_t,
+    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+        __bindgen_bitfield_unit.set(0usize, 1u8, {
+            let __mispredict: u32 = unsafe { ::std::mem::transmute(__mispredict) };
+            __mispredict as u64
+        });
+        __bindgen_bitfield_unit.set(1usize, 1u8, {
+            let __tsx_abort: u32 = unsafe { ::std::mem::transmute(__tsx_abort) };
+            __tsx_abort as u64
+        });
+        __bindgen_bitfield_unit.set(2usize, 1u8, {
+            let __in_tsx: u32 = unsafe { ::std::mem::transmute(__in_tsx) };
+            __in_tsx as u64
+        });
+        __bindgen_bitfield_unit.set(3usize, 16u8, {
+            let __cycle_count: u32 = unsafe { ::std::mem::transmute(__cycle_count) };
+            __cycle_count as u64
+        });
+        __bindgen_bitfield_unit.set(19usize, 13u8, {
+            let __reserved: u32 = unsafe { ::std::mem::transmute(__reserved) };
+            __reserved as u64
+        });
+        __bindgen_bitfield_unit
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __last_branch_state {
+    pub __lbr_count: ::std::os::raw::c_int,
+    pub _bitfield_align_1: [u32; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+    pub __lbrs: [__last_branch_record; 32usize],
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of __last_branch_state"][::std::mem::size_of::<__last_branch_state>() - 776usize];
+    ["Alignment of __last_branch_state"][::std::mem::align_of::<__last_branch_state>() - 8usize];
+    ["Offset of field: __last_branch_state::__lbr_count"]
+        [::std::mem::offset_of!(__last_branch_state, __lbr_count) - 0usize];
+    ["Offset of field: __last_branch_state::__lbrs"]
+        [::std::mem::offset_of!(__last_branch_state, __lbrs) - 8usize];
+};
+impl __last_branch_state {
+    #[inline]
+    pub fn __lbr_supported_tsx(&self) -> __uint32_t {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+    }
+    #[inline]
+    pub fn set___lbr_supported_tsx(&mut self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn __lbr_supported_tsx_raw(this: *const Self) -> __uint32_t {
+        unsafe {
+            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 4usize]>>::raw_get(
+                ::std::ptr::addr_of!((*this)._bitfield_1),
+                0usize,
+                1u8,
+            ) as u32)
+        }
+    }
+    #[inline]
+    pub unsafe fn set___lbr_supported_tsx_raw(this: *mut Self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<[u8; 4usize]>>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                0usize,
+                1u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
+    pub fn __lbr_supported_cycle_count(&self) -> __uint32_t {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+    }
+    #[inline]
+    pub fn set___lbr_supported_cycle_count(&mut self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(1usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn __lbr_supported_cycle_count_raw(this: *const Self) -> __uint32_t {
+        unsafe {
+            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 4usize]>>::raw_get(
+                ::std::ptr::addr_of!((*this)._bitfield_1),
+                1usize,
+                1u8,
+            ) as u32)
+        }
+    }
+    #[inline]
+    pub unsafe fn set___lbr_supported_cycle_count_raw(this: *mut Self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<[u8; 4usize]>>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                1usize,
+                1u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
+    pub fn __reserved(&self) -> __uint32_t {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(2usize, 30u8) as u32) }
+    }
+    #[inline]
+    pub fn set___reserved(&mut self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(2usize, 30u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn __reserved_raw(this: *const Self) -> __uint32_t {
+        unsafe {
+            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 4usize]>>::raw_get(
+                ::std::ptr::addr_of!((*this)._bitfield_1),
+                2usize,
+                30u8,
+            ) as u32)
+        }
+    }
+    #[inline]
+    pub unsafe fn set___reserved_raw(this: *mut Self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<[u8; 4usize]>>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                2usize,
+                30u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
+    pub fn new_bitfield_1(
+        __lbr_supported_tsx: __uint32_t,
+        __lbr_supported_cycle_count: __uint32_t,
+        __reserved: __uint32_t,
+    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+        __bindgen_bitfield_unit.set(0usize, 1u8, {
+            let __lbr_supported_tsx: u32 = unsafe { ::std::mem::transmute(__lbr_supported_tsx) };
+            __lbr_supported_tsx as u64
+        });
+        __bindgen_bitfield_unit.set(1usize, 1u8, {
+            let __lbr_supported_cycle_count: u32 =
+                unsafe { ::std::mem::transmute(__lbr_supported_cycle_count) };
+            __lbr_supported_cycle_count as u64
+        });
+        __bindgen_bitfield_unit.set(2usize, 30u8, {
+            let __reserved: u32 = unsafe { ::std::mem::transmute(__reserved) };
+            __reserved as u64
+        });
+        __bindgen_bitfield_unit
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __x86_pagein_state {
     pub __pagein_error: ::std::os::raw::c_int,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of __arm_pagein_state"][::std::mem::size_of::<__arm_pagein_state>() - 4usize];
-    ["Alignment of __arm_pagein_state"][::std::mem::align_of::<__arm_pagein_state>() - 4usize];
-    ["Offset of field: __arm_pagein_state::__pagein_error"]
-        [::std::mem::offset_of!(__arm_pagein_state, __pagein_error) - 0usize];
+    ["Size of __x86_pagein_state"][::std::mem::size_of::<__x86_pagein_state>() - 4usize];
+    ["Alignment of __x86_pagein_state"][::std::mem::align_of::<__x86_pagein_state>() - 4usize];
+    ["Offset of field: __x86_pagein_state::__pagein_error"]
+        [::std::mem::offset_of!(__x86_pagein_state, __pagein_error) - 0usize];
 };
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct __arm_legacy_debug_state {
-    pub __bvr: [__uint32_t; 16usize],
-    pub __bcr: [__uint32_t; 16usize],
-    pub __wvr: [__uint32_t; 16usize],
-    pub __wcr: [__uint32_t; 16usize],
+pub struct __darwin_x86_thread_state64 {
+    pub __rax: __uint64_t,
+    pub __rbx: __uint64_t,
+    pub __rcx: __uint64_t,
+    pub __rdx: __uint64_t,
+    pub __rdi: __uint64_t,
+    pub __rsi: __uint64_t,
+    pub __rbp: __uint64_t,
+    pub __rsp: __uint64_t,
+    pub __r8: __uint64_t,
+    pub __r9: __uint64_t,
+    pub __r10: __uint64_t,
+    pub __r11: __uint64_t,
+    pub __r12: __uint64_t,
+    pub __r13: __uint64_t,
+    pub __r14: __uint64_t,
+    pub __r15: __uint64_t,
+    pub __rip: __uint64_t,
+    pub __rflags: __uint64_t,
+    pub __cs: __uint64_t,
+    pub __fs: __uint64_t,
+    pub __gs: __uint64_t,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of __arm_legacy_debug_state"]
-        [::std::mem::size_of::<__arm_legacy_debug_state>() - 256usize];
-    ["Alignment of __arm_legacy_debug_state"]
-        [::std::mem::align_of::<__arm_legacy_debug_state>() - 4usize];
-    ["Offset of field: __arm_legacy_debug_state::__bvr"]
-        [::std::mem::offset_of!(__arm_legacy_debug_state, __bvr) - 0usize];
-    ["Offset of field: __arm_legacy_debug_state::__bcr"]
-        [::std::mem::offset_of!(__arm_legacy_debug_state, __bcr) - 64usize];
-    ["Offset of field: __arm_legacy_debug_state::__wvr"]
-        [::std::mem::offset_of!(__arm_legacy_debug_state, __wvr) - 128usize];
-    ["Offset of field: __arm_legacy_debug_state::__wcr"]
-        [::std::mem::offset_of!(__arm_legacy_debug_state, __wcr) - 192usize];
+    ["Size of __darwin_x86_thread_state64"]
+        [::std::mem::size_of::<__darwin_x86_thread_state64>() - 168usize];
+    ["Alignment of __darwin_x86_thread_state64"]
+        [::std::mem::align_of::<__darwin_x86_thread_state64>() - 8usize];
+    ["Offset of field: __darwin_x86_thread_state64::__rax"]
+        [::std::mem::offset_of!(__darwin_x86_thread_state64, __rax) - 0usize];
+    ["Offset of field: __darwin_x86_thread_state64::__rbx"]
+        [::std::mem::offset_of!(__darwin_x86_thread_state64, __rbx) - 8usize];
+    ["Offset of field: __darwin_x86_thread_state64::__rcx"]
+        [::std::mem::offset_of!(__darwin_x86_thread_state64, __rcx) - 16usize];
+    ["Offset of field: __darwin_x86_thread_state64::__rdx"]
+        [::std::mem::offset_of!(__darwin_x86_thread_state64, __rdx) - 24usize];
+    ["Offset of field: __darwin_x86_thread_state64::__rdi"]
+        [::std::mem::offset_of!(__darwin_x86_thread_state64, __rdi) - 32usize];
+    ["Offset of field: __darwin_x86_thread_state64::__rsi"]
+        [::std::mem::offset_of!(__darwin_x86_thread_state64, __rsi) - 40usize];
+    ["Offset of field: __darwin_x86_thread_state64::__rbp"]
+        [::std::mem::offset_of!(__darwin_x86_thread_state64, __rbp) - 48usize];
+    ["Offset of field: __darwin_x86_thread_state64::__rsp"]
+        [::std::mem::offset_of!(__darwin_x86_thread_state64, __rsp) - 56usize];
+    ["Offset of field: __darwin_x86_thread_state64::__r8"]
+        [::std::mem::offset_of!(__darwin_x86_thread_state64, __r8) - 64usize];
+    ["Offset of field: __darwin_x86_thread_state64::__r9"]
+        [::std::mem::offset_of!(__darwin_x86_thread_state64, __r9) - 72usize];
+    ["Offset of field: __darwin_x86_thread_state64::__r10"]
+        [::std::mem::offset_of!(__darwin_x86_thread_state64, __r10) - 80usize];
+    ["Offset of field: __darwin_x86_thread_state64::__r11"]
+        [::std::mem::offset_of!(__darwin_x86_thread_state64, __r11) - 88usize];
+    ["Offset of field: __darwin_x86_thread_state64::__r12"]
+        [::std::mem::offset_of!(__darwin_x86_thread_state64, __r12) - 96usize];
+    ["Offset of field: __darwin_x86_thread_state64::__r13"]
+        [::std::mem::offset_of!(__darwin_x86_thread_state64, __r13) - 104usize];
+    ["Offset of field: __darwin_x86_thread_state64::__r14"]
+        [::std::mem::offset_of!(__darwin_x86_thread_state64, __r14) - 112usize];
+    ["Offset of field: __darwin_x86_thread_state64::__r15"]
+        [::std::mem::offset_of!(__darwin_x86_thread_state64, __r15) - 120usize];
+    ["Offset of field: __darwin_x86_thread_state64::__rip"]
+        [::std::mem::offset_of!(__darwin_x86_thread_state64, __rip) - 128usize];
+    ["Offset of field: __darwin_x86_thread_state64::__rflags"]
+        [::std::mem::offset_of!(__darwin_x86_thread_state64, __rflags) - 136usize];
+    ["Offset of field: __darwin_x86_thread_state64::__cs"]
+        [::std::mem::offset_of!(__darwin_x86_thread_state64, __cs) - 144usize];
+    ["Offset of field: __darwin_x86_thread_state64::__fs"]
+        [::std::mem::offset_of!(__darwin_x86_thread_state64, __fs) - 152usize];
+    ["Offset of field: __darwin_x86_thread_state64::__gs"]
+        [::std::mem::offset_of!(__darwin_x86_thread_state64, __gs) - 160usize];
 };
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct __darwin_arm_debug_state32 {
-    pub __bvr: [__uint32_t; 16usize],
-    pub __bcr: [__uint32_t; 16usize],
-    pub __wvr: [__uint32_t; 16usize],
-    pub __wcr: [__uint32_t; 16usize],
-    pub __mdscr_el1: __uint64_t,
+pub struct __darwin_x86_thread_full_state64 {
+    pub __ss64: __darwin_x86_thread_state64,
+    pub __ds: __uint64_t,
+    pub __es: __uint64_t,
+    pub __ss: __uint64_t,
+    pub __gsbase: __uint64_t,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of __darwin_arm_debug_state32"]
-        [::std::mem::size_of::<__darwin_arm_debug_state32>() - 264usize];
-    ["Alignment of __darwin_arm_debug_state32"]
-        [::std::mem::align_of::<__darwin_arm_debug_state32>() - 8usize];
-    ["Offset of field: __darwin_arm_debug_state32::__bvr"]
-        [::std::mem::offset_of!(__darwin_arm_debug_state32, __bvr) - 0usize];
-    ["Offset of field: __darwin_arm_debug_state32::__bcr"]
-        [::std::mem::offset_of!(__darwin_arm_debug_state32, __bcr) - 64usize];
-    ["Offset of field: __darwin_arm_debug_state32::__wvr"]
-        [::std::mem::offset_of!(__darwin_arm_debug_state32, __wvr) - 128usize];
-    ["Offset of field: __darwin_arm_debug_state32::__wcr"]
-        [::std::mem::offset_of!(__darwin_arm_debug_state32, __wcr) - 192usize];
-    ["Offset of field: __darwin_arm_debug_state32::__mdscr_el1"]
-        [::std::mem::offset_of!(__darwin_arm_debug_state32, __mdscr_el1) - 256usize];
+    ["Size of __darwin_x86_thread_full_state64"]
+        [::std::mem::size_of::<__darwin_x86_thread_full_state64>() - 200usize];
+    ["Alignment of __darwin_x86_thread_full_state64"]
+        [::std::mem::align_of::<__darwin_x86_thread_full_state64>() - 8usize];
+    ["Offset of field: __darwin_x86_thread_full_state64::__ss64"]
+        [::std::mem::offset_of!(__darwin_x86_thread_full_state64, __ss64) - 0usize];
+    ["Offset of field: __darwin_x86_thread_full_state64::__ds"]
+        [::std::mem::offset_of!(__darwin_x86_thread_full_state64, __ds) - 168usize];
+    ["Offset of field: __darwin_x86_thread_full_state64::__es"]
+        [::std::mem::offset_of!(__darwin_x86_thread_full_state64, __es) - 176usize];
+    ["Offset of field: __darwin_x86_thread_full_state64::__ss"]
+        [::std::mem::offset_of!(__darwin_x86_thread_full_state64, __ss) - 184usize];
+    ["Offset of field: __darwin_x86_thread_full_state64::__gsbase"]
+        [::std::mem::offset_of!(__darwin_x86_thread_full_state64, __gsbase) - 192usize];
 };
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct __darwin_arm_debug_state64 {
-    pub __bvr: [__uint64_t; 16usize],
-    pub __bcr: [__uint64_t; 16usize],
-    pub __wvr: [__uint64_t; 16usize],
-    pub __wcr: [__uint64_t; 16usize],
-    pub __mdscr_el1: __uint64_t,
+pub struct __darwin_x86_float_state64 {
+    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
+    pub __fpu_fcw: __darwin_fp_control,
+    pub __fpu_fsw: __darwin_fp_status,
+    pub __fpu_ftw: __uint8_t,
+    pub __fpu_rsrv1: __uint8_t,
+    pub __fpu_fop: __uint16_t,
+    pub __fpu_ip: __uint32_t,
+    pub __fpu_cs: __uint16_t,
+    pub __fpu_rsrv2: __uint16_t,
+    pub __fpu_dp: __uint32_t,
+    pub __fpu_ds: __uint16_t,
+    pub __fpu_rsrv3: __uint16_t,
+    pub __fpu_mxcsr: __uint32_t,
+    pub __fpu_mxcsrmask: __uint32_t,
+    pub __fpu_stmm0: __darwin_mmst_reg,
+    pub __fpu_stmm1: __darwin_mmst_reg,
+    pub __fpu_stmm2: __darwin_mmst_reg,
+    pub __fpu_stmm3: __darwin_mmst_reg,
+    pub __fpu_stmm4: __darwin_mmst_reg,
+    pub __fpu_stmm5: __darwin_mmst_reg,
+    pub __fpu_stmm6: __darwin_mmst_reg,
+    pub __fpu_stmm7: __darwin_mmst_reg,
+    pub __fpu_xmm0: __darwin_xmm_reg,
+    pub __fpu_xmm1: __darwin_xmm_reg,
+    pub __fpu_xmm2: __darwin_xmm_reg,
+    pub __fpu_xmm3: __darwin_xmm_reg,
+    pub __fpu_xmm4: __darwin_xmm_reg,
+    pub __fpu_xmm5: __darwin_xmm_reg,
+    pub __fpu_xmm6: __darwin_xmm_reg,
+    pub __fpu_xmm7: __darwin_xmm_reg,
+    pub __fpu_xmm8: __darwin_xmm_reg,
+    pub __fpu_xmm9: __darwin_xmm_reg,
+    pub __fpu_xmm10: __darwin_xmm_reg,
+    pub __fpu_xmm11: __darwin_xmm_reg,
+    pub __fpu_xmm12: __darwin_xmm_reg,
+    pub __fpu_xmm13: __darwin_xmm_reg,
+    pub __fpu_xmm14: __darwin_xmm_reg,
+    pub __fpu_xmm15: __darwin_xmm_reg,
+    pub __fpu_rsrv4: [::std::os::raw::c_char; 96usize],
+    pub __fpu_reserved1: ::std::os::raw::c_int,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of __darwin_arm_debug_state64"]
-        [::std::mem::size_of::<__darwin_arm_debug_state64>() - 520usize];
-    ["Alignment of __darwin_arm_debug_state64"]
-        [::std::mem::align_of::<__darwin_arm_debug_state64>() - 8usize];
-    ["Offset of field: __darwin_arm_debug_state64::__bvr"]
-        [::std::mem::offset_of!(__darwin_arm_debug_state64, __bvr) - 0usize];
-    ["Offset of field: __darwin_arm_debug_state64::__bcr"]
-        [::std::mem::offset_of!(__darwin_arm_debug_state64, __bcr) - 128usize];
-    ["Offset of field: __darwin_arm_debug_state64::__wvr"]
-        [::std::mem::offset_of!(__darwin_arm_debug_state64, __wvr) - 256usize];
-    ["Offset of field: __darwin_arm_debug_state64::__wcr"]
-        [::std::mem::offset_of!(__darwin_arm_debug_state64, __wcr) - 384usize];
-    ["Offset of field: __darwin_arm_debug_state64::__mdscr_el1"]
-        [::std::mem::offset_of!(__darwin_arm_debug_state64, __mdscr_el1) - 512usize];
+    ["Size of __darwin_x86_float_state64"]
+        [::std::mem::size_of::<__darwin_x86_float_state64>() - 524usize];
+    ["Alignment of __darwin_x86_float_state64"]
+        [::std::mem::align_of::<__darwin_x86_float_state64>() - 4usize];
+    ["Offset of field: __darwin_x86_float_state64::__fpu_reserved"]
+        [::std::mem::offset_of!(__darwin_x86_float_state64, __fpu_reserved) - 0usize];
+    ["Offset of field: __darwin_x86_float_state64::__fpu_fcw"]
+        [::std::mem::offset_of!(__darwin_x86_float_state64, __fpu_fcw) - 8usize];
+    ["Offset of field: __darwin_x86_float_state64::__fpu_fsw"]
+        [::std::mem::offset_of!(__darwin_x86_float_state64, __fpu_fsw) - 10usize];
+    ["Offset of field: __darwin_x86_float_state64::__fpu_ftw"]
+        [::std::mem::offset_of!(__darwin_x86_float_state64, __fpu_ftw) - 12usize];
+    ["Offset of field: __darwin_x86_float_state64::__fpu_rsrv1"]
+        [::std::mem::offset_of!(__darwin_x86_float_state64, __fpu_rsrv1) - 13usize];
+    ["Offset of field: __darwin_x86_float_state64::__fpu_fop"]
+        [::std::mem::offset_of!(__darwin_x86_float_state64, __fpu_fop) - 14usize];
+    ["Offset of field: __darwin_x86_float_state64::__fpu_ip"]
+        [::std::mem::offset_of!(__darwin_x86_float_state64, __fpu_ip) - 16usize];
+    ["Offset of field: __darwin_x86_float_state64::__fpu_cs"]
+        [::std::mem::offset_of!(__darwin_x86_float_state64, __fpu_cs) - 20usize];
+    ["Offset of field: __darwin_x86_float_state64::__fpu_rsrv2"]
+        [::std::mem::offset_of!(__darwin_x86_float_state64, __fpu_rsrv2) - 22usize];
+    ["Offset of field: __darwin_x86_float_state64::__fpu_dp"]
+        [::std::mem::offset_of!(__darwin_x86_float_state64, __fpu_dp) - 24usize];
+    ["Offset of field: __darwin_x86_float_state64::__fpu_ds"]
+        [::std::mem::offset_of!(__darwin_x86_float_state64, __fpu_ds) - 28usize];
+    ["Offset of field: __darwin_x86_float_state64::__fpu_rsrv3"]
+        [::std::mem::offset_of!(__darwin_x86_float_state64, __fpu_rsrv3) - 30usize];
+    ["Offset of field: __darwin_x86_float_state64::__fpu_mxcsr"]
+        [::std::mem::offset_of!(__darwin_x86_float_state64, __fpu_mxcsr) - 32usize];
+    ["Offset of field: __darwin_x86_float_state64::__fpu_mxcsrmask"]
+        [::std::mem::offset_of!(__darwin_x86_float_state64, __fpu_mxcsrmask) - 36usize];
+    ["Offset of field: __darwin_x86_float_state64::__fpu_stmm0"]
+        [::std::mem::offset_of!(__darwin_x86_float_state64, __fpu_stmm0) - 40usize];
+    ["Offset of field: __darwin_x86_float_state64::__fpu_stmm1"]
+        [::std::mem::offset_of!(__darwin_x86_float_state64, __fpu_stmm1) - 56usize];
+    ["Offset of field: __darwin_x86_float_state64::__fpu_stmm2"]
+        [::std::mem::offset_of!(__darwin_x86_float_state64, __fpu_stmm2) - 72usize];
+    ["Offset of field: __darwin_x86_float_state64::__fpu_stmm3"]
+        [::std::mem::offset_of!(__darwin_x86_float_state64, __fpu_stmm3) - 88usize];
+    ["Offset of field: __darwin_x86_float_state64::__fpu_stmm4"]
+        [::std::mem::offset_of!(__darwin_x86_float_state64, __fpu_stmm4) - 104usize];
+    ["Offset of field: __darwin_x86_float_state64::__fpu_stmm5"]
+        [::std::mem::offset_of!(__darwin_x86_float_state64, __fpu_stmm5) - 120usize];
+    ["Offset of field: __darwin_x86_float_state64::__fpu_stmm6"]
+        [::std::mem::offset_of!(__darwin_x86_float_state64, __fpu_stmm6) - 136usize];
+    ["Offset of field: __darwin_x86_float_state64::__fpu_stmm7"]
+        [::std::mem::offset_of!(__darwin_x86_float_state64, __fpu_stmm7) - 152usize];
+    ["Offset of field: __darwin_x86_float_state64::__fpu_xmm0"]
+        [::std::mem::offset_of!(__darwin_x86_float_state64, __fpu_xmm0) - 168usize];
+    ["Offset of field: __darwin_x86_float_state64::__fpu_xmm1"]
+        [::std::mem::offset_of!(__darwin_x86_float_state64, __fpu_xmm1) - 184usize];
+    ["Offset of field: __darwin_x86_float_state64::__fpu_xmm2"]
+        [::std::mem::offset_of!(__darwin_x86_float_state64, __fpu_xmm2) - 200usize];
+    ["Offset of field: __darwin_x86_float_state64::__fpu_xmm3"]
+        [::std::mem::offset_of!(__darwin_x86_float_state64, __fpu_xmm3) - 216usize];
+    ["Offset of field: __darwin_x86_float_state64::__fpu_xmm4"]
+        [::std::mem::offset_of!(__darwin_x86_float_state64, __fpu_xmm4) - 232usize];
+    ["Offset of field: __darwin_x86_float_state64::__fpu_xmm5"]
+        [::std::mem::offset_of!(__darwin_x86_float_state64, __fpu_xmm5) - 248usize];
+    ["Offset of field: __darwin_x86_float_state64::__fpu_xmm6"]
+        [::std::mem::offset_of!(__darwin_x86_float_state64, __fpu_xmm6) - 264usize];
+    ["Offset of field: __darwin_x86_float_state64::__fpu_xmm7"]
+        [::std::mem::offset_of!(__darwin_x86_float_state64, __fpu_xmm7) - 280usize];
+    ["Offset of field: __darwin_x86_float_state64::__fpu_xmm8"]
+        [::std::mem::offset_of!(__darwin_x86_float_state64, __fpu_xmm8) - 296usize];
+    ["Offset of field: __darwin_x86_float_state64::__fpu_xmm9"]
+        [::std::mem::offset_of!(__darwin_x86_float_state64, __fpu_xmm9) - 312usize];
+    ["Offset of field: __darwin_x86_float_state64::__fpu_xmm10"]
+        [::std::mem::offset_of!(__darwin_x86_float_state64, __fpu_xmm10) - 328usize];
+    ["Offset of field: __darwin_x86_float_state64::__fpu_xmm11"]
+        [::std::mem::offset_of!(__darwin_x86_float_state64, __fpu_xmm11) - 344usize];
+    ["Offset of field: __darwin_x86_float_state64::__fpu_xmm12"]
+        [::std::mem::offset_of!(__darwin_x86_float_state64, __fpu_xmm12) - 360usize];
+    ["Offset of field: __darwin_x86_float_state64::__fpu_xmm13"]
+        [::std::mem::offset_of!(__darwin_x86_float_state64, __fpu_xmm13) - 376usize];
+    ["Offset of field: __darwin_x86_float_state64::__fpu_xmm14"]
+        [::std::mem::offset_of!(__darwin_x86_float_state64, __fpu_xmm14) - 392usize];
+    ["Offset of field: __darwin_x86_float_state64::__fpu_xmm15"]
+        [::std::mem::offset_of!(__darwin_x86_float_state64, __fpu_xmm15) - 408usize];
+    ["Offset of field: __darwin_x86_float_state64::__fpu_rsrv4"]
+        [::std::mem::offset_of!(__darwin_x86_float_state64, __fpu_rsrv4) - 424usize];
+    ["Offset of field: __darwin_x86_float_state64::__fpu_reserved1"]
+        [::std::mem::offset_of!(__darwin_x86_float_state64, __fpu_reserved1) - 520usize];
 };
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct __darwin_arm_cpmu_state64 {
+pub struct __darwin_x86_avx_state64 {
+    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
+    pub __fpu_fcw: __darwin_fp_control,
+    pub __fpu_fsw: __darwin_fp_status,
+    pub __fpu_ftw: __uint8_t,
+    pub __fpu_rsrv1: __uint8_t,
+    pub __fpu_fop: __uint16_t,
+    pub __fpu_ip: __uint32_t,
+    pub __fpu_cs: __uint16_t,
+    pub __fpu_rsrv2: __uint16_t,
+    pub __fpu_dp: __uint32_t,
+    pub __fpu_ds: __uint16_t,
+    pub __fpu_rsrv3: __uint16_t,
+    pub __fpu_mxcsr: __uint32_t,
+    pub __fpu_mxcsrmask: __uint32_t,
+    pub __fpu_stmm0: __darwin_mmst_reg,
+    pub __fpu_stmm1: __darwin_mmst_reg,
+    pub __fpu_stmm2: __darwin_mmst_reg,
+    pub __fpu_stmm3: __darwin_mmst_reg,
+    pub __fpu_stmm4: __darwin_mmst_reg,
+    pub __fpu_stmm5: __darwin_mmst_reg,
+    pub __fpu_stmm6: __darwin_mmst_reg,
+    pub __fpu_stmm7: __darwin_mmst_reg,
+    pub __fpu_xmm0: __darwin_xmm_reg,
+    pub __fpu_xmm1: __darwin_xmm_reg,
+    pub __fpu_xmm2: __darwin_xmm_reg,
+    pub __fpu_xmm3: __darwin_xmm_reg,
+    pub __fpu_xmm4: __darwin_xmm_reg,
+    pub __fpu_xmm5: __darwin_xmm_reg,
+    pub __fpu_xmm6: __darwin_xmm_reg,
+    pub __fpu_xmm7: __darwin_xmm_reg,
+    pub __fpu_xmm8: __darwin_xmm_reg,
+    pub __fpu_xmm9: __darwin_xmm_reg,
+    pub __fpu_xmm10: __darwin_xmm_reg,
+    pub __fpu_xmm11: __darwin_xmm_reg,
+    pub __fpu_xmm12: __darwin_xmm_reg,
+    pub __fpu_xmm13: __darwin_xmm_reg,
+    pub __fpu_xmm14: __darwin_xmm_reg,
+    pub __fpu_xmm15: __darwin_xmm_reg,
+    pub __fpu_rsrv4: [::std::os::raw::c_char; 96usize],
+    pub __fpu_reserved1: ::std::os::raw::c_int,
+    pub __avx_reserved1: [::std::os::raw::c_char; 64usize],
+    pub __fpu_ymmh0: __darwin_xmm_reg,
+    pub __fpu_ymmh1: __darwin_xmm_reg,
+    pub __fpu_ymmh2: __darwin_xmm_reg,
+    pub __fpu_ymmh3: __darwin_xmm_reg,
+    pub __fpu_ymmh4: __darwin_xmm_reg,
+    pub __fpu_ymmh5: __darwin_xmm_reg,
+    pub __fpu_ymmh6: __darwin_xmm_reg,
+    pub __fpu_ymmh7: __darwin_xmm_reg,
+    pub __fpu_ymmh8: __darwin_xmm_reg,
+    pub __fpu_ymmh9: __darwin_xmm_reg,
+    pub __fpu_ymmh10: __darwin_xmm_reg,
+    pub __fpu_ymmh11: __darwin_xmm_reg,
+    pub __fpu_ymmh12: __darwin_xmm_reg,
+    pub __fpu_ymmh13: __darwin_xmm_reg,
+    pub __fpu_ymmh14: __darwin_xmm_reg,
+    pub __fpu_ymmh15: __darwin_xmm_reg,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of __darwin_x86_avx_state64"]
+        [::std::mem::size_of::<__darwin_x86_avx_state64>() - 844usize];
+    ["Alignment of __darwin_x86_avx_state64"]
+        [::std::mem::align_of::<__darwin_x86_avx_state64>() - 4usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_reserved"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_reserved) - 0usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_fcw"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_fcw) - 8usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_fsw"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_fsw) - 10usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_ftw"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_ftw) - 12usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_rsrv1"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_rsrv1) - 13usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_fop"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_fop) - 14usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_ip"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_ip) - 16usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_cs"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_cs) - 20usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_rsrv2"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_rsrv2) - 22usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_dp"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_dp) - 24usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_ds"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_ds) - 28usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_rsrv3"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_rsrv3) - 30usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_mxcsr"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_mxcsr) - 32usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_mxcsrmask"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_mxcsrmask) - 36usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_stmm0"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_stmm0) - 40usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_stmm1"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_stmm1) - 56usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_stmm2"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_stmm2) - 72usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_stmm3"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_stmm3) - 88usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_stmm4"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_stmm4) - 104usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_stmm5"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_stmm5) - 120usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_stmm6"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_stmm6) - 136usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_stmm7"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_stmm7) - 152usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_xmm0"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_xmm0) - 168usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_xmm1"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_xmm1) - 184usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_xmm2"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_xmm2) - 200usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_xmm3"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_xmm3) - 216usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_xmm4"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_xmm4) - 232usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_xmm5"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_xmm5) - 248usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_xmm6"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_xmm6) - 264usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_xmm7"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_xmm7) - 280usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_xmm8"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_xmm8) - 296usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_xmm9"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_xmm9) - 312usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_xmm10"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_xmm10) - 328usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_xmm11"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_xmm11) - 344usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_xmm12"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_xmm12) - 360usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_xmm13"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_xmm13) - 376usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_xmm14"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_xmm14) - 392usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_xmm15"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_xmm15) - 408usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_rsrv4"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_rsrv4) - 424usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_reserved1"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_reserved1) - 520usize];
+    ["Offset of field: __darwin_x86_avx_state64::__avx_reserved1"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __avx_reserved1) - 524usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_ymmh0"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_ymmh0) - 588usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_ymmh1"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_ymmh1) - 604usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_ymmh2"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_ymmh2) - 620usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_ymmh3"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_ymmh3) - 636usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_ymmh4"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_ymmh4) - 652usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_ymmh5"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_ymmh5) - 668usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_ymmh6"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_ymmh6) - 684usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_ymmh7"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_ymmh7) - 700usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_ymmh8"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_ymmh8) - 716usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_ymmh9"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_ymmh9) - 732usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_ymmh10"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_ymmh10) - 748usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_ymmh11"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_ymmh11) - 764usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_ymmh12"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_ymmh12) - 780usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_ymmh13"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_ymmh13) - 796usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_ymmh14"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_ymmh14) - 812usize];
+    ["Offset of field: __darwin_x86_avx_state64::__fpu_ymmh15"]
+        [::std::mem::offset_of!(__darwin_x86_avx_state64, __fpu_ymmh15) - 828usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __darwin_x86_avx512_state64 {
+    pub __fpu_reserved: [::std::os::raw::c_int; 2usize],
+    pub __fpu_fcw: __darwin_fp_control,
+    pub __fpu_fsw: __darwin_fp_status,
+    pub __fpu_ftw: __uint8_t,
+    pub __fpu_rsrv1: __uint8_t,
+    pub __fpu_fop: __uint16_t,
+    pub __fpu_ip: __uint32_t,
+    pub __fpu_cs: __uint16_t,
+    pub __fpu_rsrv2: __uint16_t,
+    pub __fpu_dp: __uint32_t,
+    pub __fpu_ds: __uint16_t,
+    pub __fpu_rsrv3: __uint16_t,
+    pub __fpu_mxcsr: __uint32_t,
+    pub __fpu_mxcsrmask: __uint32_t,
+    pub __fpu_stmm0: __darwin_mmst_reg,
+    pub __fpu_stmm1: __darwin_mmst_reg,
+    pub __fpu_stmm2: __darwin_mmst_reg,
+    pub __fpu_stmm3: __darwin_mmst_reg,
+    pub __fpu_stmm4: __darwin_mmst_reg,
+    pub __fpu_stmm5: __darwin_mmst_reg,
+    pub __fpu_stmm6: __darwin_mmst_reg,
+    pub __fpu_stmm7: __darwin_mmst_reg,
+    pub __fpu_xmm0: __darwin_xmm_reg,
+    pub __fpu_xmm1: __darwin_xmm_reg,
+    pub __fpu_xmm2: __darwin_xmm_reg,
+    pub __fpu_xmm3: __darwin_xmm_reg,
+    pub __fpu_xmm4: __darwin_xmm_reg,
+    pub __fpu_xmm5: __darwin_xmm_reg,
+    pub __fpu_xmm6: __darwin_xmm_reg,
+    pub __fpu_xmm7: __darwin_xmm_reg,
+    pub __fpu_xmm8: __darwin_xmm_reg,
+    pub __fpu_xmm9: __darwin_xmm_reg,
+    pub __fpu_xmm10: __darwin_xmm_reg,
+    pub __fpu_xmm11: __darwin_xmm_reg,
+    pub __fpu_xmm12: __darwin_xmm_reg,
+    pub __fpu_xmm13: __darwin_xmm_reg,
+    pub __fpu_xmm14: __darwin_xmm_reg,
+    pub __fpu_xmm15: __darwin_xmm_reg,
+    pub __fpu_rsrv4: [::std::os::raw::c_char; 96usize],
+    pub __fpu_reserved1: ::std::os::raw::c_int,
+    pub __avx_reserved1: [::std::os::raw::c_char; 64usize],
+    pub __fpu_ymmh0: __darwin_xmm_reg,
+    pub __fpu_ymmh1: __darwin_xmm_reg,
+    pub __fpu_ymmh2: __darwin_xmm_reg,
+    pub __fpu_ymmh3: __darwin_xmm_reg,
+    pub __fpu_ymmh4: __darwin_xmm_reg,
+    pub __fpu_ymmh5: __darwin_xmm_reg,
+    pub __fpu_ymmh6: __darwin_xmm_reg,
+    pub __fpu_ymmh7: __darwin_xmm_reg,
+    pub __fpu_ymmh8: __darwin_xmm_reg,
+    pub __fpu_ymmh9: __darwin_xmm_reg,
+    pub __fpu_ymmh10: __darwin_xmm_reg,
+    pub __fpu_ymmh11: __darwin_xmm_reg,
+    pub __fpu_ymmh12: __darwin_xmm_reg,
+    pub __fpu_ymmh13: __darwin_xmm_reg,
+    pub __fpu_ymmh14: __darwin_xmm_reg,
+    pub __fpu_ymmh15: __darwin_xmm_reg,
+    pub __fpu_k0: __darwin_opmask_reg,
+    pub __fpu_k1: __darwin_opmask_reg,
+    pub __fpu_k2: __darwin_opmask_reg,
+    pub __fpu_k3: __darwin_opmask_reg,
+    pub __fpu_k4: __darwin_opmask_reg,
+    pub __fpu_k5: __darwin_opmask_reg,
+    pub __fpu_k6: __darwin_opmask_reg,
+    pub __fpu_k7: __darwin_opmask_reg,
+    pub __fpu_zmmh0: __darwin_ymm_reg,
+    pub __fpu_zmmh1: __darwin_ymm_reg,
+    pub __fpu_zmmh2: __darwin_ymm_reg,
+    pub __fpu_zmmh3: __darwin_ymm_reg,
+    pub __fpu_zmmh4: __darwin_ymm_reg,
+    pub __fpu_zmmh5: __darwin_ymm_reg,
+    pub __fpu_zmmh6: __darwin_ymm_reg,
+    pub __fpu_zmmh7: __darwin_ymm_reg,
+    pub __fpu_zmmh8: __darwin_ymm_reg,
+    pub __fpu_zmmh9: __darwin_ymm_reg,
+    pub __fpu_zmmh10: __darwin_ymm_reg,
+    pub __fpu_zmmh11: __darwin_ymm_reg,
+    pub __fpu_zmmh12: __darwin_ymm_reg,
+    pub __fpu_zmmh13: __darwin_ymm_reg,
+    pub __fpu_zmmh14: __darwin_ymm_reg,
+    pub __fpu_zmmh15: __darwin_ymm_reg,
+    pub __fpu_zmm16: __darwin_zmm_reg,
+    pub __fpu_zmm17: __darwin_zmm_reg,
+    pub __fpu_zmm18: __darwin_zmm_reg,
+    pub __fpu_zmm19: __darwin_zmm_reg,
+    pub __fpu_zmm20: __darwin_zmm_reg,
+    pub __fpu_zmm21: __darwin_zmm_reg,
+    pub __fpu_zmm22: __darwin_zmm_reg,
+    pub __fpu_zmm23: __darwin_zmm_reg,
+    pub __fpu_zmm24: __darwin_zmm_reg,
+    pub __fpu_zmm25: __darwin_zmm_reg,
+    pub __fpu_zmm26: __darwin_zmm_reg,
+    pub __fpu_zmm27: __darwin_zmm_reg,
+    pub __fpu_zmm28: __darwin_zmm_reg,
+    pub __fpu_zmm29: __darwin_zmm_reg,
+    pub __fpu_zmm30: __darwin_zmm_reg,
+    pub __fpu_zmm31: __darwin_zmm_reg,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of __darwin_x86_avx512_state64"]
+        [::std::mem::size_of::<__darwin_x86_avx512_state64>() - 2444usize];
+    ["Alignment of __darwin_x86_avx512_state64"]
+        [::std::mem::align_of::<__darwin_x86_avx512_state64>() - 4usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_reserved"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_reserved) - 0usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_fcw"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_fcw) - 8usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_fsw"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_fsw) - 10usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_ftw"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_ftw) - 12usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_rsrv1"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_rsrv1) - 13usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_fop"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_fop) - 14usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_ip"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_ip) - 16usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_cs"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_cs) - 20usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_rsrv2"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_rsrv2) - 22usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_dp"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_dp) - 24usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_ds"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_ds) - 28usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_rsrv3"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_rsrv3) - 30usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_mxcsr"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_mxcsr) - 32usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_mxcsrmask"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_mxcsrmask) - 36usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_stmm0"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_stmm0) - 40usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_stmm1"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_stmm1) - 56usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_stmm2"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_stmm2) - 72usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_stmm3"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_stmm3) - 88usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_stmm4"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_stmm4) - 104usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_stmm5"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_stmm5) - 120usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_stmm6"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_stmm6) - 136usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_stmm7"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_stmm7) - 152usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_xmm0"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_xmm0) - 168usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_xmm1"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_xmm1) - 184usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_xmm2"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_xmm2) - 200usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_xmm3"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_xmm3) - 216usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_xmm4"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_xmm4) - 232usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_xmm5"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_xmm5) - 248usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_xmm6"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_xmm6) - 264usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_xmm7"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_xmm7) - 280usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_xmm8"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_xmm8) - 296usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_xmm9"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_xmm9) - 312usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_xmm10"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_xmm10) - 328usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_xmm11"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_xmm11) - 344usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_xmm12"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_xmm12) - 360usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_xmm13"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_xmm13) - 376usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_xmm14"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_xmm14) - 392usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_xmm15"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_xmm15) - 408usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_rsrv4"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_rsrv4) - 424usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_reserved1"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_reserved1) - 520usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__avx_reserved1"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __avx_reserved1) - 524usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_ymmh0"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_ymmh0) - 588usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_ymmh1"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_ymmh1) - 604usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_ymmh2"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_ymmh2) - 620usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_ymmh3"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_ymmh3) - 636usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_ymmh4"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_ymmh4) - 652usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_ymmh5"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_ymmh5) - 668usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_ymmh6"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_ymmh6) - 684usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_ymmh7"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_ymmh7) - 700usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_ymmh8"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_ymmh8) - 716usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_ymmh9"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_ymmh9) - 732usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_ymmh10"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_ymmh10) - 748usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_ymmh11"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_ymmh11) - 764usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_ymmh12"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_ymmh12) - 780usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_ymmh13"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_ymmh13) - 796usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_ymmh14"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_ymmh14) - 812usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_ymmh15"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_ymmh15) - 828usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_k0"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_k0) - 844usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_k1"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_k1) - 852usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_k2"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_k2) - 860usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_k3"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_k3) - 868usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_k4"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_k4) - 876usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_k5"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_k5) - 884usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_k6"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_k6) - 892usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_k7"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_k7) - 900usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_zmmh0"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_zmmh0) - 908usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_zmmh1"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_zmmh1) - 940usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_zmmh2"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_zmmh2) - 972usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_zmmh3"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_zmmh3) - 1004usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_zmmh4"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_zmmh4) - 1036usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_zmmh5"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_zmmh5) - 1068usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_zmmh6"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_zmmh6) - 1100usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_zmmh7"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_zmmh7) - 1132usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_zmmh8"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_zmmh8) - 1164usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_zmmh9"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_zmmh9) - 1196usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_zmmh10"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_zmmh10) - 1228usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_zmmh11"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_zmmh11) - 1260usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_zmmh12"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_zmmh12) - 1292usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_zmmh13"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_zmmh13) - 1324usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_zmmh14"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_zmmh14) - 1356usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_zmmh15"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_zmmh15) - 1388usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_zmm16"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_zmm16) - 1420usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_zmm17"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_zmm17) - 1484usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_zmm18"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_zmm18) - 1548usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_zmm19"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_zmm19) - 1612usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_zmm20"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_zmm20) - 1676usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_zmm21"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_zmm21) - 1740usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_zmm22"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_zmm22) - 1804usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_zmm23"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_zmm23) - 1868usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_zmm24"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_zmm24) - 1932usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_zmm25"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_zmm25) - 1996usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_zmm26"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_zmm26) - 2060usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_zmm27"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_zmm27) - 2124usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_zmm28"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_zmm28) - 2188usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_zmm29"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_zmm29) - 2252usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_zmm30"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_zmm30) - 2316usize];
+    ["Offset of field: __darwin_x86_avx512_state64::__fpu_zmm31"]
+        [::std::mem::offset_of!(__darwin_x86_avx512_state64, __fpu_zmm31) - 2380usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __darwin_x86_exception_state64 {
+    pub __trapno: __uint16_t,
+    pub __cpu: __uint16_t,
+    pub __err: __uint32_t,
+    pub __faultvaddr: __uint64_t,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of __darwin_x86_exception_state64"]
+        [::std::mem::size_of::<__darwin_x86_exception_state64>() - 16usize];
+    ["Alignment of __darwin_x86_exception_state64"]
+        [::std::mem::align_of::<__darwin_x86_exception_state64>() - 8usize];
+    ["Offset of field: __darwin_x86_exception_state64::__trapno"]
+        [::std::mem::offset_of!(__darwin_x86_exception_state64, __trapno) - 0usize];
+    ["Offset of field: __darwin_x86_exception_state64::__cpu"]
+        [::std::mem::offset_of!(__darwin_x86_exception_state64, __cpu) - 2usize];
+    ["Offset of field: __darwin_x86_exception_state64::__err"]
+        [::std::mem::offset_of!(__darwin_x86_exception_state64, __err) - 4usize];
+    ["Offset of field: __darwin_x86_exception_state64::__faultvaddr"]
+        [::std::mem::offset_of!(__darwin_x86_exception_state64, __faultvaddr) - 8usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __darwin_x86_debug_state64 {
+    pub __dr0: __uint64_t,
+    pub __dr1: __uint64_t,
+    pub __dr2: __uint64_t,
+    pub __dr3: __uint64_t,
+    pub __dr4: __uint64_t,
+    pub __dr5: __uint64_t,
+    pub __dr6: __uint64_t,
+    pub __dr7: __uint64_t,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of __darwin_x86_debug_state64"]
+        [::std::mem::size_of::<__darwin_x86_debug_state64>() - 64usize];
+    ["Alignment of __darwin_x86_debug_state64"]
+        [::std::mem::align_of::<__darwin_x86_debug_state64>() - 8usize];
+    ["Offset of field: __darwin_x86_debug_state64::__dr0"]
+        [::std::mem::offset_of!(__darwin_x86_debug_state64, __dr0) - 0usize];
+    ["Offset of field: __darwin_x86_debug_state64::__dr1"]
+        [::std::mem::offset_of!(__darwin_x86_debug_state64, __dr1) - 8usize];
+    ["Offset of field: __darwin_x86_debug_state64::__dr2"]
+        [::std::mem::offset_of!(__darwin_x86_debug_state64, __dr2) - 16usize];
+    ["Offset of field: __darwin_x86_debug_state64::__dr3"]
+        [::std::mem::offset_of!(__darwin_x86_debug_state64, __dr3) - 24usize];
+    ["Offset of field: __darwin_x86_debug_state64::__dr4"]
+        [::std::mem::offset_of!(__darwin_x86_debug_state64, __dr4) - 32usize];
+    ["Offset of field: __darwin_x86_debug_state64::__dr5"]
+        [::std::mem::offset_of!(__darwin_x86_debug_state64, __dr5) - 40usize];
+    ["Offset of field: __darwin_x86_debug_state64::__dr6"]
+        [::std::mem::offset_of!(__darwin_x86_debug_state64, __dr6) - 48usize];
+    ["Offset of field: __darwin_x86_debug_state64::__dr7"]
+        [::std::mem::offset_of!(__darwin_x86_debug_state64, __dr7) - 56usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __darwin_x86_cpmu_state64 {
     pub __ctrs: [__uint64_t; 16usize],
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of __darwin_arm_cpmu_state64"]
-        [::std::mem::size_of::<__darwin_arm_cpmu_state64>() - 128usize];
-    ["Alignment of __darwin_arm_cpmu_state64"]
-        [::std::mem::align_of::<__darwin_arm_cpmu_state64>() - 8usize];
-    ["Offset of field: __darwin_arm_cpmu_state64::__ctrs"]
-        [::std::mem::offset_of!(__darwin_arm_cpmu_state64, __ctrs) - 0usize];
+    ["Size of __darwin_x86_cpmu_state64"]
+        [::std::mem::size_of::<__darwin_x86_cpmu_state64>() - 128usize];
+    ["Alignment of __darwin_x86_cpmu_state64"]
+        [::std::mem::align_of::<__darwin_x86_cpmu_state64>() - 8usize];
+    ["Offset of field: __darwin_x86_cpmu_state64::__ctrs"]
+        [::std::mem::offset_of!(__darwin_x86_cpmu_state64, __ctrs) - 0usize];
 };
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __darwin_mcontext32 {
-    pub __es: __darwin_arm_exception_state,
-    pub __ss: __darwin_arm_thread_state,
-    pub __fs: __darwin_arm_vfp_state,
+    pub __es: __darwin_i386_exception_state,
+    pub __ss: __darwin_i386_thread_state,
+    pub __fs: __darwin_i386_float_state,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of __darwin_mcontext32"][::std::mem::size_of::<__darwin_mcontext32>() - 340usize];
+    ["Size of __darwin_mcontext32"][::std::mem::size_of::<__darwin_mcontext32>() - 600usize];
     ["Alignment of __darwin_mcontext32"][::std::mem::align_of::<__darwin_mcontext32>() - 4usize];
     ["Offset of field: __darwin_mcontext32::__es"]
         [::std::mem::offset_of!(__darwin_mcontext32, __es) - 0usize];
     ["Offset of field: __darwin_mcontext32::__ss"]
         [::std::mem::offset_of!(__darwin_mcontext32, __ss) - 12usize];
     ["Offset of field: __darwin_mcontext32::__fs"]
-        [::std::mem::offset_of!(__darwin_mcontext32, __fs) - 80usize];
+        [::std::mem::offset_of!(__darwin_mcontext32, __fs) - 76usize];
 };
 #[repr(C)]
-#[repr(align(16))]
 #[derive(Debug, Copy, Clone)]
-pub struct __darwin_mcontext64 {
-    pub __es: __darwin_arm_exception_state64,
-    pub __ss: __darwin_arm_thread_state64,
-    pub __ns: __darwin_arm_neon_state64,
+pub struct __darwin_mcontext_avx32 {
+    pub __es: __darwin_i386_exception_state,
+    pub __ss: __darwin_i386_thread_state,
+    pub __fs: __darwin_i386_avx_state,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of __darwin_mcontext64"][::std::mem::size_of::<__darwin_mcontext64>() - 816usize];
-    ["Alignment of __darwin_mcontext64"][::std::mem::align_of::<__darwin_mcontext64>() - 16usize];
+    ["Size of __darwin_mcontext_avx32"]
+        [::std::mem::size_of::<__darwin_mcontext_avx32>() - 792usize];
+    ["Alignment of __darwin_mcontext_avx32"]
+        [::std::mem::align_of::<__darwin_mcontext_avx32>() - 4usize];
+    ["Offset of field: __darwin_mcontext_avx32::__es"]
+        [::std::mem::offset_of!(__darwin_mcontext_avx32, __es) - 0usize];
+    ["Offset of field: __darwin_mcontext_avx32::__ss"]
+        [::std::mem::offset_of!(__darwin_mcontext_avx32, __ss) - 12usize];
+    ["Offset of field: __darwin_mcontext_avx32::__fs"]
+        [::std::mem::offset_of!(__darwin_mcontext_avx32, __fs) - 76usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __darwin_mcontext_avx512_32 {
+    pub __es: __darwin_i386_exception_state,
+    pub __ss: __darwin_i386_thread_state,
+    pub __fs: __darwin_i386_avx512_state,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of __darwin_mcontext_avx512_32"]
+        [::std::mem::size_of::<__darwin_mcontext_avx512_32>() - 1112usize];
+    ["Alignment of __darwin_mcontext_avx512_32"]
+        [::std::mem::align_of::<__darwin_mcontext_avx512_32>() - 4usize];
+    ["Offset of field: __darwin_mcontext_avx512_32::__es"]
+        [::std::mem::offset_of!(__darwin_mcontext_avx512_32, __es) - 0usize];
+    ["Offset of field: __darwin_mcontext_avx512_32::__ss"]
+        [::std::mem::offset_of!(__darwin_mcontext_avx512_32, __ss) - 12usize];
+    ["Offset of field: __darwin_mcontext_avx512_32::__fs"]
+        [::std::mem::offset_of!(__darwin_mcontext_avx512_32, __fs) - 76usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __darwin_mcontext64 {
+    pub __es: __darwin_x86_exception_state64,
+    pub __ss: __darwin_x86_thread_state64,
+    pub __fs: __darwin_x86_float_state64,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of __darwin_mcontext64"][::std::mem::size_of::<__darwin_mcontext64>() - 712usize];
+    ["Alignment of __darwin_mcontext64"][::std::mem::align_of::<__darwin_mcontext64>() - 8usize];
     ["Offset of field: __darwin_mcontext64::__es"]
         [::std::mem::offset_of!(__darwin_mcontext64, __es) - 0usize];
     ["Offset of field: __darwin_mcontext64::__ss"]
         [::std::mem::offset_of!(__darwin_mcontext64, __ss) - 16usize];
-    ["Offset of field: __darwin_mcontext64::__ns"]
-        [::std::mem::offset_of!(__darwin_mcontext64, __ns) - 288usize];
+    ["Offset of field: __darwin_mcontext64::__fs"]
+        [::std::mem::offset_of!(__darwin_mcontext64, __fs) - 184usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __darwin_mcontext64_full {
+    pub __es: __darwin_x86_exception_state64,
+    pub __ss: __darwin_x86_thread_full_state64,
+    pub __fs: __darwin_x86_float_state64,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of __darwin_mcontext64_full"]
+        [::std::mem::size_of::<__darwin_mcontext64_full>() - 744usize];
+    ["Alignment of __darwin_mcontext64_full"]
+        [::std::mem::align_of::<__darwin_mcontext64_full>() - 8usize];
+    ["Offset of field: __darwin_mcontext64_full::__es"]
+        [::std::mem::offset_of!(__darwin_mcontext64_full, __es) - 0usize];
+    ["Offset of field: __darwin_mcontext64_full::__ss"]
+        [::std::mem::offset_of!(__darwin_mcontext64_full, __ss) - 16usize];
+    ["Offset of field: __darwin_mcontext64_full::__fs"]
+        [::std::mem::offset_of!(__darwin_mcontext64_full, __fs) - 216usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __darwin_mcontext_avx64 {
+    pub __es: __darwin_x86_exception_state64,
+    pub __ss: __darwin_x86_thread_state64,
+    pub __fs: __darwin_x86_avx_state64,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of __darwin_mcontext_avx64"]
+        [::std::mem::size_of::<__darwin_mcontext_avx64>() - 1032usize];
+    ["Alignment of __darwin_mcontext_avx64"]
+        [::std::mem::align_of::<__darwin_mcontext_avx64>() - 8usize];
+    ["Offset of field: __darwin_mcontext_avx64::__es"]
+        [::std::mem::offset_of!(__darwin_mcontext_avx64, __es) - 0usize];
+    ["Offset of field: __darwin_mcontext_avx64::__ss"]
+        [::std::mem::offset_of!(__darwin_mcontext_avx64, __ss) - 16usize];
+    ["Offset of field: __darwin_mcontext_avx64::__fs"]
+        [::std::mem::offset_of!(__darwin_mcontext_avx64, __fs) - 184usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __darwin_mcontext_avx64_full {
+    pub __es: __darwin_x86_exception_state64,
+    pub __ss: __darwin_x86_thread_full_state64,
+    pub __fs: __darwin_x86_avx_state64,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of __darwin_mcontext_avx64_full"]
+        [::std::mem::size_of::<__darwin_mcontext_avx64_full>() - 1064usize];
+    ["Alignment of __darwin_mcontext_avx64_full"]
+        [::std::mem::align_of::<__darwin_mcontext_avx64_full>() - 8usize];
+    ["Offset of field: __darwin_mcontext_avx64_full::__es"]
+        [::std::mem::offset_of!(__darwin_mcontext_avx64_full, __es) - 0usize];
+    ["Offset of field: __darwin_mcontext_avx64_full::__ss"]
+        [::std::mem::offset_of!(__darwin_mcontext_avx64_full, __ss) - 16usize];
+    ["Offset of field: __darwin_mcontext_avx64_full::__fs"]
+        [::std::mem::offset_of!(__darwin_mcontext_avx64_full, __fs) - 216usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __darwin_mcontext_avx512_64 {
+    pub __es: __darwin_x86_exception_state64,
+    pub __ss: __darwin_x86_thread_state64,
+    pub __fs: __darwin_x86_avx512_state64,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of __darwin_mcontext_avx512_64"]
+        [::std::mem::size_of::<__darwin_mcontext_avx512_64>() - 2632usize];
+    ["Alignment of __darwin_mcontext_avx512_64"]
+        [::std::mem::align_of::<__darwin_mcontext_avx512_64>() - 8usize];
+    ["Offset of field: __darwin_mcontext_avx512_64::__es"]
+        [::std::mem::offset_of!(__darwin_mcontext_avx512_64, __es) - 0usize];
+    ["Offset of field: __darwin_mcontext_avx512_64::__ss"]
+        [::std::mem::offset_of!(__darwin_mcontext_avx512_64, __ss) - 16usize];
+    ["Offset of field: __darwin_mcontext_avx512_64::__fs"]
+        [::std::mem::offset_of!(__darwin_mcontext_avx512_64, __fs) - 184usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __darwin_mcontext_avx512_64_full {
+    pub __es: __darwin_x86_exception_state64,
+    pub __ss: __darwin_x86_thread_full_state64,
+    pub __fs: __darwin_x86_avx512_state64,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of __darwin_mcontext_avx512_64_full"]
+        [::std::mem::size_of::<__darwin_mcontext_avx512_64_full>() - 2664usize];
+    ["Alignment of __darwin_mcontext_avx512_64_full"]
+        [::std::mem::align_of::<__darwin_mcontext_avx512_64_full>() - 8usize];
+    ["Offset of field: __darwin_mcontext_avx512_64_full::__es"]
+        [::std::mem::offset_of!(__darwin_mcontext_avx512_64_full, __es) - 0usize];
+    ["Offset of field: __darwin_mcontext_avx512_64_full::__ss"]
+        [::std::mem::offset_of!(__darwin_mcontext_avx512_64_full, __ss) - 16usize];
+    ["Offset of field: __darwin_mcontext_avx512_64_full::__fs"]
+        [::std::mem::offset_of!(__darwin_mcontext_avx512_64_full, __fs) - 216usize];
 };
 pub type mcontext_t = *mut __darwin_mcontext64;
 pub type pthread_attr_t = __darwin_pthread_attr_t;
@@ -3863,7 +6567,10 @@ pub struct rusage_info_v6 {
     pub ri_penergy_nj: u64,
     pub ri_secure_time_in_system: u64,
     pub ri_secure_ptime_in_system: u64,
-    pub ri_reserved: [u64; 12usize],
+    pub ri_neural_footprint: u64,
+    pub ri_lifetime_max_neural_footprint: u64,
+    pub ri_interval_max_neural_footprint: u64,
+    pub ri_reserved: [u64; 9usize],
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
@@ -3959,8 +6666,14 @@ const _: () = {
         [::std::mem::offset_of!(rusage_info_v6, ri_secure_time_in_system) - 352usize];
     ["Offset of field: rusage_info_v6::ri_secure_ptime_in_system"]
         [::std::mem::offset_of!(rusage_info_v6, ri_secure_ptime_in_system) - 360usize];
+    ["Offset of field: rusage_info_v6::ri_neural_footprint"]
+        [::std::mem::offset_of!(rusage_info_v6, ri_neural_footprint) - 368usize];
+    ["Offset of field: rusage_info_v6::ri_lifetime_max_neural_footprint"]
+        [::std::mem::offset_of!(rusage_info_v6, ri_lifetime_max_neural_footprint) - 376usize];
+    ["Offset of field: rusage_info_v6::ri_interval_max_neural_footprint"]
+        [::std::mem::offset_of!(rusage_info_v6, ri_interval_max_neural_footprint) - 384usize];
     ["Offset of field: rusage_info_v6::ri_reserved"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_reserved) - 368usize];
+        [::std::mem::offset_of!(rusage_info_v6, ri_reserved) - 392usize];
 };
 pub type rusage_info_current = rusage_info_v6;
 #[repr(C)]
@@ -4025,42 +6738,6 @@ unsafe extern "C" {
 unsafe extern "C" {
     pub fn setrlimit(arg1: ::std::os::raw::c_int, arg2: *const rlimit) -> ::std::os::raw::c_int;
 }
-#[repr(C, packed)]
-#[derive(Debug, Copy, Clone)]
-pub struct _OSUnalignedU16 {
-    pub __val: u16,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of _OSUnalignedU16"][::std::mem::size_of::<_OSUnalignedU16>() - 2usize];
-    ["Alignment of _OSUnalignedU16"][::std::mem::align_of::<_OSUnalignedU16>() - 1usize];
-    ["Offset of field: _OSUnalignedU16::__val"]
-        [::std::mem::offset_of!(_OSUnalignedU16, __val) - 0usize];
-};
-#[repr(C, packed)]
-#[derive(Debug, Copy, Clone)]
-pub struct _OSUnalignedU32 {
-    pub __val: u32,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of _OSUnalignedU32"][::std::mem::size_of::<_OSUnalignedU32>() - 4usize];
-    ["Alignment of _OSUnalignedU32"][::std::mem::align_of::<_OSUnalignedU32>() - 1usize];
-    ["Offset of field: _OSUnalignedU32::__val"]
-        [::std::mem::offset_of!(_OSUnalignedU32, __val) - 0usize];
-};
-#[repr(C, packed)]
-#[derive(Debug, Copy, Clone)]
-pub struct _OSUnalignedU64 {
-    pub __val: u64,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of _OSUnalignedU64"][::std::mem::size_of::<_OSUnalignedU64>() - 8usize];
-    ["Alignment of _OSUnalignedU64"][::std::mem::align_of::<_OSUnalignedU64>() - 1usize];
-    ["Offset of field: _OSUnalignedU64::__val"]
-        [::std::mem::offset_of!(_OSUnalignedU64, __val) - 0usize];
-};
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union wait {
@@ -4416,7 +7093,7 @@ unsafe extern "C" {
     ) -> pid_t;
 }
 unsafe extern "C" {
-    pub fn alloca(arg1: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void;
+    pub fn alloca(__size: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void;
 }
 pub type ct_rune_t = __darwin_ct_rune_t;
 pub type rune_t = __darwin_rune_t;
@@ -4584,7 +7261,7 @@ unsafe extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 unsafe extern "C" {
-    pub fn valloc(arg1: usize) -> *mut ::std::os::raw::c_void;
+    pub fn valloc(__size: usize) -> *mut ::std::os::raw::c_void;
 }
 unsafe extern "C" {
     pub fn aligned_alloc(
@@ -4607,6 +7284,11 @@ unsafe extern "C" {
 }
 unsafe extern "C" {
     pub fn atexit(arg1: ::std::option::Option<unsafe extern "C" fn()>) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn at_quick_exit(
+        arg1: ::std::option::Option<unsafe extern "C" fn()>,
+    ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
     pub fn atof(arg1: *const ::std::os::raw::c_char) -> f64;
@@ -4659,13 +7341,13 @@ unsafe extern "C" {
     pub fn mblen(__s: *const ::std::os::raw::c_char, __n: usize) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn mbstowcs(arg1: *mut wchar_t, arg2: *const ::std::os::raw::c_char, arg3: usize) -> usize;
+    pub fn mbstowcs(arg1: *mut wchar_t, arg2: *const ::std::os::raw::c_char, __n: usize) -> usize;
 }
 unsafe extern "C" {
     pub fn mbtowc(
         arg1: *mut wchar_t,
         arg2: *const ::std::os::raw::c_char,
-        arg3: usize,
+        __n: usize,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
@@ -4680,6 +7362,9 @@ unsafe extern "C" {
             ) -> ::std::os::raw::c_int,
         >,
     );
+}
+unsafe extern "C" {
+    pub fn quick_exit(arg1: ::std::os::raw::c_int) -> !;
 }
 unsafe extern "C" {
     pub fn rand() -> ::std::os::raw::c_int;
@@ -4710,7 +7395,7 @@ unsafe extern "C" {
     pub fn strtold(
         arg1: *const ::std::os::raw::c_char,
         arg2: *mut *mut ::std::os::raw::c_char,
-    ) -> f64;
+    ) -> u128;
 }
 unsafe extern "C" {
     pub fn strtoll(
@@ -4737,7 +7422,7 @@ unsafe extern "C" {
     pub fn system(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn wcstombs(arg1: *mut ::std::os::raw::c_char, arg2: *const wchar_t, arg3: usize) -> usize;
+    pub fn wcstombs(arg1: *mut ::std::os::raw::c_char, arg2: *const wchar_t, __n: usize) -> usize;
 }
 unsafe extern "C" {
     pub fn wctomb(arg1: *mut ::std::os::raw::c_char, arg2: wchar_t) -> ::std::os::raw::c_int;
@@ -4791,7 +7476,7 @@ unsafe extern "C" {
     pub fn initstate(
         arg1: ::std::os::raw::c_uint,
         arg2: *mut ::std::os::raw::c_char,
-        arg3: usize,
+        __size: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
@@ -4881,7 +7566,10 @@ unsafe extern "C" {
     pub fn arc4random() -> u32;
 }
 unsafe extern "C" {
-    pub fn arc4random_addrandom(arg1: *mut ::std::os::raw::c_uchar, arg2: ::std::os::raw::c_int);
+    pub fn arc4random_addrandom(
+        arg1: *mut ::std::os::raw::c_uchar,
+        __datlen: ::std::os::raw::c_int,
+    );
 }
 unsafe extern "C" {
     pub fn arc4random_buf(__buf: *mut ::std::os::raw::c_void, __nbytes: usize);
@@ -4964,6 +7652,7 @@ unsafe extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[link_name = "\u{1}_daemon$1050"]
     pub fn daemon(
         arg1: ::std::os::raw::c_int,
         arg2: ::std::os::raw::c_int,
@@ -4987,7 +7676,7 @@ unsafe extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn getloadavg(arg1: *mut f64, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn getloadavg(arg1: *mut f64, __nelem: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
     pub fn getprogname() -> *const ::std::os::raw::c_char;
@@ -5147,7 +7836,7 @@ unsafe extern "C" {
     pub static mut suboptarg: *mut ::std::os::raw::c_char;
 }
 pub type rsize_t = ::std::os::raw::c_ulong;
-pub type max_align_t = f64;
+pub type max_align_t = u128;
 unsafe extern "C" {
     #[doc = " allocates array and initializes it with 0; returns NULL if memory allocation failed"]
     pub fn BMSallocClearMemory_call(
@@ -8364,12 +11053,14 @@ unsafe extern "C" {
     pub fn SCIPbanditGetNActions(bandit: *mut SCIP_BANDIT) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " compares two benderss w. r. to their priority"]
     pub fn SCIPbendersComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting benderss w.r.t. to their name"]
     pub fn SCIPbendersCompName(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -8739,12 +11430,14 @@ unsafe extern "C" {
     ) -> ::std::os::raw::c_uint;
 }
 unsafe extern "C" {
+    #[doc = " compares two Benders' decomposition cuts w. r. to their priority"]
     pub fn SCIPbenderscutComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting Benders' decomposition cuts w.r.t. to their name"]
     pub fn SCIPbenderscutCompName(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -8807,12 +11500,14 @@ unsafe extern "C" {
     );
 }
 unsafe extern "C" {
+    #[doc = " compares two branching rules w. r. to their priority"]
     pub fn SCIPbranchruleComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting branching rules w.r.t. to their name"]
     pub fn SCIPbranchruleCompName(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -8916,12 +11611,14 @@ unsafe extern "C" {
     pub fn SCIPbranchruleIsInitialized(branchrule: *mut SCIP_BRANCHRULE) -> ::std::os::raw::c_uint;
 }
 unsafe extern "C" {
+    #[doc = " compares two conflict handlers w. r. to their priority"]
     pub fn SCIPconflicthdlrComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting conflict handler w.r.t. to their name"]
     pub fn SCIPconflicthdlrCompName(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -8973,24 +11670,28 @@ unsafe extern "C" {
     pub fn SCIPconflicthdlrGetTime(conflicthdlr: *mut SCIP_CONFLICTHDLR) -> f64;
 }
 unsafe extern "C" {
+    #[doc = " compares two constraint handlers w.r.t. their separation priority"]
     pub fn SCIPconshdlrCompSepa(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " compares two constraint handlers w.r.t. their enforcing priority"]
     pub fn SCIPconshdlrCompEnfo(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " compares two constraint handlers w.r.t. their feasibility check priority"]
     pub fn SCIPconshdlrCompCheck(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " compares two constraints w.r.t. their feasibility check priority"]
     pub fn SCIPconsCompCheck(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -10566,6 +13267,7 @@ unsafe extern "C" {
     pub fn SCIPexprhdlrHasGetSymData(exprhdlr: *mut SCIP_EXPRHDLR) -> ::std::os::raw::c_uint;
 }
 unsafe extern "C" {
+    #[doc = " compares two expression handler w.r.t. their name"]
     pub fn SCIPexprhdlrComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -11028,18 +13730,21 @@ unsafe extern "C" {
     pub fn SCIPfclose(fp: *mut SCIP_FILE) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " compares two heuristics w.r.t. to their delay positions and priorities"]
     pub fn SCIPheurComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " compares two heuristics w.r.t. to their priority values"]
     pub fn SCIPheurCompPriority(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting heuristics w.r.t. to their name"]
     pub fn SCIPheurCompName(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -11336,12 +14041,14 @@ unsafe extern "C" {
     pub fn SCIPvariableGraphFree(scip: *mut SCIP, vargraph: *mut *mut SCIP_VGRAPH);
 }
 unsafe extern "C" {
+    #[doc = " compares two compressions w. r. to their priority"]
     pub fn SCIPcomprComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting compressions w.r.t. to their name"]
     pub fn SCIPcomprCompName(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -11491,6 +14198,7 @@ unsafe extern "C" {
     pub fn SCIPiisGetSubscip(iis: *mut SCIP_IIS) -> *mut SCIP;
 }
 unsafe extern "C" {
+    #[doc = " compares two IIS finders w. r. to their priority"]
     pub fn SCIPiisfinderComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -11837,6 +14545,7 @@ unsafe extern "C" {
     pub fn SCIPboundtypeOpposite(boundtype: SCIP_BOUNDTYPE) -> SCIP_BOUNDTYPE;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting rows by non-decreasing index"]
     pub fn SCIProwComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -12009,6 +14718,7 @@ pub struct SCIP_LPiExact {
 }
 pub type SCIP_LPIEXACT = SCIP_LPiExact;
 unsafe extern "C" {
+    #[doc = " comparison method for sorting rows by non-decreasing index"]
     pub fn SCIProwExactComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -12651,6 +15361,12 @@ unsafe extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
+    pub fn strchrnul(
+        __s: *const ::std::os::raw::c_char,
+        __c: ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
     pub fn strnstr(
         __big: *const ::std::os::raw::c_char,
         __little: *const ::std::os::raw::c_char,
@@ -12684,7 +15400,7 @@ unsafe extern "C" {
     pub fn swab(
         arg1: *const ::std::os::raw::c_void,
         arg2: *mut ::std::os::raw::c_void,
-        arg3: isize,
+        __len: isize,
     );
 }
 unsafe extern "C" {
@@ -12705,18 +15421,18 @@ unsafe extern "C" {
     pub fn bcmp(
         arg1: *const ::std::os::raw::c_void,
         arg2: *const ::std::os::raw::c_void,
-        arg3: ::std::os::raw::c_ulong,
+        __n: ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
     pub fn bcopy(
         arg1: *const ::std::os::raw::c_void,
         arg2: *mut ::std::os::raw::c_void,
-        arg3: usize,
+        __n: ::std::os::raw::c_ulong,
     );
 }
 unsafe extern "C" {
-    pub fn bzero(arg1: *mut ::std::os::raw::c_void, arg2: ::std::os::raw::c_ulong);
+    pub fn bzero(arg1: *mut ::std::os::raw::c_void, __n: ::std::os::raw::c_ulong);
 }
 unsafe extern "C" {
     pub fn index(
@@ -12836,7 +15552,7 @@ unsafe extern "C" {
     pub fn SCIPmessageVPrintInfo(
         messagehdlr: *mut SCIP_MESSAGEHDLR,
         formatstr: *const ::std::os::raw::c_char,
-        ap: va_list,
+        ap: *mut __va_list_tag,
     );
 }
 unsafe extern "C" {
@@ -12853,7 +15569,7 @@ unsafe extern "C" {
         messagehdlr: *mut SCIP_MESSAGEHDLR,
         file: *mut FILE,
         formatstr: *const ::std::os::raw::c_char,
-        ap: va_list,
+        ap: *mut __va_list_tag,
     );
 }
 unsafe extern "C" {
@@ -12868,7 +15584,7 @@ unsafe extern "C" {
     pub fn SCIPmessageVPrintWarning(
         messagehdlr: *mut SCIP_MESSAGEHDLR,
         formatstr: *const ::std::os::raw::c_char,
-        ap: va_list,
+        ap: *mut __va_list_tag,
     );
 }
 unsafe extern "C" {
@@ -12883,7 +15599,7 @@ unsafe extern "C" {
     pub fn SCIPmessageVFPrintWarning(
         messagehdlr: *mut SCIP_MESSAGEHDLR,
         formatstr: *const ::std::os::raw::c_char,
-        ap: va_list,
+        ap: *mut __va_list_tag,
     );
 }
 unsafe extern "C" {
@@ -12898,7 +15614,7 @@ unsafe extern "C" {
     pub fn SCIPmessageVPrintDialog(
         messagehdlr: *mut SCIP_MESSAGEHDLR,
         formatstr: *const ::std::os::raw::c_char,
-        ap: va_list,
+        ap: *mut __va_list_tag,
     );
 }
 unsafe extern "C" {
@@ -12915,7 +15631,7 @@ unsafe extern "C" {
         messagehdlr: *mut SCIP_MESSAGEHDLR,
         file: *mut FILE,
         formatstr: *const ::std::os::raw::c_char,
-        ap: va_list,
+        ap: *mut __va_list_tag,
     );
 }
 unsafe extern "C" {
@@ -12934,7 +15650,7 @@ unsafe extern "C" {
         verblevel: SCIP_VERBLEVEL,
         msgverblevel: SCIP_VERBLEVEL,
         formatstr: *const ::std::os::raw::c_char,
-        ap: va_list,
+        ap: *mut __va_list_tag,
     );
 }
 unsafe extern "C" {
@@ -12955,7 +15671,7 @@ unsafe extern "C" {
         msgverblevel: SCIP_VERBLEVEL,
         file: *mut FILE,
         formatstr: *const ::std::os::raw::c_char,
-        ap: va_list,
+        ap: *mut __va_list_tag,
     );
 }
 unsafe extern "C" {
@@ -12970,7 +15686,7 @@ unsafe extern "C" {
 }
 unsafe extern "C" {
     #[doc = " prints an error message, acting like the vprintf() command using the static message handler"]
-    pub fn SCIPmessageVPrintError(formatstr: *const ::std::os::raw::c_char, ap: va_list);
+    pub fn SCIPmessageVPrintError(formatstr: *const ::std::os::raw::c_char, ap: *mut __va_list_tag);
 }
 unsafe extern "C" {
     #[doc = " Method to set the error printing method. Setting the error printing method to NULL will suspend all error methods.\n\n  @note The error printing method is a static variable. This means that all occurring errors are handled via this method."]
@@ -16230,12 +18946,14 @@ unsafe extern "C" {
     );
 }
 unsafe extern "C" {
+    #[doc = " default comparer for integers"]
     pub fn SCIPsortCompInt(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " implements argsort\n\n The data pointer is a lookup array of integers."]
     pub fn SCIPsortArgsortInt(
         dataptr: *mut ::std::os::raw::c_void,
         ind1: ::std::os::raw::c_int,
@@ -16243,6 +18961,7 @@ unsafe extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " implements argsort\n\n The data pointer is a lookup array, which are pointer arrays."]
     pub fn SCIPsortArgsortPtr(
         dataptr: *mut ::std::os::raw::c_void,
         ind1: ::std::os::raw::c_int,
@@ -21944,6 +24663,7 @@ unsafe extern "C" {
     );
 }
 unsafe extern "C" {
+    #[doc = " standard hash key comparator for string keys"]
     pub fn SCIPhashKeyEqString(
         userptr: *mut ::std::os::raw::c_void,
         key1: *mut ::std::os::raw::c_void,
@@ -21951,18 +24671,21 @@ unsafe extern "C" {
     ) -> ::std::os::raw::c_uint;
 }
 unsafe extern "C" {
+    #[doc = " standard hashing function for string keys"]
     pub fn SCIPhashKeyValString(
         userptr: *mut ::std::os::raw::c_void,
         key: *mut ::std::os::raw::c_void,
     ) -> u64;
 }
 unsafe extern "C" {
+    #[doc = " gets the element as the key"]
     pub fn SCIPhashGetKeyStandard(
         userptr: *mut ::std::os::raw::c_void,
         elem: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 unsafe extern "C" {
+    #[doc = " returns TRUE iff both keys(pointer) are equal"]
     pub fn SCIPhashKeyEqPtr(
         userptr: *mut ::std::os::raw::c_void,
         key1: *mut ::std::os::raw::c_void,
@@ -21970,6 +24693,7 @@ unsafe extern "C" {
     ) -> ::std::os::raw::c_uint;
 }
 unsafe extern "C" {
+    #[doc = " returns the hash value of the key"]
     pub fn SCIPhashKeyValPtr(
         userptr: *mut ::std::os::raw::c_void,
         key: *mut ::std::os::raw::c_void,
@@ -23082,12 +25806,14 @@ unsafe extern "C" {
     pub fn SCIPparamIsDefault(param: *mut SCIP_PARAM) -> ::std::os::raw::c_uint;
 }
 unsafe extern "C" {
+    #[doc = " compares two presolvers w. r. to their priority"]
     pub fn SCIPpresolComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting presolvers w.r.t. to their name"]
     pub fn SCIPpresolCompName(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -23186,12 +25912,14 @@ unsafe extern "C" {
     pub fn SCIPpresolGetNCalls(presol: *mut SCIP_PRESOL) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " compares two pricers w. r. to their priority"]
     pub fn SCIPpricerComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting pricers w.r.t. to their name"]
     pub fn SCIPpricerCompName(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -23282,12 +26010,14 @@ unsafe extern "C" {
     pub fn SCIPreaderCanWrite(reader: *mut SCIP_READER) -> ::std::os::raw::c_uint;
 }
 unsafe extern "C" {
+    #[doc = " compares two relaxation handlers w. r. to their priority"]
     pub fn SCIPrelaxComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting relaxators w.r.t. to their name"]
     pub fn SCIPrelaxCompName(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -23460,12 +26190,14 @@ unsafe extern "C" {
     pub fn SCIPreoptGetNTotalInfNodes(reopt: *mut SCIP_REOPT) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " compares two separators w. r. to their priority"]
     pub fn SCIPsepaComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting separators w.r.t. to their name"]
     pub fn SCIPsepaCompName(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -23664,24 +26396,28 @@ unsafe extern "C" {
     pub fn SCIPcutselGetNLocalCutsFiltered(cutsel: *mut SCIP_CUTSEL) -> ::std::os::raw::c_longlong;
 }
 unsafe extern "C" {
+    #[doc = " compares two cut selectors w. r. to their priority"]
     pub fn SCIPcutselComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " compares two propagators w. r. to their priority"]
     pub fn SCIPpropComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " compares two propagators w. r. to their presolving priority"]
     pub fn SCIPpropCompPresol(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting propagators w.r.t. to their name"]
     pub fn SCIPpropCompName(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -23940,6 +26676,7 @@ unsafe extern "C" {
     pub fn SCIPsolGetRelConsViolation(sol: *mut SCIP_SOL) -> f64;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting solution by decreasing objective value (best solution will be sorted to the end)"]
     pub fn SCIPsolComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -23978,6 +26715,7 @@ unsafe extern "C" {
     pub fn SCIPtableIsInitialized(table: *mut SCIP_TABLE) -> ::std::os::raw::c_uint;
 }
 unsafe extern "C" {
+    #[doc = " node comparator for best lower bound"]
     pub fn SCIPnodeCompLowerbound(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -24168,6 +26906,7 @@ unsafe extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting active and negated variables by non-decreasing index, active and negated\n  variables are handled as the same variables"]
     pub fn SCIPvarCompActiveAndNegated(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -24178,24 +26917,28 @@ unsafe extern "C" {
     pub fn SCIPvarCompare(var1: *mut SCIP_VAR, var2: *mut SCIP_VAR) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting variables by non-decreasing index"]
     pub fn SCIPvarComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting variables by non-decreasing objective coefficient"]
     pub fn SCIPvarCompObj(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " hash key retrieval function for variables"]
     pub fn SCIPvarGetHashkey(
         userptr: *mut ::std::os::raw::c_void,
         elem: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 unsafe extern "C" {
+    #[doc = " returns TRUE iff the indices of both variables are equal"]
     pub fn SCIPvarIsHashkeyEq(
         userptr: *mut ::std::os::raw::c_void,
         key1: *mut ::std::os::raw::c_void,
@@ -24203,6 +26946,7 @@ unsafe extern "C" {
     ) -> ::std::os::raw::c_uint;
 }
 unsafe extern "C" {
+    #[doc = " returns the hash value of the key"]
     pub fn SCIPvarGetHashkeyVal(
         userptr: *mut ::std::os::raw::c_void,
         key: *mut ::std::os::raw::c_void,
@@ -25937,7 +28681,9 @@ pub struct SCIP_AggrRow {
     pub slacksign: *mut ::std::os::raw::c_int,
     #[doc = "< weights of rows that have been added to the cutrow"]
     pub rowweights: *mut f64,
+    #[doc = "< right hand side of the cut row"]
     pub rhshi: f64,
+    #[doc = "< right hand side of the cut row"]
     pub rhslo: f64,
     #[doc = "< number of non-zeros in the cut row"]
     pub nnz: ::std::os::raw::c_int,
@@ -31471,6 +34217,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " calls the print callback for an expression\n\n @see SCIP_DECL_EXPRPRINT"]
     pub fn SCIPcallExprPrint(
         scip: *mut SCIP,
         expr: *mut SCIP_EXPR,
@@ -31481,6 +34228,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " calls the curvature callback for an expression\n\n @see SCIP_DECL_EXPRCURVATURE\n\n Returns unknown curvature if callback not implemented."]
     pub fn SCIPcallExprCurvature(
         scip: *mut SCIP,
         expr: *mut SCIP_EXPR,
@@ -31490,6 +34238,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " calls the monotonicity callback for an expression\n\n @see SCIP_DECL_EXPRMONOTONICITY\n\n Returns unknown monotonicity if callback not implemented."]
     pub fn SCIPcallExprMonotonicity(
         scip: *mut SCIP,
         expr: *mut SCIP_EXPR,
@@ -31518,6 +34267,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " calls the interval evaluation callback for an expression\n\n @see SCIP_DECL_EXPRINTEVAL\n\n Returns entire interval if callback not implemented."]
     pub fn SCIPcallExprInteval(
         scip: *mut SCIP,
         expr: *mut SCIP_EXPR,
@@ -31533,6 +34283,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " calls the estimate callback for an expression\n\n @see SCIP_DECL_EXPRESTIMATE\n\n Returns without success if callback not implemented."]
     pub fn SCIPcallExprEstimate(
         scip: *mut SCIP,
         expr: *mut SCIP_EXPR,
@@ -31549,6 +34300,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " calls the initial estimators callback for an expression\n\n @see SCIP_DECL_EXPRINITESTIMATES\n\n Returns no estimators if callback not implemented."]
     pub fn SCIPcallExprInitestimates(
         scip: *mut SCIP,
         expr: *mut SCIP_EXPR,
@@ -31560,6 +34312,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " calls the simplify callback for an expression\n\n @see SCIP_DECL_EXPRSIMPLIFY\n\n Returns unmodified expression if simplify callback not implemented.\n\n Does not simplify descendants (children, etc). Use SCIPsimplifyExpr() for that."]
     pub fn SCIPcallExprSimplify(
         scip: *mut SCIP,
         expr: *mut SCIP_EXPR,
@@ -31598,6 +34351,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " calls the reverse propagation callback for an expression\n\n @see SCIP_DECL_EXPRREVERSEPROP\n\n Returns unmodified `childrenbounds` if reverseprop callback not implemented."]
     pub fn SCIPcallExprReverseprop(
         scip: *mut SCIP,
         expr: *mut SCIP_EXPR,
@@ -31607,6 +34361,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " calls the symmetry information callback for an expression\n\n Returns NULL pointer if not implemented."]
     pub fn SCIPcallExprGetSymData(
         scip: *mut SCIP,
         expr: *mut SCIP_EXPR,
@@ -33122,6 +35877,7 @@ unsafe extern "C" {
     -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " compares two NLPIs w.r.t. their priority"]
     pub fn SCIPnlpiComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -33418,6 +36174,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " gets internal pointer to NLP solver\n\n Depending on the solver interface, a solver pointer may exist for every NLP problem instance.\n For this case, a NLPI problem can be passed in as well."]
     pub fn SCIPgetNlpiSolverPointer(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33425,6 +36182,7 @@ unsafe extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 unsafe extern "C" {
+    #[doc = " creates an empty problem instance"]
     pub fn SCIPcreateNlpiProblem(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33433,6 +36191,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " frees a problem instance"]
     pub fn SCIPfreeNlpiProblem(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33440,6 +36199,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " gets internal pointer to solver-internal problem instance"]
     pub fn SCIPgetNlpiProblemPointer(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33447,6 +36207,7 @@ unsafe extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 unsafe extern "C" {
+    #[doc = " add variables to nlpi"]
     pub fn SCIPaddNlpiVars(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33458,6 +36219,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " add constraints to nlpi"]
     pub fn SCIPaddNlpiConstraints(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33473,6 +36235,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " sets or overwrites objective, a minimization problem is expected"]
     pub fn SCIPsetNlpiObjective(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33485,6 +36248,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " change variable bounds"]
     pub fn SCIPchgNlpiVarBounds(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33496,6 +36260,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " change constraint sides"]
     pub fn SCIPchgNlpiConsSides(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33507,6 +36272,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " delete a set of variables"]
     pub fn SCIPdelNlpiVarSet(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33516,6 +36282,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " delete a set of constraints"]
     pub fn SCIPdelNlpiConsSet(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33525,6 +36292,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " changes or adds linear coefficients in a constraint or objective"]
     pub fn SCIPchgNlpiLinearCoefs(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33536,6 +36304,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " change the expression in the nonlinear part"]
     pub fn SCIPchgNlpiExpr(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33545,6 +36314,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " change the constant offset in the objective"]
     pub fn SCIPchgNlpiObjConstant(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33553,6 +36323,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " sets initial guess"]
     pub fn SCIPsetNlpiInitialGuess(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33564,6 +36335,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " try to solve NLP with all parameters given as SCIP_NLPPARAM struct\n\n Typical use is\n\n     SCIP_NLPPARAM nlparam = { SCIP_NLPPARAM_DEFAULT(scip); }\n     nlpparam.iterlimit = 42;\n     SCIP_CALL( SCIPsolveNlpiParam(scip, nlpi, nlpiproblem, nlpparam) );\n\n or, in \"one\" line:\n\n     SCIP_CALL( SCIPsolveNlpiParam(scip, nlpi, nlpiproblem,\n        (SCIP_NLPPARAM){ SCIP_NLPPARAM_DEFAULT(scip), .iterlimit = 42 }) );\n\n To get the latter, also \\ref SCIPsolveNlpi can be used."]
     pub fn SCIPsolveNlpiParam(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33572,6 +36344,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " gives solution status"]
     pub fn SCIPgetNlpiSolstat(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33579,6 +36352,7 @@ unsafe extern "C" {
     ) -> SCIP_NLPSOLSTAT;
 }
 unsafe extern "C" {
+    #[doc = " gives termination reason"]
     pub fn SCIPgetNlpiTermstat(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33586,6 +36360,7 @@ unsafe extern "C" {
     ) -> SCIP_NLPTERMSTAT;
 }
 unsafe extern "C" {
+    #[doc = " gives primal and dual solution\n for a ranged constraint, the dual variable is positive if the right hand side is active and negative if the left hand side is active"]
     pub fn SCIPgetNlpiSolution(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33598,6 +36373,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " gives solve statistics"]
     pub fn SCIPgetNlpiStatistics(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -40782,6 +43558,7 @@ unsafe extern "C" {
     pub fn SCIPincludeConshdlrCountsols(scip: *mut SCIP) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the count command"]
     pub fn SCIPdialogExecCountPresolve(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -40790,6 +43567,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the count command"]
     pub fn SCIPdialogExecCount(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -40798,6 +43576,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " execution method of dialog for writing all solutions"]
     pub fn SCIPdialogExecWriteAllsolutions(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55019,6 +57798,7 @@ unsafe extern "C" {
     pub fn SCIPgetSlackConsSuperindicator(cons: *mut SCIP_CONS) -> *mut SCIP_CONS;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the SCIPtransformMinUC() command"]
     pub fn SCIPdialogExecChangeMinUC(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55241,6 +58021,7 @@ unsafe extern "C" {
     pub fn SCIPincludeDispDefault(scip: *mut SCIP) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " standard menu dialog execution method, that displays it's help screen if the remaining command line is empty"]
     pub fn SCIPdialogExecMenu(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55249,6 +58030,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " standard menu dialog execution method, that doesn't display it's help screen"]
     pub fn SCIPdialogExecMenuLazy(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55257,6 +58039,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the change add constraint"]
     pub fn SCIPdialogExecChangeAddCons(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55265,6 +58048,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the change bounds command"]
     pub fn SCIPdialogExecChangeBounds(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55273,6 +58057,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the freetransproblem command"]
     pub fn SCIPdialogExecChangeFreetransproblem(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55281,6 +58066,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the changing the objective sense"]
     pub fn SCIPdialogExecChangeObjSense(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55289,6 +58075,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the checksol command"]
     pub fn SCIPdialogExecChecksol(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55297,6 +58084,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the cliquegraph command"]
     pub fn SCIPdialogExecCliquegraph(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55305,6 +58093,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display benders command"]
     pub fn SCIPdialogExecDisplayBenders(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55313,6 +58102,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display branching command"]
     pub fn SCIPdialogExecDisplayBranching(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55321,6 +58111,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display compression command"]
     pub fn SCIPdialogExecDisplayCompression(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55329,6 +58120,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display conflict command"]
     pub fn SCIPdialogExecDisplayConflict(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55337,6 +58129,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display conshdlrs command"]
     pub fn SCIPdialogExecDisplayConshdlrs(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55345,6 +58138,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display displaycols command"]
     pub fn SCIPdialogExecDisplayDisplaycols(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55353,6 +58147,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display exprhdlrs command"]
     pub fn SCIPdialogExecDisplayExprhdlrs(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55361,6 +58156,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display cutselectors command"]
     pub fn SCIPdialogExecDisplayCutselectors(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55369,6 +58165,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display heuristics command"]
     pub fn SCIPdialogExecDisplayHeuristics(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55377,6 +58174,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display IIS command"]
     pub fn SCIPdialogExecDisplayIIS(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55385,6 +58183,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display memory command"]
     pub fn SCIPdialogExecDisplayMemory(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55393,6 +58192,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display nodeselectors command"]
     pub fn SCIPdialogExecDisplayNodeselectors(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55401,6 +58201,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display nlpi command"]
     pub fn SCIPdialogExecDisplayNlpi(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55409,6 +58210,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display parameters command"]
     pub fn SCIPdialogExecDisplayParameters(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55417,6 +58219,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display presolvers command"]
     pub fn SCIPdialogExecDisplayPresolvers(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55425,6 +58228,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display pricer command"]
     pub fn SCIPdialogExecDisplayPricers(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55433,6 +58237,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display problem command"]
     pub fn SCIPdialogExecDisplayProblem(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55441,6 +58246,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display propagators command"]
     pub fn SCIPdialogExecDisplayPropagators(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55449,6 +58255,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display readers command"]
     pub fn SCIPdialogExecDisplayReaders(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55457,6 +58264,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display relaxators command"]
     pub fn SCIPdialogExecDisplayRelaxators(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55465,6 +58273,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display separators command"]
     pub fn SCIPdialogExecDisplaySeparators(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55473,6 +58282,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display solution command"]
     pub fn SCIPdialogExecDisplaySolution(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55481,6 +58291,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display finitesolution command"]
     pub fn SCIPdialogExecDisplayFiniteSolution(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55489,6 +58300,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display dual solution command"]
     pub fn SCIPdialogExecDisplayDualSolution(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55497,6 +58309,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display of solutions in the pool command"]
     pub fn SCIPdialogExecDisplaySolutionPool(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55505,6 +58318,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display subproblem command"]
     pub fn SCIPdialogExecDisplaySubproblem(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55513,6 +58327,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display subsolution command"]
     pub fn SCIPdialogExecDisplaySubSolution(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55521,6 +58336,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display statistics command"]
     pub fn SCIPdialogExecDisplayStatistics(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55529,6 +58345,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display symmetry command"]
     pub fn SCIPdialogExecDisplaySymmetry(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55537,6 +58354,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display reoptstatistics command"]
     pub fn SCIPdialogExecDisplayReoptStatistics(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55545,6 +58363,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display transproblem command"]
     pub fn SCIPdialogExecDisplayTransproblem(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55553,6 +58372,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display value command"]
     pub fn SCIPdialogExecDisplayValue(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55561,6 +58381,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display varbranchstatistics command"]
     pub fn SCIPdialogExecDisplayVarbranchstatistics(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55569,6 +58390,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display LP solution quality command"]
     pub fn SCIPdialogExecDisplayLPSolutionQuality(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55577,6 +58399,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display transsolution command"]
     pub fn SCIPdialogExecDisplayTranssolution(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55585,6 +58408,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the help command"]
     pub fn SCIPdialogExecHelp(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55593,6 +58417,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the free command"]
     pub fn SCIPdialogExecFree(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55601,6 +58426,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the newstart command"]
     pub fn SCIPdialogExecNewstart(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55609,6 +58435,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the transform command"]
     pub fn SCIPdialogExecTransform(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55617,6 +58444,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the optimize command"]
     pub fn SCIPdialogExecOptimize(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55625,6 +58453,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the parallelopt command"]
     pub fn SCIPdialogExecConcurrentOpt(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55633,6 +58462,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the presolve command"]
     pub fn SCIPdialogExecPresolve(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55641,6 +58471,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the iis command"]
     pub fn SCIPdialogExecIIS(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55649,6 +58480,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the quit command"]
     pub fn SCIPdialogExecQuit(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55657,6 +58489,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the read command"]
     pub fn SCIPdialogExecRead(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55665,6 +58498,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set default command"]
     pub fn SCIPdialogExecSetDefault(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55673,6 +58507,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set load command"]
     pub fn SCIPdialogExecSetLoad(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55681,6 +58516,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set save command"]
     pub fn SCIPdialogExecSetSave(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55689,6 +58525,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set diffsave command"]
     pub fn SCIPdialogExecSetDiffsave(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55697,6 +58534,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set parameter command"]
     pub fn SCIPdialogExecSetParam(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55705,9 +58543,11 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog description method for the set parameter command"]
     pub fn SCIPdialogDescSetParam(scip: *mut SCIP, dialog: *mut SCIP_DIALOG) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the fix parameter command"]
     pub fn SCIPdialogExecFixParam(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55716,9 +58556,11 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog description method for the fix parameter command"]
     pub fn SCIPdialogDescFixParam(scip: *mut SCIP, dialog: *mut SCIP_DIALOG) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set branching direction command"]
     pub fn SCIPdialogExecSetBranchingDirection(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55727,6 +58569,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set branching priority command"]
     pub fn SCIPdialogExecSetBranchingPriority(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55735,6 +58578,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set heuristics aggressive command"]
     pub fn SCIPdialogExecSetHeuristicsAggressive(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55743,6 +58587,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set heuristics default command"]
     pub fn SCIPdialogExecSetHeuristicsDefault(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55751,6 +58596,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set heuristics fast command"]
     pub fn SCIPdialogExecSetHeuristicsFast(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55759,6 +58605,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set heuristics off command"]
     pub fn SCIPdialogExecSetHeuristicsOff(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55767,6 +58614,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set presolving aggressive command"]
     pub fn SCIPdialogExecSetPresolvingAggressive(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55775,6 +58623,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set presolving default command"]
     pub fn SCIPdialogExecSetPresolvingDefault(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55783,6 +58632,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set presolving fast command"]
     pub fn SCIPdialogExecSetPresolvingFast(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55791,6 +58641,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set presolving off command"]
     pub fn SCIPdialogExecSetPresolvingOff(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55799,6 +58650,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set separating aggressive command"]
     pub fn SCIPdialogExecSetSeparatingAggressive(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55807,6 +58659,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set separating default command"]
     pub fn SCIPdialogExecSetSeparatingDefault(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55815,6 +58668,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set separating fast command"]
     pub fn SCIPdialogExecSetSeparatingFast(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55823,6 +58677,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set separating off command"]
     pub fn SCIPdialogExecSetSeparatingOff(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55831,6 +58686,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set emphasis counter command"]
     pub fn SCIPdialogExecSetEmphasisCounter(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55839,6 +58695,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set emphasis cpsolver command"]
     pub fn SCIPdialogExecSetEmphasisCpsolver(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55847,6 +58704,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set emphasis easy CIP command"]
     pub fn SCIPdialogExecSetEmphasisEasycip(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55855,6 +58713,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set emphasis feasibility command"]
     pub fn SCIPdialogExecSetEmphasisFeasibility(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55863,6 +58722,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set emphasis hard LP command"]
     pub fn SCIPdialogExecSetEmphasisHardlp(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55871,6 +58731,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set emphasis optimality command"]
     pub fn SCIPdialogExecSetEmphasisOptimality(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55879,6 +58740,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set emphasis numerics command"]
     pub fn SCIPdialogExecSetEmphasisNumerics(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55887,6 +58749,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set emphasis benchmark command"]
     pub fn SCIPdialogExecSetEmphasisBenchmark(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55895,6 +58758,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set limits objective command"]
     pub fn SCIPdialogExecSetLimitsObjective(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55903,6 +58767,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for linear constraint type classification"]
     pub fn SCIPdialogExecDisplayLinearConsClassification(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -57242,6 +60107,7 @@ unsafe extern "C" {
     pub fn SCIPnlhdlrHasSollinearize(nlhdlr: *mut SCIP_NLHDLR) -> ::std::os::raw::c_uint;
 }
 unsafe extern "C" {
+    #[doc = " compares two nonlinear handlers by detection priority\n\n if handlers have same detection priority, then compare by name"]
     pub fn SCIPnlhdlrComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -58682,5 +61548,25 @@ unsafe extern "C" {
     #[doc = " includes default plugins into SCIP with respect to priorities"]
     pub fn SCIPincludeDefaultPlugins(scip: *mut SCIP) -> SCIP_RETCODE;
 }
-pub type __builtin_va_list = *mut ::std::os::raw::c_char;
-pub type __uint128_t = u128;
+pub type __builtin_va_list = [__va_list_tag; 1usize];
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __va_list_tag {
+    pub gp_offset: ::std::os::raw::c_uint,
+    pub fp_offset: ::std::os::raw::c_uint,
+    pub overflow_arg_area: *mut ::std::os::raw::c_void,
+    pub reg_save_area: *mut ::std::os::raw::c_void,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of __va_list_tag"][::std::mem::size_of::<__va_list_tag>() - 24usize];
+    ["Alignment of __va_list_tag"][::std::mem::align_of::<__va_list_tag>() - 8usize];
+    ["Offset of field: __va_list_tag::gp_offset"]
+        [::std::mem::offset_of!(__va_list_tag, gp_offset) - 0usize];
+    ["Offset of field: __va_list_tag::fp_offset"]
+        [::std::mem::offset_of!(__va_list_tag, fp_offset) - 4usize];
+    ["Offset of field: __va_list_tag::overflow_arg_area"]
+        [::std::mem::offset_of!(__va_list_tag, overflow_arg_area) - 8usize];
+    ["Offset of field: __va_list_tag::reg_save_area"]
+        [::std::mem::offset_of!(__va_list_tag, reg_save_area) - 16usize];
+};

--- a/src/bindings/windows.rs
+++ b/src/bindings/windows.rs
@@ -136,616 +136,268 @@ where
         }
     }
 }
-pub const __has_safe_buffers: u32 = 1;
-pub const __DARWIN_ONLY_64_BIT_INO_T: u32 = 1;
-pub const __DARWIN_ONLY_UNIX_CONFORMANCE: u32 = 1;
-pub const __DARWIN_ONLY_VERS_1050: u32 = 1;
-pub const __DARWIN_UNIX03: u32 = 1;
-pub const __DARWIN_64_BIT_INO_T: u32 = 1;
-pub const __DARWIN_VERS_1050: u32 = 1;
-pub const __DARWIN_NON_CANCELABLE: u32 = 0;
-pub const __DARWIN_SUF_EXTSN: &[u8; 14] = b"$DARWIN_EXTSN\0";
-pub const __DARWIN_C_ANSI: u32 = 4096;
-pub const __DARWIN_C_FULL: u32 = 900000;
-pub const __DARWIN_C_LEVEL: u32 = 900000;
-pub const __STDC_WANT_LIB_EXT1__: u32 = 1;
-pub const __DARWIN_NO_LONG_LONG: u32 = 0;
-pub const _DARWIN_FEATURE_64_BIT_INODE: u32 = 1;
-pub const _DARWIN_FEATURE_ONLY_64_BIT_INODE: u32 = 1;
-pub const _DARWIN_FEATURE_ONLY_VERS_1050: u32 = 1;
-pub const _DARWIN_FEATURE_ONLY_UNIX_CONFORMANCE: u32 = 1;
-pub const _DARWIN_FEATURE_UNIX_CONFORMANCE: u32 = 3;
-pub const __has_ptrcheck: u32 = 0;
-pub const __API_TO_BE_DEPRECATED: u32 = 100000;
-pub const __API_TO_BE_DEPRECATED_MACOS: u32 = 100000;
-pub const __API_TO_BE_DEPRECATED_IOS: u32 = 100000;
-pub const __API_TO_BE_DEPRECATED_MACCATALYST: u32 = 100000;
-pub const __API_TO_BE_DEPRECATED_WATCHOS: u32 = 100000;
-pub const __API_TO_BE_DEPRECATED_TVOS: u32 = 100000;
-pub const __API_TO_BE_DEPRECATED_DRIVERKIT: u32 = 100000;
-pub const __API_TO_BE_DEPRECATED_VISIONOS: u32 = 100000;
-pub const __MAC_10_0: u32 = 1000;
-pub const __MAC_10_1: u32 = 1010;
-pub const __MAC_10_2: u32 = 1020;
-pub const __MAC_10_3: u32 = 1030;
-pub const __MAC_10_4: u32 = 1040;
-pub const __MAC_10_5: u32 = 1050;
-pub const __MAC_10_6: u32 = 1060;
-pub const __MAC_10_7: u32 = 1070;
-pub const __MAC_10_8: u32 = 1080;
-pub const __MAC_10_9: u32 = 1090;
-pub const __MAC_10_10: u32 = 101000;
-pub const __MAC_10_10_2: u32 = 101002;
-pub const __MAC_10_10_3: u32 = 101003;
-pub const __MAC_10_11: u32 = 101100;
-pub const __MAC_10_11_2: u32 = 101102;
-pub const __MAC_10_11_3: u32 = 101103;
-pub const __MAC_10_11_4: u32 = 101104;
-pub const __MAC_10_12: u32 = 101200;
-pub const __MAC_10_12_1: u32 = 101201;
-pub const __MAC_10_12_2: u32 = 101202;
-pub const __MAC_10_12_4: u32 = 101204;
-pub const __MAC_10_13: u32 = 101300;
-pub const __MAC_10_13_1: u32 = 101301;
-pub const __MAC_10_13_2: u32 = 101302;
-pub const __MAC_10_13_4: u32 = 101304;
-pub const __MAC_10_14: u32 = 101400;
-pub const __MAC_10_14_1: u32 = 101401;
-pub const __MAC_10_14_4: u32 = 101404;
-pub const __MAC_10_14_5: u32 = 101405;
-pub const __MAC_10_14_6: u32 = 101406;
-pub const __MAC_10_15: u32 = 101500;
-pub const __MAC_10_15_1: u32 = 101501;
-pub const __MAC_10_15_4: u32 = 101504;
-pub const __MAC_10_16: u32 = 101600;
-pub const __MAC_11_0: u32 = 110000;
-pub const __MAC_11_1: u32 = 110100;
-pub const __MAC_11_3: u32 = 110300;
-pub const __MAC_11_4: u32 = 110400;
-pub const __MAC_11_5: u32 = 110500;
-pub const __MAC_11_6: u32 = 110600;
-pub const __MAC_12_0: u32 = 120000;
-pub const __MAC_12_1: u32 = 120100;
-pub const __MAC_12_2: u32 = 120200;
-pub const __MAC_12_3: u32 = 120300;
-pub const __MAC_12_4: u32 = 120400;
-pub const __MAC_12_5: u32 = 120500;
-pub const __MAC_12_6: u32 = 120600;
-pub const __MAC_12_7: u32 = 120700;
-pub const __MAC_13_0: u32 = 130000;
-pub const __MAC_13_1: u32 = 130100;
-pub const __MAC_13_2: u32 = 130200;
-pub const __MAC_13_3: u32 = 130300;
-pub const __MAC_13_4: u32 = 130400;
-pub const __MAC_13_5: u32 = 130500;
-pub const __MAC_13_6: u32 = 130600;
-pub const __MAC_14_0: u32 = 140000;
-pub const __MAC_14_1: u32 = 140100;
-pub const __MAC_14_2: u32 = 140200;
-pub const __MAC_14_3: u32 = 140300;
-pub const __MAC_14_4: u32 = 140400;
-pub const __MAC_14_5: u32 = 140500;
-pub const __IPHONE_2_0: u32 = 20000;
-pub const __IPHONE_2_1: u32 = 20100;
-pub const __IPHONE_2_2: u32 = 20200;
-pub const __IPHONE_3_0: u32 = 30000;
-pub const __IPHONE_3_1: u32 = 30100;
-pub const __IPHONE_3_2: u32 = 30200;
-pub const __IPHONE_4_0: u32 = 40000;
-pub const __IPHONE_4_1: u32 = 40100;
-pub const __IPHONE_4_2: u32 = 40200;
-pub const __IPHONE_4_3: u32 = 40300;
-pub const __IPHONE_5_0: u32 = 50000;
-pub const __IPHONE_5_1: u32 = 50100;
-pub const __IPHONE_6_0: u32 = 60000;
-pub const __IPHONE_6_1: u32 = 60100;
-pub const __IPHONE_7_0: u32 = 70000;
-pub const __IPHONE_7_1: u32 = 70100;
-pub const __IPHONE_8_0: u32 = 80000;
-pub const __IPHONE_8_1: u32 = 80100;
-pub const __IPHONE_8_2: u32 = 80200;
-pub const __IPHONE_8_3: u32 = 80300;
-pub const __IPHONE_8_4: u32 = 80400;
-pub const __IPHONE_9_0: u32 = 90000;
-pub const __IPHONE_9_1: u32 = 90100;
-pub const __IPHONE_9_2: u32 = 90200;
-pub const __IPHONE_9_3: u32 = 90300;
-pub const __IPHONE_10_0: u32 = 100000;
-pub const __IPHONE_10_1: u32 = 100100;
-pub const __IPHONE_10_2: u32 = 100200;
-pub const __IPHONE_10_3: u32 = 100300;
-pub const __IPHONE_11_0: u32 = 110000;
-pub const __IPHONE_11_1: u32 = 110100;
-pub const __IPHONE_11_2: u32 = 110200;
-pub const __IPHONE_11_3: u32 = 110300;
-pub const __IPHONE_11_4: u32 = 110400;
-pub const __IPHONE_12_0: u32 = 120000;
-pub const __IPHONE_12_1: u32 = 120100;
-pub const __IPHONE_12_2: u32 = 120200;
-pub const __IPHONE_12_3: u32 = 120300;
-pub const __IPHONE_12_4: u32 = 120400;
-pub const __IPHONE_13_0: u32 = 130000;
-pub const __IPHONE_13_1: u32 = 130100;
-pub const __IPHONE_13_2: u32 = 130200;
-pub const __IPHONE_13_3: u32 = 130300;
-pub const __IPHONE_13_4: u32 = 130400;
-pub const __IPHONE_13_5: u32 = 130500;
-pub const __IPHONE_13_6: u32 = 130600;
-pub const __IPHONE_13_7: u32 = 130700;
-pub const __IPHONE_14_0: u32 = 140000;
-pub const __IPHONE_14_1: u32 = 140100;
-pub const __IPHONE_14_2: u32 = 140200;
-pub const __IPHONE_14_3: u32 = 140300;
-pub const __IPHONE_14_5: u32 = 140500;
-pub const __IPHONE_14_4: u32 = 140400;
-pub const __IPHONE_14_6: u32 = 140600;
-pub const __IPHONE_14_7: u32 = 140700;
-pub const __IPHONE_14_8: u32 = 140800;
-pub const __IPHONE_15_0: u32 = 150000;
-pub const __IPHONE_15_1: u32 = 150100;
-pub const __IPHONE_15_2: u32 = 150200;
-pub const __IPHONE_15_3: u32 = 150300;
-pub const __IPHONE_15_4: u32 = 150400;
-pub const __IPHONE_15_5: u32 = 150500;
-pub const __IPHONE_15_6: u32 = 150600;
-pub const __IPHONE_15_7: u32 = 150700;
-pub const __IPHONE_15_8: u32 = 150800;
-pub const __IPHONE_16_0: u32 = 160000;
-pub const __IPHONE_16_1: u32 = 160100;
-pub const __IPHONE_16_2: u32 = 160200;
-pub const __IPHONE_16_3: u32 = 160300;
-pub const __IPHONE_16_4: u32 = 160400;
-pub const __IPHONE_16_5: u32 = 160500;
-pub const __IPHONE_16_6: u32 = 160600;
-pub const __IPHONE_16_7: u32 = 160700;
-pub const __IPHONE_17_0: u32 = 170000;
-pub const __IPHONE_17_1: u32 = 170100;
-pub const __IPHONE_17_2: u32 = 170200;
-pub const __IPHONE_17_3: u32 = 170300;
-pub const __IPHONE_17_4: u32 = 170400;
-pub const __IPHONE_17_5: u32 = 170500;
-pub const __WATCHOS_1_0: u32 = 10000;
-pub const __WATCHOS_2_0: u32 = 20000;
-pub const __WATCHOS_2_1: u32 = 20100;
-pub const __WATCHOS_2_2: u32 = 20200;
-pub const __WATCHOS_3_0: u32 = 30000;
-pub const __WATCHOS_3_1: u32 = 30100;
-pub const __WATCHOS_3_1_1: u32 = 30101;
-pub const __WATCHOS_3_2: u32 = 30200;
-pub const __WATCHOS_4_0: u32 = 40000;
-pub const __WATCHOS_4_1: u32 = 40100;
-pub const __WATCHOS_4_2: u32 = 40200;
-pub const __WATCHOS_4_3: u32 = 40300;
-pub const __WATCHOS_5_0: u32 = 50000;
-pub const __WATCHOS_5_1: u32 = 50100;
-pub const __WATCHOS_5_2: u32 = 50200;
-pub const __WATCHOS_5_3: u32 = 50300;
-pub const __WATCHOS_6_0: u32 = 60000;
-pub const __WATCHOS_6_1: u32 = 60100;
-pub const __WATCHOS_6_2: u32 = 60200;
-pub const __WATCHOS_7_0: u32 = 70000;
-pub const __WATCHOS_7_1: u32 = 70100;
-pub const __WATCHOS_7_2: u32 = 70200;
-pub const __WATCHOS_7_3: u32 = 70300;
-pub const __WATCHOS_7_4: u32 = 70400;
-pub const __WATCHOS_7_5: u32 = 70500;
-pub const __WATCHOS_7_6: u32 = 70600;
-pub const __WATCHOS_8_0: u32 = 80000;
-pub const __WATCHOS_8_1: u32 = 80100;
-pub const __WATCHOS_8_3: u32 = 80300;
-pub const __WATCHOS_8_4: u32 = 80400;
-pub const __WATCHOS_8_5: u32 = 80500;
-pub const __WATCHOS_8_6: u32 = 80600;
-pub const __WATCHOS_8_7: u32 = 80700;
-pub const __WATCHOS_8_8: u32 = 80800;
-pub const __WATCHOS_9_0: u32 = 90000;
-pub const __WATCHOS_9_1: u32 = 90100;
-pub const __WATCHOS_9_2: u32 = 90200;
-pub const __WATCHOS_9_3: u32 = 90300;
-pub const __WATCHOS_9_4: u32 = 90400;
-pub const __WATCHOS_9_5: u32 = 90500;
-pub const __WATCHOS_9_6: u32 = 90600;
-pub const __WATCHOS_10_0: u32 = 100000;
-pub const __WATCHOS_10_1: u32 = 100100;
-pub const __WATCHOS_10_2: u32 = 100200;
-pub const __WATCHOS_10_3: u32 = 100300;
-pub const __WATCHOS_10_4: u32 = 100400;
-pub const __WATCHOS_10_5: u32 = 100500;
-pub const __TVOS_9_0: u32 = 90000;
-pub const __TVOS_9_1: u32 = 90100;
-pub const __TVOS_9_2: u32 = 90200;
-pub const __TVOS_10_0: u32 = 100000;
-pub const __TVOS_10_0_1: u32 = 100001;
-pub const __TVOS_10_1: u32 = 100100;
-pub const __TVOS_10_2: u32 = 100200;
-pub const __TVOS_11_0: u32 = 110000;
-pub const __TVOS_11_1: u32 = 110100;
-pub const __TVOS_11_2: u32 = 110200;
-pub const __TVOS_11_3: u32 = 110300;
-pub const __TVOS_11_4: u32 = 110400;
-pub const __TVOS_12_0: u32 = 120000;
-pub const __TVOS_12_1: u32 = 120100;
-pub const __TVOS_12_2: u32 = 120200;
-pub const __TVOS_12_3: u32 = 120300;
-pub const __TVOS_12_4: u32 = 120400;
-pub const __TVOS_13_0: u32 = 130000;
-pub const __TVOS_13_2: u32 = 130200;
-pub const __TVOS_13_3: u32 = 130300;
-pub const __TVOS_13_4: u32 = 130400;
-pub const __TVOS_14_0: u32 = 140000;
-pub const __TVOS_14_1: u32 = 140100;
-pub const __TVOS_14_2: u32 = 140200;
-pub const __TVOS_14_3: u32 = 140300;
-pub const __TVOS_14_5: u32 = 140500;
-pub const __TVOS_14_6: u32 = 140600;
-pub const __TVOS_14_7: u32 = 140700;
-pub const __TVOS_15_0: u32 = 150000;
-pub const __TVOS_15_1: u32 = 150100;
-pub const __TVOS_15_2: u32 = 150200;
-pub const __TVOS_15_3: u32 = 150300;
-pub const __TVOS_15_4: u32 = 150400;
-pub const __TVOS_15_5: u32 = 150500;
-pub const __TVOS_15_6: u32 = 150600;
-pub const __TVOS_16_0: u32 = 160000;
-pub const __TVOS_16_1: u32 = 160100;
-pub const __TVOS_16_2: u32 = 160200;
-pub const __TVOS_16_3: u32 = 160300;
-pub const __TVOS_16_4: u32 = 160400;
-pub const __TVOS_16_5: u32 = 160500;
-pub const __TVOS_16_6: u32 = 160600;
-pub const __TVOS_17_0: u32 = 170000;
-pub const __TVOS_17_1: u32 = 170100;
-pub const __TVOS_17_2: u32 = 170200;
-pub const __TVOS_17_3: u32 = 170300;
-pub const __TVOS_17_4: u32 = 170400;
-pub const __TVOS_17_5: u32 = 170500;
-pub const __BRIDGEOS_2_0: u32 = 20000;
-pub const __BRIDGEOS_3_0: u32 = 30000;
-pub const __BRIDGEOS_3_1: u32 = 30100;
-pub const __BRIDGEOS_3_4: u32 = 30400;
-pub const __BRIDGEOS_4_0: u32 = 40000;
-pub const __BRIDGEOS_4_1: u32 = 40100;
-pub const __BRIDGEOS_5_0: u32 = 50000;
-pub const __BRIDGEOS_5_1: u32 = 50100;
-pub const __BRIDGEOS_5_3: u32 = 50300;
-pub const __BRIDGEOS_6_0: u32 = 60000;
-pub const __BRIDGEOS_6_2: u32 = 60200;
-pub const __BRIDGEOS_6_4: u32 = 60400;
-pub const __BRIDGEOS_6_5: u32 = 60500;
-pub const __BRIDGEOS_6_6: u32 = 60600;
-pub const __BRIDGEOS_7_0: u32 = 70000;
-pub const __BRIDGEOS_7_1: u32 = 70100;
-pub const __BRIDGEOS_7_2: u32 = 70200;
-pub const __BRIDGEOS_7_3: u32 = 70300;
-pub const __BRIDGEOS_7_4: u32 = 70400;
-pub const __BRIDGEOS_7_6: u32 = 70600;
-pub const __BRIDGEOS_8_0: u32 = 80000;
-pub const __BRIDGEOS_8_1: u32 = 80100;
-pub const __BRIDGEOS_8_2: u32 = 80200;
-pub const __BRIDGEOS_8_3: u32 = 80300;
-pub const __BRIDGEOS_8_4: u32 = 80400;
-pub const __BRIDGEOS_8_5: u32 = 80500;
-pub const __DRIVERKIT_19_0: u32 = 190000;
-pub const __DRIVERKIT_20_0: u32 = 200000;
-pub const __DRIVERKIT_21_0: u32 = 210000;
-pub const __DRIVERKIT_22_0: u32 = 220000;
-pub const __DRIVERKIT_22_4: u32 = 220400;
-pub const __DRIVERKIT_22_5: u32 = 220500;
-pub const __DRIVERKIT_22_6: u32 = 220600;
-pub const __DRIVERKIT_23_0: u32 = 230000;
-pub const __DRIVERKIT_23_1: u32 = 230100;
-pub const __DRIVERKIT_23_2: u32 = 230200;
-pub const __DRIVERKIT_23_3: u32 = 230300;
-pub const __DRIVERKIT_23_4: u32 = 230400;
-pub const __DRIVERKIT_23_5: u32 = 230500;
-pub const __VISIONOS_1_0: u32 = 10000;
-pub const __VISIONOS_1_1: u32 = 10100;
-pub const __VISIONOS_1_2: u32 = 10200;
-pub const MAC_OS_X_VERSION_10_0: u32 = 1000;
-pub const MAC_OS_X_VERSION_10_1: u32 = 1010;
-pub const MAC_OS_X_VERSION_10_2: u32 = 1020;
-pub const MAC_OS_X_VERSION_10_3: u32 = 1030;
-pub const MAC_OS_X_VERSION_10_4: u32 = 1040;
-pub const MAC_OS_X_VERSION_10_5: u32 = 1050;
-pub const MAC_OS_X_VERSION_10_6: u32 = 1060;
-pub const MAC_OS_X_VERSION_10_7: u32 = 1070;
-pub const MAC_OS_X_VERSION_10_8: u32 = 1080;
-pub const MAC_OS_X_VERSION_10_9: u32 = 1090;
-pub const MAC_OS_X_VERSION_10_10: u32 = 101000;
-pub const MAC_OS_X_VERSION_10_10_2: u32 = 101002;
-pub const MAC_OS_X_VERSION_10_10_3: u32 = 101003;
-pub const MAC_OS_X_VERSION_10_11: u32 = 101100;
-pub const MAC_OS_X_VERSION_10_11_2: u32 = 101102;
-pub const MAC_OS_X_VERSION_10_11_3: u32 = 101103;
-pub const MAC_OS_X_VERSION_10_11_4: u32 = 101104;
-pub const MAC_OS_X_VERSION_10_12: u32 = 101200;
-pub const MAC_OS_X_VERSION_10_12_1: u32 = 101201;
-pub const MAC_OS_X_VERSION_10_12_2: u32 = 101202;
-pub const MAC_OS_X_VERSION_10_12_4: u32 = 101204;
-pub const MAC_OS_X_VERSION_10_13: u32 = 101300;
-pub const MAC_OS_X_VERSION_10_13_1: u32 = 101301;
-pub const MAC_OS_X_VERSION_10_13_2: u32 = 101302;
-pub const MAC_OS_X_VERSION_10_13_4: u32 = 101304;
-pub const MAC_OS_X_VERSION_10_14: u32 = 101400;
-pub const MAC_OS_X_VERSION_10_14_1: u32 = 101401;
-pub const MAC_OS_X_VERSION_10_14_4: u32 = 101404;
-pub const MAC_OS_X_VERSION_10_14_5: u32 = 101405;
-pub const MAC_OS_X_VERSION_10_14_6: u32 = 101406;
-pub const MAC_OS_X_VERSION_10_15: u32 = 101500;
-pub const MAC_OS_X_VERSION_10_15_1: u32 = 101501;
-pub const MAC_OS_X_VERSION_10_15_4: u32 = 101504;
-pub const MAC_OS_X_VERSION_10_16: u32 = 101600;
-pub const MAC_OS_VERSION_11_0: u32 = 110000;
-pub const MAC_OS_VERSION_11_1: u32 = 110100;
-pub const MAC_OS_VERSION_11_3: u32 = 110300;
-pub const MAC_OS_VERSION_11_4: u32 = 110400;
-pub const MAC_OS_VERSION_11_5: u32 = 110500;
-pub const MAC_OS_VERSION_11_6: u32 = 110600;
-pub const MAC_OS_VERSION_12_0: u32 = 120000;
-pub const MAC_OS_VERSION_12_1: u32 = 120100;
-pub const MAC_OS_VERSION_12_2: u32 = 120200;
-pub const MAC_OS_VERSION_12_3: u32 = 120300;
-pub const MAC_OS_VERSION_12_4: u32 = 120400;
-pub const MAC_OS_VERSION_12_5: u32 = 120500;
-pub const MAC_OS_VERSION_12_6: u32 = 120600;
-pub const MAC_OS_VERSION_12_7: u32 = 120700;
-pub const MAC_OS_VERSION_13_0: u32 = 130000;
-pub const MAC_OS_VERSION_13_1: u32 = 130100;
-pub const MAC_OS_VERSION_13_2: u32 = 130200;
-pub const MAC_OS_VERSION_13_3: u32 = 130300;
-pub const MAC_OS_VERSION_13_4: u32 = 130400;
-pub const MAC_OS_VERSION_13_5: u32 = 130500;
-pub const MAC_OS_VERSION_13_6: u32 = 130600;
-pub const MAC_OS_VERSION_14_0: u32 = 140000;
-pub const MAC_OS_VERSION_14_1: u32 = 140100;
-pub const MAC_OS_VERSION_14_2: u32 = 140200;
-pub const MAC_OS_VERSION_14_3: u32 = 140300;
-pub const MAC_OS_VERSION_14_4: u32 = 140400;
-pub const MAC_OS_VERSION_14_5: u32 = 140500;
-pub const __MAC_OS_X_VERSION_MAX_ALLOWED: u32 = 140500;
-pub const __ENABLE_LEGACY_MAC_AVAILABILITY: u32 = 1;
-pub const __PTHREAD_SIZE__: u32 = 8176;
-pub const __PTHREAD_ATTR_SIZE__: u32 = 56;
-pub const __PTHREAD_MUTEXATTR_SIZE__: u32 = 8;
-pub const __PTHREAD_MUTEX_SIZE__: u32 = 56;
-pub const __PTHREAD_CONDATTR_SIZE__: u32 = 8;
-pub const __PTHREAD_COND_SIZE__: u32 = 40;
-pub const __PTHREAD_ONCE_SIZE__: u32 = 8;
-pub const __PTHREAD_RWLOCK_SIZE__: u32 = 192;
-pub const __PTHREAD_RWLOCKATTR_SIZE__: u32 = 16;
-pub const __DARWIN_WCHAR_MIN: i32 = -2147483648;
-pub const _FORTIFY_SOURCE: u32 = 2;
-pub const RENAME_SECLUDE: u32 = 1;
-pub const RENAME_SWAP: u32 = 2;
-pub const RENAME_EXCL: u32 = 4;
-pub const RENAME_RESERVED1: u32 = 8;
-pub const RENAME_NOFOLLOW_ANY: u32 = 16;
-pub const SEEK_SET: u32 = 0;
+pub const _VCRT_COMPILER_PREPROCESSOR: u32 = 1;
+pub const _SAL_VERSION: u32 = 20;
+pub const __SAL_H_VERSION: u32 = 180000000;
+pub const _USE_DECLSPECS_FOR_SAL: u32 = 0;
+pub const _USE_ATTRIBUTES_FOR_SAL: u32 = 0;
+pub const _CRT_PACKING: u32 = 8;
+pub const _HAS_EXCEPTIONS: u32 = 1;
+pub const _STL_LANG: u32 = 0;
+pub const _HAS_CXX17: u32 = 0;
+pub const _HAS_CXX20: u32 = 0;
+pub const _HAS_CXX23: u32 = 0;
+pub const _HAS_CXX26: u32 = 0;
+pub const _ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE: u32 = 1;
+pub const _CRT_BUILD_DESKTOP_APP: u32 = 1;
+pub const _ARGMAX: u32 = 100;
+pub const _CRT_INT_MAX: u32 = 2147483647;
+pub const _CRT_FUNCTIONS_REQUIRED: u32 = 1;
+pub const _CRT_HAS_CXX17: u32 = 0;
+pub const _CRT_HAS_C11: u32 = 1;
+pub const _CRT_INTERNAL_NONSTDC_NAMES: u32 = 1;
+pub const __STDC_SECURE_LIB__: u32 = 200411;
+pub const __GOT_SECURE_LIB__: u32 = 200411;
+pub const __STDC_WANT_SECURE_LIB__: u32 = 1;
+pub const _SECURECRT_FILL_BUFFER_PATTERN: u32 = 254;
+pub const _CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES: u32 = 0;
+pub const _CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_COUNT: u32 = 0;
+pub const _CRT_SECURE_CPP_OVERLOAD_SECURE_NAMES: u32 = 1;
+pub const _CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES_MEMORY: u32 = 0;
+pub const _CRT_SECURE_CPP_OVERLOAD_SECURE_NAMES_MEMORY: u32 = 0;
+pub const _STATIC_INLINE_UCRT_FUNCTIONS: u32 = 0;
+pub const _CRT_INTERNAL_STDIO_SYMBOL_PREFIX: &[u8; 1] = b"\0";
+pub const _CRT_INTERNAL_PRINTF_LEGACY_VSPRINTF_NULL_TERMINATION: u32 = 1;
+pub const _CRT_INTERNAL_PRINTF_STANDARD_SNPRINTF_BEHAVIOR: u32 = 2;
+pub const _CRT_INTERNAL_PRINTF_LEGACY_WIDE_SPECIFIERS: u32 = 4;
+pub const _CRT_INTERNAL_PRINTF_LEGACY_MSVCRT_COMPATIBILITY: u32 = 8;
+pub const _CRT_INTERNAL_PRINTF_LEGACY_THREE_DIGIT_EXPONENTS: u32 = 16;
+pub const _CRT_INTERNAL_PRINTF_STANDARD_ROUNDING: u32 = 32;
+pub const _CRT_INTERNAL_SCANF_SECURECRT: u32 = 1;
+pub const _CRT_INTERNAL_SCANF_LEGACY_WIDE_SPECIFIERS: u32 = 2;
+pub const _CRT_INTERNAL_SCANF_LEGACY_MSVCRT_COMPATIBILITY: u32 = 4;
+pub const BUFSIZ: u32 = 512;
+pub const _NSTREAM_: u32 = 512;
+pub const _IOB_ENTRIES: u32 = 3;
+pub const EOF: i32 = -1;
+pub const _IOFBF: u32 = 0;
+pub const _IOLBF: u32 = 64;
+pub const _IONBF: u32 = 4;
+pub const L_tmpnam: u32 = 260;
+pub const L_tmpnam_s: u32 = 260;
 pub const SEEK_CUR: u32 = 1;
 pub const SEEK_END: u32 = 2;
-pub const SEEK_HOLE: u32 = 3;
-pub const SEEK_DATA: u32 = 4;
-pub const __SLBF: u32 = 1;
-pub const __SNBF: u32 = 2;
-pub const __SRD: u32 = 4;
-pub const __SWR: u32 = 8;
-pub const __SRW: u32 = 16;
-pub const __SEOF: u32 = 32;
-pub const __SERR: u32 = 64;
-pub const __SMBF: u32 = 128;
-pub const __SAPP: u32 = 256;
-pub const __SSTR: u32 = 512;
-pub const __SOPT: u32 = 1024;
-pub const __SNPT: u32 = 2048;
-pub const __SOFF: u32 = 4096;
-pub const __SMOD: u32 = 8192;
-pub const __SALC: u32 = 16384;
-pub const __SIGN: u32 = 32768;
-pub const _IOFBF: u32 = 0;
-pub const _IOLBF: u32 = 1;
-pub const _IONBF: u32 = 2;
-pub const BUFSIZ: u32 = 1024;
-pub const EOF: i32 = -1;
+pub const SEEK_SET: u32 = 0;
+pub const FILENAME_MAX: u32 = 260;
 pub const FOPEN_MAX: u32 = 20;
-pub const FILENAME_MAX: u32 = 1024;
-pub const P_tmpdir: &[u8; 10] = b"/var/tmp/\0";
-pub const L_tmpnam: u32 = 1024;
-pub const TMP_MAX: u32 = 308915776;
-pub const L_ctermid: u32 = 1024;
-pub const _USE_FORTIFY_LEVEL: u32 = 2;
-pub const __WORDSIZE: u32 = 64;
-pub const INT8_MAX: u32 = 127;
-pub const INT16_MAX: u32 = 32767;
-pub const INT32_MAX: u32 = 2147483647;
-pub const INT64_MAX: u64 = 9223372036854775807;
-pub const INT8_MIN: i32 = -128;
-pub const INT16_MIN: i32 = -32768;
-pub const INT32_MIN: i32 = -2147483648;
-pub const INT64_MIN: i64 = -9223372036854775808;
-pub const UINT8_MAX: u32 = 255;
-pub const UINT16_MAX: u32 = 65535;
-pub const UINT32_MAX: u32 = 4294967295;
-pub const UINT64_MAX: i32 = -1;
-pub const INT_LEAST8_MIN: i32 = -128;
-pub const INT_LEAST16_MIN: i32 = -32768;
-pub const INT_LEAST32_MIN: i32 = -2147483648;
-pub const INT_LEAST64_MIN: i64 = -9223372036854775808;
-pub const INT_LEAST8_MAX: u32 = 127;
-pub const INT_LEAST16_MAX: u32 = 32767;
-pub const INT_LEAST32_MAX: u32 = 2147483647;
-pub const INT_LEAST64_MAX: u64 = 9223372036854775807;
-pub const UINT_LEAST8_MAX: u32 = 255;
-pub const UINT_LEAST16_MAX: u32 = 65535;
-pub const UINT_LEAST32_MAX: u32 = 4294967295;
-pub const UINT_LEAST64_MAX: i32 = -1;
-pub const INT_FAST8_MIN: i32 = -128;
-pub const INT_FAST16_MIN: i32 = -32768;
-pub const INT_FAST32_MIN: i32 = -2147483648;
-pub const INT_FAST64_MIN: i64 = -9223372036854775808;
-pub const INT_FAST8_MAX: u32 = 127;
-pub const INT_FAST16_MAX: u32 = 32767;
-pub const INT_FAST32_MAX: u32 = 2147483647;
-pub const INT_FAST64_MAX: u64 = 9223372036854775807;
-pub const UINT_FAST8_MAX: u32 = 255;
-pub const UINT_FAST16_MAX: u32 = 65535;
-pub const UINT_FAST32_MAX: u32 = 4294967295;
-pub const UINT_FAST64_MAX: i32 = -1;
-pub const INTPTR_MAX: u64 = 9223372036854775807;
-pub const INTPTR_MIN: i64 = -9223372036854775808;
-pub const UINTPTR_MAX: i32 = -1;
-pub const SIZE_MAX: i32 = -1;
-pub const RSIZE_MAX: i32 = -1;
-pub const WINT_MIN: i32 = -2147483648;
-pub const WINT_MAX: u32 = 2147483647;
-pub const SIG_ATOMIC_MIN: i32 = -2147483648;
-pub const SIG_ATOMIC_MAX: u32 = 2147483647;
-pub const FP_SUPERNORMAL: u32 = 6;
-pub const FP_FAST_FMA: u32 = 1;
-pub const FP_FAST_FMAF: u32 = 1;
-pub const FP_FAST_FMAL: u32 = 1;
+pub const _SYS_OPEN: u32 = 20;
+pub const TMP_MAX: u32 = 2147483647;
+pub const TMP_MAX_S: u32 = 2147483647;
+pub const _TMP_MAX_S: u32 = 2147483647;
+pub const SYS_OPEN: u32 = 20;
+pub const WCHAR_MIN: u32 = 0;
+pub const WCHAR_MAX: u32 = 65535;
+pub const WINT_MIN: u32 = 0;
+pub const WINT_MAX: u32 = 65535;
+pub const _DOMAIN: u32 = 1;
+pub const _SING: u32 = 2;
+pub const _OVERFLOW: u32 = 3;
+pub const _UNDERFLOW: u32 = 4;
+pub const _TLOSS: u32 = 5;
+pub const _PLOSS: u32 = 6;
+pub const _HUGE_ENUF : f64 = 1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000.0 ;
+pub const _DENORM: i32 = -2;
+pub const _FINITE: i32 = -1;
+pub const _INFCODE: u32 = 1;
+pub const _NANCODE: u32 = 2;
+pub const _C2: u32 = 1;
 pub const FP_ILOGB0: i32 = -2147483648;
-pub const FP_ILOGBNAN: i32 = -2147483648;
+pub const FP_ILOGBNAN: u32 = 2147483647;
 pub const MATH_ERRNO: u32 = 1;
 pub const MATH_ERREXCEPT: u32 = 2;
-pub const M_E: f64 = 2.718281828459045;
-pub const M_LOG2E: f64 = 1.4426950408889634;
-pub const M_LOG10E: f64 = 0.4342944819032518;
-pub const M_LN2: f64 = 0.6931471805599453;
-pub const M_LN10: f64 = 2.302585092994046;
-pub const M_PI: f64 = 3.141592653589793;
-pub const M_PI_2: f64 = 1.5707963267948966;
-pub const M_PI_4: f64 = 0.7853981633974483;
-pub const M_1_PI: f64 = 0.3183098861837907;
-pub const M_2_PI: f64 = 0.6366197723675814;
-pub const M_2_SQRTPI: f64 = 1.1283791670955126;
-pub const M_SQRT2: f64 = 1.4142135623730951;
-pub const M_SQRT1_2: f64 = 0.7071067811865476;
-pub const FP_SNAN: u32 = 1;
-pub const FP_QNAN: u32 = 1;
+pub const math_errhandling: u32 = 3;
+pub const _FE_DIVBYZERO: u32 = 4;
+pub const _FE_INEXACT: u32 = 32;
+pub const _FE_INVALID: u32 = 1;
+pub const _FE_OVERFLOW: u32 = 8;
+pub const _FE_UNDERFLOW: u32 = 16;
+pub const _D0_C: u32 = 3;
+pub const _D1_C: u32 = 2;
+pub const _D2_C: u32 = 1;
+pub const _D3_C: u32 = 0;
+pub const _DBIAS: u32 = 1022;
+pub const _DOFF: u32 = 4;
+pub const _F0_C: u32 = 1;
+pub const _F1_C: u32 = 0;
+pub const _FBIAS: u32 = 126;
+pub const _FOFF: u32 = 7;
+pub const _FRND: u32 = 1;
+pub const _L0_C: u32 = 3;
+pub const _L1_C: u32 = 2;
+pub const _L2_C: u32 = 1;
+pub const _L3_C: u32 = 0;
+pub const _LBIAS: u32 = 1022;
+pub const _LOFF: u32 = 4;
+pub const _FP_LT: u32 = 1;
+pub const _FP_EQ: u32 = 2;
+pub const _FP_GT: u32 = 4;
 pub const DOMAIN: u32 = 1;
 pub const SING: u32 = 2;
 pub const OVERFLOW: u32 = 3;
 pub const UNDERFLOW: u32 = 4;
 pub const TLOSS: u32 = 5;
 pub const PLOSS: u32 = 6;
-pub const __DARWIN_CLK_TCK: u32 = 100;
-pub const MB_LEN_MAX: u32 = 6;
-pub const CLK_TCK: u32 = 100;
 pub const CHAR_BIT: u32 = 8;
-pub const SCHAR_MAX: u32 = 127;
 pub const SCHAR_MIN: i32 = -128;
+pub const SCHAR_MAX: u32 = 127;
 pub const UCHAR_MAX: u32 = 255;
-pub const CHAR_MAX: u32 = 127;
 pub const CHAR_MIN: i32 = -128;
-pub const USHRT_MAX: u32 = 65535;
-pub const SHRT_MAX: u32 = 32767;
+pub const CHAR_MAX: u32 = 127;
+pub const MB_LEN_MAX: u32 = 5;
 pub const SHRT_MIN: i32 = -32768;
-pub const UINT_MAX: u32 = 4294967295;
-pub const INT_MAX: u32 = 2147483647;
+pub const SHRT_MAX: u32 = 32767;
+pub const USHRT_MAX: u32 = 65535;
 pub const INT_MIN: i32 = -2147483648;
-pub const ULONG_MAX: i32 = -1;
-pub const LONG_MAX: u64 = 9223372036854775807;
-pub const LONG_MIN: i64 = -9223372036854775808;
-pub const ULLONG_MAX: i32 = -1;
-pub const LLONG_MAX: u64 = 9223372036854775807;
-pub const LLONG_MIN: i64 = -9223372036854775808;
-pub const LONG_BIT: u32 = 64;
-pub const SSIZE_MAX: u64 = 9223372036854775807;
-pub const WORD_BIT: u32 = 32;
-pub const SIZE_T_MAX: i32 = -1;
-pub const UQUAD_MAX: i32 = -1;
-pub const QUAD_MAX: u64 = 9223372036854775807;
-pub const QUAD_MIN: i64 = -9223372036854775808;
-pub const ARG_MAX: u32 = 1048576;
-pub const CHILD_MAX: u32 = 266;
-pub const GID_MAX: u32 = 2147483647;
-pub const LINK_MAX: u32 = 32767;
-pub const MAX_CANON: u32 = 1024;
-pub const MAX_INPUT: u32 = 1024;
-pub const NAME_MAX: u32 = 255;
-pub const NGROUPS_MAX: u32 = 16;
-pub const UID_MAX: u32 = 2147483647;
-pub const OPEN_MAX: u32 = 10240;
-pub const PATH_MAX: u32 = 1024;
-pub const PIPE_BUF: u32 = 512;
-pub const BC_BASE_MAX: u32 = 99;
-pub const BC_DIM_MAX: u32 = 2048;
-pub const BC_SCALE_MAX: u32 = 99;
-pub const BC_STRING_MAX: u32 = 1000;
-pub const CHARCLASS_NAME_MAX: u32 = 14;
-pub const COLL_WEIGHTS_MAX: u32 = 2;
-pub const EQUIV_CLASS_MAX: u32 = 2;
-pub const EXPR_NEST_MAX: u32 = 32;
-pub const LINE_MAX: u32 = 2048;
-pub const RE_DUP_MAX: u32 = 255;
-pub const NZERO: u32 = 20;
-pub const _POSIX_ARG_MAX: u32 = 4096;
-pub const _POSIX_CHILD_MAX: u32 = 25;
-pub const _POSIX_LINK_MAX: u32 = 8;
-pub const _POSIX_MAX_CANON: u32 = 255;
-pub const _POSIX_MAX_INPUT: u32 = 255;
-pub const _POSIX_NAME_MAX: u32 = 14;
-pub const _POSIX_NGROUPS_MAX: u32 = 8;
-pub const _POSIX_OPEN_MAX: u32 = 20;
-pub const _POSIX_PATH_MAX: u32 = 256;
-pub const _POSIX_PIPE_BUF: u32 = 512;
-pub const _POSIX_SSIZE_MAX: u32 = 32767;
-pub const _POSIX_STREAM_MAX: u32 = 8;
-pub const _POSIX_TZNAME_MAX: u32 = 6;
-pub const _POSIX2_BC_BASE_MAX: u32 = 99;
-pub const _POSIX2_BC_DIM_MAX: u32 = 2048;
-pub const _POSIX2_BC_SCALE_MAX: u32 = 99;
-pub const _POSIX2_BC_STRING_MAX: u32 = 1000;
-pub const _POSIX2_EQUIV_CLASS_MAX: u32 = 2;
-pub const _POSIX2_EXPR_NEST_MAX: u32 = 32;
-pub const _POSIX2_LINE_MAX: u32 = 2048;
-pub const _POSIX2_RE_DUP_MAX: u32 = 255;
-pub const _POSIX_AIO_LISTIO_MAX: u32 = 2;
-pub const _POSIX_AIO_MAX: u32 = 1;
-pub const _POSIX_DELAYTIMER_MAX: u32 = 32;
-pub const _POSIX_MQ_OPEN_MAX: u32 = 8;
-pub const _POSIX_MQ_PRIO_MAX: u32 = 32;
-pub const _POSIX_RTSIG_MAX: u32 = 8;
-pub const _POSIX_SEM_NSEMS_MAX: u32 = 256;
-pub const _POSIX_SEM_VALUE_MAX: u32 = 32767;
-pub const _POSIX_SIGQUEUE_MAX: u32 = 32;
-pub const _POSIX_TIMER_MAX: u32 = 32;
-pub const _POSIX_CLOCKRES_MIN: u32 = 20000000;
-pub const _POSIX_THREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
-pub const _POSIX_THREAD_KEYS_MAX: u32 = 128;
-pub const _POSIX_THREAD_THREADS_MAX: u32 = 64;
-pub const PTHREAD_DESTRUCTOR_ITERATIONS: u32 = 4;
-pub const PTHREAD_KEYS_MAX: u32 = 512;
-pub const PTHREAD_STACK_MIN: u32 = 16384;
-pub const _POSIX_HOST_NAME_MAX: u32 = 255;
-pub const _POSIX_LOGIN_NAME_MAX: u32 = 9;
-pub const _POSIX_SS_REPL_MAX: u32 = 4;
-pub const _POSIX_SYMLINK_MAX: u32 = 255;
-pub const _POSIX_SYMLOOP_MAX: u32 = 8;
-pub const _POSIX_TRACE_EVENT_NAME_MAX: u32 = 30;
-pub const _POSIX_TRACE_NAME_MAX: u32 = 8;
-pub const _POSIX_TRACE_SYS_MAX: u32 = 8;
-pub const _POSIX_TRACE_USER_EVENT_MAX: u32 = 32;
-pub const _POSIX_TTY_NAME_MAX: u32 = 9;
-pub const _POSIX2_CHARCLASS_NAME_MAX: u32 = 14;
-pub const _POSIX2_COLL_WEIGHTS_MAX: u32 = 2;
-pub const _POSIX_RE_DUP_MAX: u32 = 255;
-pub const OFF_MIN: i64 = -9223372036854775808;
-pub const OFF_MAX: u64 = 9223372036854775807;
-pub const PASS_MAX: u32 = 128;
-pub const NL_ARGMAX: u32 = 9;
-pub const NL_LANGMAX: u32 = 14;
-pub const NL_MSGMAX: u32 = 32767;
-pub const NL_NMAX: u32 = 1;
-pub const NL_SETMAX: u32 = 255;
-pub const NL_TEXTMAX: u32 = 2048;
-pub const _XOPEN_IOV_MAX: u32 = 16;
-pub const IOV_MAX: u32 = 1024;
-pub const _XOPEN_NAME_MAX: u32 = 255;
-pub const _XOPEN_PATH_MAX: u32 = 1024;
-pub const FLT_HAS_SUBNORM: u32 = 1;
+pub const INT_MAX: u32 = 2147483647;
+pub const UINT_MAX: u32 = 4294967295;
+pub const LONG_MIN: i32 = -2147483648;
+pub const LONG_MAX: u32 = 2147483647;
+pub const ULONG_MAX: u32 = 4294967295;
+pub const FLT_EVAL_METHOD: u32 = 0;
+pub const DBL_DECIMAL_DIG: u32 = 17;
+pub const DBL_DIG: u32 = 15;
 pub const DBL_HAS_SUBNORM: u32 = 1;
+pub const DBL_MANT_DIG: u32 = 53;
+pub const DBL_MAX_10_EXP: u32 = 308;
+pub const DBL_MAX_EXP: u32 = 1024;
+pub const DBL_MIN_10_EXP: i32 = -307;
+pub const DBL_MIN_EXP: i32 = -1021;
+pub const _DBL_RADIX: u32 = 2;
+pub const FLT_DECIMAL_DIG: u32 = 9;
+pub const FLT_DIG: u32 = 6;
+pub const FLT_HAS_SUBNORM: u32 = 1;
+pub const FLT_GUARD: u32 = 0;
+pub const FLT_MANT_DIG: u32 = 24;
+pub const FLT_MAX_10_EXP: u32 = 38;
+pub const FLT_MAX_EXP: u32 = 128;
+pub const FLT_MIN_10_EXP: i32 = -37;
+pub const FLT_MIN_EXP: i32 = -125;
+pub const FLT_NORMALIZE: u32 = 0;
+pub const FLT_RADIX: u32 = 2;
+pub const LDBL_DIG: u32 = 15;
 pub const LDBL_HAS_SUBNORM: u32 = 1;
+pub const LDBL_MANT_DIG: u32 = 53;
+pub const LDBL_MAX_10_EXP: u32 = 308;
+pub const LDBL_MAX_EXP: u32 = 1024;
+pub const LDBL_MIN_10_EXP: i32 = -307;
+pub const LDBL_MIN_EXP: i32 = -1021;
+pub const _LDBL_RADIX: u32 = 2;
+pub const DECIMAL_DIG: u32 = 17;
+pub const _SW_INEXACT: u32 = 1;
+pub const _SW_UNDERFLOW: u32 = 2;
+pub const _SW_OVERFLOW: u32 = 4;
+pub const _SW_ZERODIVIDE: u32 = 8;
+pub const _SW_INVALID: u32 = 16;
+pub const _SW_DENORMAL: u32 = 524288;
+pub const _EM_AMBIGUIOUS: u32 = 2147483648;
+pub const _EM_AMBIGUOUS: u32 = 2147483648;
+pub const _MCW_EM: u32 = 524319;
+pub const _EM_INEXACT: u32 = 1;
+pub const _EM_UNDERFLOW: u32 = 2;
+pub const _EM_OVERFLOW: u32 = 4;
+pub const _EM_ZERODIVIDE: u32 = 8;
+pub const _EM_INVALID: u32 = 16;
+pub const _EM_DENORMAL: u32 = 524288;
+pub const _MCW_RC: u32 = 768;
+pub const _RC_NEAR: u32 = 0;
+pub const _RC_DOWN: u32 = 256;
+pub const _RC_UP: u32 = 512;
+pub const _RC_CHOP: u32 = 768;
+pub const _MCW_PC: u32 = 196608;
+pub const _PC_64: u32 = 0;
+pub const _PC_53: u32 = 65536;
+pub const _PC_24: u32 = 131072;
+pub const _MCW_IC: u32 = 262144;
+pub const _IC_AFFINE: u32 = 262144;
+pub const _IC_PROJECTIVE: u32 = 0;
+pub const _MCW_DN: u32 = 50331648;
+pub const _DN_SAVE: u32 = 0;
+pub const _DN_FLUSH: u32 = 16777216;
+pub const _DN_FLUSH_OPERANDS_SAVE_RESULTS: u32 = 33554432;
+pub const _DN_SAVE_OPERANDS_FLUSH_RESULTS: u32 = 50331648;
+pub const _SW_UNEMULATED: u32 = 64;
+pub const _SW_SQRTNEG: u32 = 128;
+pub const _SW_STACKOVERFLOW: u32 = 512;
+pub const _SW_STACKUNDERFLOW: u32 = 1024;
+pub const _FPE_INVALID: u32 = 129;
+pub const _FPE_DENORMAL: u32 = 130;
+pub const _FPE_ZERODIVIDE: u32 = 131;
+pub const _FPE_OVERFLOW: u32 = 132;
+pub const _FPE_UNDERFLOW: u32 = 133;
+pub const _FPE_INEXACT: u32 = 134;
+pub const _FPE_UNEMULATED: u32 = 135;
+pub const _FPE_SQRTNEG: u32 = 136;
+pub const _FPE_STACKOVERFLOW: u32 = 138;
+pub const _FPE_STACKUNDERFLOW: u32 = 139;
+pub const _FPE_EXPLICITGEN: u32 = 140;
+pub const _FPE_MULTIPLE_TRAPS: u32 = 141;
+pub const _FPE_MULTIPLE_FAULTS: u32 = 142;
+pub const _FPCLASS_SNAN: u32 = 1;
+pub const _FPCLASS_QNAN: u32 = 2;
+pub const _FPCLASS_NINF: u32 = 4;
+pub const _FPCLASS_NN: u32 = 8;
+pub const _FPCLASS_ND: u32 = 16;
+pub const _FPCLASS_NZ: u32 = 32;
+pub const _FPCLASS_PZ: u32 = 64;
+pub const _FPCLASS_PD: u32 = 128;
+pub const _FPCLASS_PN: u32 = 256;
+pub const _FPCLASS_PINF: u32 = 512;
+pub const _CW_DEFAULT: u32 = 524319;
+pub const DBL_RADIX: u32 = 2;
+pub const LDBL_RADIX: u32 = 2;
+pub const EM_AMBIGUIOUS: u32 = 2147483648;
+pub const EM_AMBIGUOUS: u32 = 2147483648;
+pub const MCW_EM: u32 = 524319;
+pub const EM_INVALID: u32 = 16;
+pub const EM_DENORMAL: u32 = 524288;
+pub const EM_ZERODIVIDE: u32 = 8;
+pub const EM_OVERFLOW: u32 = 4;
+pub const EM_UNDERFLOW: u32 = 2;
+pub const EM_INEXACT: u32 = 1;
+pub const MCW_IC: u32 = 262144;
+pub const IC_AFFINE: u32 = 262144;
+pub const IC_PROJECTIVE: u32 = 0;
+pub const MCW_RC: u32 = 768;
+pub const RC_CHOP: u32 = 768;
+pub const RC_UP: u32 = 512;
+pub const RC_DOWN: u32 = 256;
+pub const RC_NEAR: u32 = 0;
+pub const MCW_PC: u32 = 196608;
+pub const PC_24: u32 = 131072;
+pub const PC_53: u32 = 65536;
+pub const PC_64: u32 = 0;
+pub const CW_DEFAULT: u32 = 524319;
+pub const SW_INVALID: u32 = 16;
+pub const SW_DENORMAL: u32 = 524288;
+pub const SW_ZERODIVIDE: u32 = 8;
+pub const SW_OVERFLOW: u32 = 4;
+pub const SW_UNDERFLOW: u32 = 2;
+pub const SW_INEXACT: u32 = 1;
+pub const SW_UNEMULATED: u32 = 64;
+pub const SW_SQRTNEG: u32 = 128;
+pub const SW_STACKOVERFLOW: u32 = 512;
+pub const SW_STACKUNDERFLOW: u32 = 1024;
+pub const FPE_INVALID: u32 = 129;
+pub const FPE_DENORMAL: u32 = 130;
+pub const FPE_ZERODIVIDE: u32 = 131;
+pub const FPE_OVERFLOW: u32 = 132;
+pub const FPE_UNDERFLOW: u32 = 133;
+pub const FPE_INEXACT: u32 = 134;
+pub const FPE_UNEMULATED: u32 = 135;
+pub const FPE_SQRTNEG: u32 = 136;
+pub const FPE_STACKOVERFLOW: u32 = 138;
+pub const FPE_STACKUNDERFLOW: u32 = 139;
+pub const FPE_EXPLICITGEN: u32 = 140;
 pub const SCIP_BUILD_TYPE: &[u8; 8] = b"Release\0";
 pub const SCIP_VERSION_MAJOR: u32 = 10;
 pub const SCIP_VERSION_MINOR: u32 = 0;
@@ -759,9 +411,7 @@ pub const SCIP_VERSION_SUB: u32 = 0;
 pub const SCIP_SUBVERSION: u32 = 0;
 pub const SCIP_APIVERSION: u32 = 156;
 pub const SCIP_COPYRIGHT: &[u8; 52] = b"Copyright (c) 2002-2026 Zuse Institute Berlin (ZIB)\0";
-pub const SCIP_LONGINT_MAX: u64 = 9223372036854775807;
-pub const SCIP_LONGINT_MIN: i64 = -9223372036854775808;
-pub const SCIP_LONGINT_FORMAT: &[u8; 4] = b"lld\0";
+pub const SCIP_LONGINT_FORMAT: &[u8; 5] = b"I64d\0";
 pub const SCIP_REAL_UNITROUNDOFF: f64 = 0.00000000000000011102230246251565;
 pub const SCIP_REAL_FORMAT: &[u8; 3] = b"lf\0";
 pub const SCIP_DEFAULT_INFINITY: f64 = 100000000000000000000.0;
@@ -782,7 +432,6 @@ pub const SCIP_MINEPSILON: f64 = 0.00000000000000000001;
 pub const SCIP_INVALID : f64 = 1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000.0 ;
 pub const SCIP_MAXSTRLEN: u32 = 1024;
 pub const SCIP_SPACECONTROL: &[u8; 7] = b" tnvfr\0";
-pub const SCIP_MAXMEMSIZE: u32 = 0;
 pub const SCIP_HASHSIZE_PARAMS: u32 = 2048;
 pub const SCIP_HASHSIZE_NAMES: u32 = 500;
 pub const SCIP_HASHSIZE_CUTPOOLS: u32 = 500;
@@ -795,221 +444,42 @@ pub const SCIP_DEFAULT_MEM_ARRAYGROWFAC: f64 = 1.2;
 pub const SCIP_DEFAULT_MEM_ARRAYGROWINIT: u32 = 4;
 pub const SCIP_MAXTREEDEPTH: u32 = 1073741822;
 pub const SCIP_PROBINGSCORE_PENALTYRATIO: u32 = 2;
-pub const __DARWIN_NSIG: u32 = 32;
-pub const NSIG: u32 = 32;
-pub const _ARM_SIGNAL_: u32 = 1;
-pub const SIGHUP: u32 = 1;
-pub const SIGINT: u32 = 2;
-pub const SIGQUIT: u32 = 3;
-pub const SIGILL: u32 = 4;
-pub const SIGTRAP: u32 = 5;
-pub const SIGABRT: u32 = 6;
-pub const SIGIOT: u32 = 6;
-pub const SIGEMT: u32 = 7;
-pub const SIGFPE: u32 = 8;
-pub const SIGKILL: u32 = 9;
-pub const SIGBUS: u32 = 10;
-pub const SIGSEGV: u32 = 11;
-pub const SIGSYS: u32 = 12;
-pub const SIGPIPE: u32 = 13;
-pub const SIGALRM: u32 = 14;
-pub const SIGTERM: u32 = 15;
-pub const SIGURG: u32 = 16;
-pub const SIGSTOP: u32 = 17;
-pub const SIGTSTP: u32 = 18;
-pub const SIGCONT: u32 = 19;
-pub const SIGCHLD: u32 = 20;
-pub const SIGTTIN: u32 = 21;
-pub const SIGTTOU: u32 = 22;
-pub const SIGIO: u32 = 23;
-pub const SIGXCPU: u32 = 24;
-pub const SIGXFSZ: u32 = 25;
-pub const SIGVTALRM: u32 = 26;
-pub const SIGPROF: u32 = 27;
-pub const SIGWINCH: u32 = 28;
-pub const SIGINFO: u32 = 29;
-pub const SIGUSR1: u32 = 30;
-pub const SIGUSR2: u32 = 31;
-pub const __DARWIN_OPAQUE_ARM_THREAD_STATE64: u32 = 0;
-pub const SIGEV_NONE: u32 = 0;
-pub const SIGEV_SIGNAL: u32 = 1;
-pub const SIGEV_THREAD: u32 = 3;
-pub const ILL_NOOP: u32 = 0;
-pub const ILL_ILLOPC: u32 = 1;
-pub const ILL_ILLTRP: u32 = 2;
-pub const ILL_PRVOPC: u32 = 3;
-pub const ILL_ILLOPN: u32 = 4;
-pub const ILL_ILLADR: u32 = 5;
-pub const ILL_PRVREG: u32 = 6;
-pub const ILL_COPROC: u32 = 7;
-pub const ILL_BADSTK: u32 = 8;
-pub const FPE_NOOP: u32 = 0;
-pub const FPE_FLTDIV: u32 = 1;
-pub const FPE_FLTOVF: u32 = 2;
-pub const FPE_FLTUND: u32 = 3;
-pub const FPE_FLTRES: u32 = 4;
-pub const FPE_FLTINV: u32 = 5;
-pub const FPE_FLTSUB: u32 = 6;
-pub const FPE_INTDIV: u32 = 7;
-pub const FPE_INTOVF: u32 = 8;
-pub const SEGV_NOOP: u32 = 0;
-pub const SEGV_MAPERR: u32 = 1;
-pub const SEGV_ACCERR: u32 = 2;
-pub const BUS_NOOP: u32 = 0;
-pub const BUS_ADRALN: u32 = 1;
-pub const BUS_ADRERR: u32 = 2;
-pub const BUS_OBJERR: u32 = 3;
-pub const TRAP_BRKPT: u32 = 1;
-pub const TRAP_TRACE: u32 = 2;
-pub const CLD_NOOP: u32 = 0;
-pub const CLD_EXITED: u32 = 1;
-pub const CLD_KILLED: u32 = 2;
-pub const CLD_DUMPED: u32 = 3;
-pub const CLD_TRAPPED: u32 = 4;
-pub const CLD_STOPPED: u32 = 5;
-pub const CLD_CONTINUED: u32 = 6;
-pub const POLL_IN: u32 = 1;
-pub const POLL_OUT: u32 = 2;
-pub const POLL_MSG: u32 = 3;
-pub const POLL_ERR: u32 = 4;
-pub const POLL_PRI: u32 = 5;
-pub const POLL_HUP: u32 = 6;
-pub const SA_ONSTACK: u32 = 1;
-pub const SA_RESTART: u32 = 2;
-pub const SA_RESETHAND: u32 = 4;
-pub const SA_NOCLDSTOP: u32 = 8;
-pub const SA_NODEFER: u32 = 16;
-pub const SA_NOCLDWAIT: u32 = 32;
-pub const SA_SIGINFO: u32 = 64;
-pub const SA_USERTRAMP: u32 = 256;
-pub const SA_64REGSET: u32 = 512;
-pub const SA_USERSPACE_MASK: u32 = 127;
-pub const SIG_BLOCK: u32 = 1;
-pub const SIG_UNBLOCK: u32 = 2;
-pub const SIG_SETMASK: u32 = 3;
-pub const SI_USER: u32 = 65537;
-pub const SI_QUEUE: u32 = 65538;
-pub const SI_TIMER: u32 = 65539;
-pub const SI_ASYNCIO: u32 = 65540;
-pub const SI_MESGQ: u32 = 65541;
-pub const SS_ONSTACK: u32 = 1;
-pub const SS_DISABLE: u32 = 4;
-pub const MINSIGSTKSZ: u32 = 32768;
-pub const SIGSTKSZ: u32 = 131072;
-pub const SV_ONSTACK: u32 = 1;
-pub const SV_INTERRUPT: u32 = 2;
-pub const SV_RESETHAND: u32 = 4;
-pub const SV_NODEFER: u32 = 16;
-pub const SV_NOCLDSTOP: u32 = 8;
-pub const SV_SIGINFO: u32 = 64;
-pub const PRIO_PROCESS: u32 = 0;
-pub const PRIO_PGRP: u32 = 1;
-pub const PRIO_USER: u32 = 2;
-pub const PRIO_DARWIN_THREAD: u32 = 3;
-pub const PRIO_DARWIN_PROCESS: u32 = 4;
-pub const PRIO_MIN: i32 = -20;
-pub const PRIO_MAX: u32 = 20;
-pub const PRIO_DARWIN_BG: u32 = 4096;
-pub const PRIO_DARWIN_NONUI: u32 = 4097;
-pub const RUSAGE_SELF: u32 = 0;
-pub const RUSAGE_CHILDREN: i32 = -1;
-pub const RUSAGE_INFO_V0: u32 = 0;
-pub const RUSAGE_INFO_V1: u32 = 1;
-pub const RUSAGE_INFO_V2: u32 = 2;
-pub const RUSAGE_INFO_V3: u32 = 3;
-pub const RUSAGE_INFO_V4: u32 = 4;
-pub const RUSAGE_INFO_V5: u32 = 5;
-pub const RUSAGE_INFO_V6: u32 = 6;
-pub const RUSAGE_INFO_CURRENT: u32 = 6;
-pub const RU_PROC_RUNS_RESLIDE: u32 = 1;
-pub const RLIMIT_CPU: u32 = 0;
-pub const RLIMIT_FSIZE: u32 = 1;
-pub const RLIMIT_DATA: u32 = 2;
-pub const RLIMIT_STACK: u32 = 3;
-pub const RLIMIT_CORE: u32 = 4;
-pub const RLIMIT_AS: u32 = 5;
-pub const RLIMIT_RSS: u32 = 5;
-pub const RLIMIT_MEMLOCK: u32 = 6;
-pub const RLIMIT_NPROC: u32 = 7;
-pub const RLIMIT_NOFILE: u32 = 8;
-pub const RLIM_NLIMITS: u32 = 9;
-pub const _RLIMIT_POSIX_FLAG: u32 = 4096;
-pub const RLIMIT_WAKEUPS_MONITOR: u32 = 1;
-pub const RLIMIT_CPU_USAGE_MONITOR: u32 = 2;
-pub const RLIMIT_THREAD_CPULIMITS: u32 = 3;
-pub const RLIMIT_FOOTPRINT_INTERVAL: u32 = 4;
-pub const WAKEMON_ENABLE: u32 = 1;
-pub const WAKEMON_DISABLE: u32 = 2;
-pub const WAKEMON_GET_PARAMS: u32 = 4;
-pub const WAKEMON_SET_DEFAULTS: u32 = 8;
-pub const WAKEMON_MAKE_FATAL: u32 = 16;
-pub const CPUMON_MAKE_FATAL: u32 = 4096;
-pub const FOOTPRINT_INTERVAL_RESET: u32 = 1;
-pub const IOPOL_TYPE_DISK: u32 = 0;
-pub const IOPOL_TYPE_VFS_ATIME_UPDATES: u32 = 2;
-pub const IOPOL_TYPE_VFS_MATERIALIZE_DATALESS_FILES: u32 = 3;
-pub const IOPOL_TYPE_VFS_STATFS_NO_DATA_VOLUME: u32 = 4;
-pub const IOPOL_TYPE_VFS_TRIGGER_RESOLVE: u32 = 5;
-pub const IOPOL_TYPE_VFS_IGNORE_CONTENT_PROTECTION: u32 = 6;
-pub const IOPOL_TYPE_VFS_IGNORE_PERMISSIONS: u32 = 7;
-pub const IOPOL_TYPE_VFS_SKIP_MTIME_UPDATE: u32 = 8;
-pub const IOPOL_TYPE_VFS_ALLOW_LOW_SPACE_WRITES: u32 = 9;
-pub const IOPOL_TYPE_VFS_DISALLOW_RW_FOR_O_EVTONLY: u32 = 10;
-pub const IOPOL_SCOPE_PROCESS: u32 = 0;
-pub const IOPOL_SCOPE_THREAD: u32 = 1;
-pub const IOPOL_SCOPE_DARWIN_BG: u32 = 2;
-pub const IOPOL_DEFAULT: u32 = 0;
-pub const IOPOL_IMPORTANT: u32 = 1;
-pub const IOPOL_PASSIVE: u32 = 2;
-pub const IOPOL_THROTTLE: u32 = 3;
-pub const IOPOL_UTILITY: u32 = 4;
-pub const IOPOL_STANDARD: u32 = 5;
-pub const IOPOL_APPLICATION: u32 = 5;
-pub const IOPOL_NORMAL: u32 = 1;
-pub const IOPOL_ATIME_UPDATES_DEFAULT: u32 = 0;
-pub const IOPOL_ATIME_UPDATES_OFF: u32 = 1;
-pub const IOPOL_MATERIALIZE_DATALESS_FILES_DEFAULT: u32 = 0;
-pub const IOPOL_MATERIALIZE_DATALESS_FILES_OFF: u32 = 1;
-pub const IOPOL_MATERIALIZE_DATALESS_FILES_ON: u32 = 2;
-pub const IOPOL_VFS_STATFS_NO_DATA_VOLUME_DEFAULT: u32 = 0;
-pub const IOPOL_VFS_STATFS_FORCE_NO_DATA_VOLUME: u32 = 1;
-pub const IOPOL_VFS_TRIGGER_RESOLVE_DEFAULT: u32 = 0;
-pub const IOPOL_VFS_TRIGGER_RESOLVE_OFF: u32 = 1;
-pub const IOPOL_VFS_CONTENT_PROTECTION_DEFAULT: u32 = 0;
-pub const IOPOL_VFS_CONTENT_PROTECTION_IGNORE: u32 = 1;
-pub const IOPOL_VFS_IGNORE_PERMISSIONS_OFF: u32 = 0;
-pub const IOPOL_VFS_IGNORE_PERMISSIONS_ON: u32 = 1;
-pub const IOPOL_VFS_SKIP_MTIME_UPDATE_OFF: u32 = 0;
-pub const IOPOL_VFS_SKIP_MTIME_UPDATE_ON: u32 = 1;
-pub const IOPOL_VFS_ALLOW_LOW_SPACE_WRITES_OFF: u32 = 0;
-pub const IOPOL_VFS_ALLOW_LOW_SPACE_WRITES_ON: u32 = 1;
-pub const IOPOL_VFS_DISALLOW_RW_FOR_O_EVTONLY_DEFAULT: u32 = 0;
-pub const IOPOL_VFS_DISALLOW_RW_FOR_O_EVTONLY_ON: u32 = 1;
-pub const IOPOL_VFS_NOCACHE_WRITE_FS_BLKSIZE_DEFAULT: u32 = 0;
-pub const IOPOL_VFS_NOCACHE_WRITE_FS_BLKSIZE_ON: u32 = 1;
-pub const WNOHANG: u32 = 1;
-pub const WUNTRACED: u32 = 2;
-pub const WCOREFLAG: u32 = 128;
-pub const _WSTOPPED: u32 = 127;
-pub const WEXITED: u32 = 4;
-pub const WSTOPPED: u32 = 8;
-pub const WCONTINUED: u32 = 16;
-pub const WNOWAIT: u32 = 32;
-pub const WAIT_ANY: i32 = -1;
-pub const WAIT_MYPGRP: u32 = 0;
-pub const _QUAD_HIGHWORD: u32 = 1;
-pub const _QUAD_LOWWORD: u32 = 0;
-pub const __DARWIN_LITTLE_ENDIAN: u32 = 1234;
-pub const __DARWIN_BIG_ENDIAN: u32 = 4321;
-pub const __DARWIN_PDP_ENDIAN: u32 = 3412;
-pub const __DARWIN_BYTE_ORDER: u32 = 1234;
-pub const LITTLE_ENDIAN: u32 = 1234;
-pub const BIG_ENDIAN: u32 = 4321;
-pub const PDP_ENDIAN: u32 = 3412;
-pub const BYTE_ORDER: u32 = 1234;
-pub const EXIT_FAILURE: u32 = 1;
+pub const _MAX_ITOSTR_BASE16_COUNT: u32 = 9;
+pub const _MAX_ITOSTR_BASE10_COUNT: u32 = 12;
+pub const _MAX_ITOSTR_BASE8_COUNT: u32 = 12;
+pub const _MAX_ITOSTR_BASE2_COUNT: u32 = 33;
+pub const _MAX_LTOSTR_BASE16_COUNT: u32 = 9;
+pub const _MAX_LTOSTR_BASE10_COUNT: u32 = 12;
+pub const _MAX_LTOSTR_BASE8_COUNT: u32 = 12;
+pub const _MAX_LTOSTR_BASE2_COUNT: u32 = 33;
+pub const _MAX_ULTOSTR_BASE16_COUNT: u32 = 9;
+pub const _MAX_ULTOSTR_BASE10_COUNT: u32 = 11;
+pub const _MAX_ULTOSTR_BASE8_COUNT: u32 = 12;
+pub const _MAX_ULTOSTR_BASE2_COUNT: u32 = 33;
+pub const _MAX_I64TOSTR_BASE16_COUNT: u32 = 17;
+pub const _MAX_I64TOSTR_BASE10_COUNT: u32 = 21;
+pub const _MAX_I64TOSTR_BASE8_COUNT: u32 = 23;
+pub const _MAX_I64TOSTR_BASE2_COUNT: u32 = 65;
+pub const _MAX_U64TOSTR_BASE16_COUNT: u32 = 17;
+pub const _MAX_U64TOSTR_BASE10_COUNT: u32 = 21;
+pub const _MAX_U64TOSTR_BASE8_COUNT: u32 = 23;
+pub const _MAX_U64TOSTR_BASE2_COUNT: u32 = 65;
 pub const EXIT_SUCCESS: u32 = 0;
-pub const RAND_MAX: u32 = 2147483647;
+pub const EXIT_FAILURE: u32 = 1;
+pub const _WRITE_ABORT_MSG: u32 = 1;
+pub const _CALL_REPORTFAULT: u32 = 2;
+pub const _OUT_TO_DEFAULT: u32 = 0;
+pub const _OUT_TO_STDERR: u32 = 1;
+pub const _OUT_TO_MSGBOX: u32 = 2;
+pub const _REPORT_ERRMODE: u32 = 3;
+pub const RAND_MAX: u32 = 32767;
+pub const _CVTBUFSIZE: u32 = 349;
+pub const _MAX_PATH: u32 = 260;
+pub const _MAX_DRIVE: u32 = 3;
+pub const _MAX_DIR: u32 = 256;
+pub const _MAX_FNAME: u32 = 256;
+pub const _MAX_EXT: u32 = 256;
+pub const _MAX_ENV: u32 = 32767;
 pub const SCIP_PRESOLTIMING_NONE: u32 = 2;
 pub const SCIP_PRESOLTIMING_FAST: u32 = 4;
 pub const SCIP_PRESOLTIMING_MEDIUM: u32 = 8;
@@ -1037,165 +507,160 @@ pub const SCIP_HEURTIMING_DURINGPRESOLLOOP: u32 = 512;
 pub const SCIP_HEURTIMING_AFTERPROPLOOP: u32 = 1024;
 pub const SCIP_HEURTIMING_AFTERNODE: u32 = 24;
 pub const SCIP_HEURTIMING_AFTERPLUNGE: u32 = 96;
-pub const __PRI_8_LENGTH_MODIFIER__: &[u8; 3] = b"hh\0";
-pub const __PRI_64_LENGTH_MODIFIER__: &[u8; 3] = b"ll\0";
-pub const __SCN_64_LENGTH_MODIFIER__: &[u8; 3] = b"ll\0";
-pub const __PRI_MAX_LENGTH_MODIFIER__: &[u8; 2] = b"j\0";
-pub const __SCN_MAX_LENGTH_MODIFIER__: &[u8; 2] = b"j\0";
 pub const PRId8: &[u8; 4] = b"hhd\0";
-pub const PRIi8: &[u8; 4] = b"hhi\0";
-pub const PRIo8: &[u8; 4] = b"hho\0";
-pub const PRIu8: &[u8; 4] = b"hhu\0";
-pub const PRIx8: &[u8; 4] = b"hhx\0";
-pub const PRIX8: &[u8; 4] = b"hhX\0";
 pub const PRId16: &[u8; 3] = b"hd\0";
-pub const PRIi16: &[u8; 3] = b"hi\0";
-pub const PRIo16: &[u8; 3] = b"ho\0";
-pub const PRIu16: &[u8; 3] = b"hu\0";
-pub const PRIx16: &[u8; 3] = b"hx\0";
-pub const PRIX16: &[u8; 3] = b"hX\0";
 pub const PRId32: &[u8; 2] = b"d\0";
-pub const PRIi32: &[u8; 2] = b"i\0";
-pub const PRIo32: &[u8; 2] = b"o\0";
-pub const PRIu32: &[u8; 2] = b"u\0";
-pub const PRIx32: &[u8; 2] = b"x\0";
-pub const PRIX32: &[u8; 2] = b"X\0";
 pub const PRId64: &[u8; 4] = b"lld\0";
-pub const PRIi64: &[u8; 4] = b"lli\0";
-pub const PRIo64: &[u8; 4] = b"llo\0";
-pub const PRIu64: &[u8; 4] = b"llu\0";
-pub const PRIx64: &[u8; 4] = b"llx\0";
-pub const PRIX64: &[u8; 4] = b"llX\0";
 pub const PRIdLEAST8: &[u8; 4] = b"hhd\0";
-pub const PRIiLEAST8: &[u8; 4] = b"hhi\0";
-pub const PRIoLEAST8: &[u8; 4] = b"hho\0";
-pub const PRIuLEAST8: &[u8; 4] = b"hhu\0";
-pub const PRIxLEAST8: &[u8; 4] = b"hhx\0";
-pub const PRIXLEAST8: &[u8; 4] = b"hhX\0";
 pub const PRIdLEAST16: &[u8; 3] = b"hd\0";
-pub const PRIiLEAST16: &[u8; 3] = b"hi\0";
-pub const PRIoLEAST16: &[u8; 3] = b"ho\0";
-pub const PRIuLEAST16: &[u8; 3] = b"hu\0";
-pub const PRIxLEAST16: &[u8; 3] = b"hx\0";
-pub const PRIXLEAST16: &[u8; 3] = b"hX\0";
 pub const PRIdLEAST32: &[u8; 2] = b"d\0";
-pub const PRIiLEAST32: &[u8; 2] = b"i\0";
-pub const PRIoLEAST32: &[u8; 2] = b"o\0";
-pub const PRIuLEAST32: &[u8; 2] = b"u\0";
-pub const PRIxLEAST32: &[u8; 2] = b"x\0";
-pub const PRIXLEAST32: &[u8; 2] = b"X\0";
 pub const PRIdLEAST64: &[u8; 4] = b"lld\0";
-pub const PRIiLEAST64: &[u8; 4] = b"lli\0";
-pub const PRIoLEAST64: &[u8; 4] = b"llo\0";
-pub const PRIuLEAST64: &[u8; 4] = b"llu\0";
-pub const PRIxLEAST64: &[u8; 4] = b"llx\0";
-pub const PRIXLEAST64: &[u8; 4] = b"llX\0";
 pub const PRIdFAST8: &[u8; 4] = b"hhd\0";
-pub const PRIiFAST8: &[u8; 4] = b"hhi\0";
-pub const PRIoFAST8: &[u8; 4] = b"hho\0";
-pub const PRIuFAST8: &[u8; 4] = b"hhu\0";
-pub const PRIxFAST8: &[u8; 4] = b"hhx\0";
-pub const PRIXFAST8: &[u8; 4] = b"hhX\0";
-pub const PRIdFAST16: &[u8; 3] = b"hd\0";
-pub const PRIiFAST16: &[u8; 3] = b"hi\0";
-pub const PRIoFAST16: &[u8; 3] = b"ho\0";
-pub const PRIuFAST16: &[u8; 3] = b"hu\0";
-pub const PRIxFAST16: &[u8; 3] = b"hx\0";
-pub const PRIXFAST16: &[u8; 3] = b"hX\0";
+pub const PRIdFAST16: &[u8; 2] = b"d\0";
 pub const PRIdFAST32: &[u8; 2] = b"d\0";
-pub const PRIiFAST32: &[u8; 2] = b"i\0";
-pub const PRIoFAST32: &[u8; 2] = b"o\0";
-pub const PRIuFAST32: &[u8; 2] = b"u\0";
-pub const PRIxFAST32: &[u8; 2] = b"x\0";
-pub const PRIXFAST32: &[u8; 2] = b"X\0";
 pub const PRIdFAST64: &[u8; 4] = b"lld\0";
+pub const PRIdMAX: &[u8; 4] = b"lld\0";
+pub const PRIdPTR: &[u8; 4] = b"lld\0";
+pub const PRIi8: &[u8; 4] = b"hhi\0";
+pub const PRIi16: &[u8; 3] = b"hi\0";
+pub const PRIi32: &[u8; 2] = b"i\0";
+pub const PRIi64: &[u8; 4] = b"lli\0";
+pub const PRIiLEAST8: &[u8; 4] = b"hhi\0";
+pub const PRIiLEAST16: &[u8; 3] = b"hi\0";
+pub const PRIiLEAST32: &[u8; 2] = b"i\0";
+pub const PRIiLEAST64: &[u8; 4] = b"lli\0";
+pub const PRIiFAST8: &[u8; 4] = b"hhi\0";
+pub const PRIiFAST16: &[u8; 2] = b"i\0";
+pub const PRIiFAST32: &[u8; 2] = b"i\0";
 pub const PRIiFAST64: &[u8; 4] = b"lli\0";
+pub const PRIiMAX: &[u8; 4] = b"lli\0";
+pub const PRIiPTR: &[u8; 4] = b"lli\0";
+pub const PRIo8: &[u8; 4] = b"hho\0";
+pub const PRIo16: &[u8; 3] = b"ho\0";
+pub const PRIo32: &[u8; 2] = b"o\0";
+pub const PRIo64: &[u8; 4] = b"llo\0";
+pub const PRIoLEAST8: &[u8; 4] = b"hho\0";
+pub const PRIoLEAST16: &[u8; 3] = b"ho\0";
+pub const PRIoLEAST32: &[u8; 2] = b"o\0";
+pub const PRIoLEAST64: &[u8; 4] = b"llo\0";
+pub const PRIoFAST8: &[u8; 4] = b"hho\0";
+pub const PRIoFAST16: &[u8; 2] = b"o\0";
+pub const PRIoFAST32: &[u8; 2] = b"o\0";
 pub const PRIoFAST64: &[u8; 4] = b"llo\0";
+pub const PRIoMAX: &[u8; 4] = b"llo\0";
+pub const PRIoPTR: &[u8; 4] = b"llo\0";
+pub const PRIu8: &[u8; 4] = b"hhu\0";
+pub const PRIu16: &[u8; 3] = b"hu\0";
+pub const PRIu32: &[u8; 2] = b"u\0";
+pub const PRIu64: &[u8; 4] = b"llu\0";
+pub const PRIuLEAST8: &[u8; 4] = b"hhu\0";
+pub const PRIuLEAST16: &[u8; 3] = b"hu\0";
+pub const PRIuLEAST32: &[u8; 2] = b"u\0";
+pub const PRIuLEAST64: &[u8; 4] = b"llu\0";
+pub const PRIuFAST8: &[u8; 4] = b"hhu\0";
+pub const PRIuFAST16: &[u8; 2] = b"u\0";
+pub const PRIuFAST32: &[u8; 2] = b"u\0";
 pub const PRIuFAST64: &[u8; 4] = b"llu\0";
+pub const PRIuMAX: &[u8; 4] = b"llu\0";
+pub const PRIuPTR: &[u8; 4] = b"llu\0";
+pub const PRIx8: &[u8; 4] = b"hhx\0";
+pub const PRIx16: &[u8; 3] = b"hx\0";
+pub const PRIx32: &[u8; 2] = b"x\0";
+pub const PRIx64: &[u8; 4] = b"llx\0";
+pub const PRIxLEAST8: &[u8; 4] = b"hhx\0";
+pub const PRIxLEAST16: &[u8; 3] = b"hx\0";
+pub const PRIxLEAST32: &[u8; 2] = b"x\0";
+pub const PRIxLEAST64: &[u8; 4] = b"llx\0";
+pub const PRIxFAST8: &[u8; 4] = b"hhx\0";
+pub const PRIxFAST16: &[u8; 2] = b"x\0";
+pub const PRIxFAST32: &[u8; 2] = b"x\0";
 pub const PRIxFAST64: &[u8; 4] = b"llx\0";
+pub const PRIxMAX: &[u8; 4] = b"llx\0";
+pub const PRIxPTR: &[u8; 4] = b"llx\0";
+pub const PRIX8: &[u8; 4] = b"hhX\0";
+pub const PRIX16: &[u8; 3] = b"hX\0";
+pub const PRIX32: &[u8; 2] = b"X\0";
+pub const PRIX64: &[u8; 4] = b"llX\0";
+pub const PRIXLEAST8: &[u8; 4] = b"hhX\0";
+pub const PRIXLEAST16: &[u8; 3] = b"hX\0";
+pub const PRIXLEAST32: &[u8; 2] = b"X\0";
+pub const PRIXLEAST64: &[u8; 4] = b"llX\0";
+pub const PRIXFAST8: &[u8; 4] = b"hhX\0";
+pub const PRIXFAST16: &[u8; 2] = b"X\0";
+pub const PRIXFAST32: &[u8; 2] = b"X\0";
 pub const PRIXFAST64: &[u8; 4] = b"llX\0";
-pub const PRIdPTR: &[u8; 3] = b"ld\0";
-pub const PRIiPTR: &[u8; 3] = b"li\0";
-pub const PRIoPTR: &[u8; 3] = b"lo\0";
-pub const PRIuPTR: &[u8; 3] = b"lu\0";
-pub const PRIxPTR: &[u8; 3] = b"lx\0";
-pub const PRIXPTR: &[u8; 3] = b"lX\0";
-pub const PRIdMAX: &[u8; 3] = b"jd\0";
-pub const PRIiMAX: &[u8; 3] = b"ji\0";
-pub const PRIoMAX: &[u8; 3] = b"jo\0";
-pub const PRIuMAX: &[u8; 3] = b"ju\0";
-pub const PRIxMAX: &[u8; 3] = b"jx\0";
-pub const PRIXMAX: &[u8; 3] = b"jX\0";
+pub const PRIXMAX: &[u8; 4] = b"llX\0";
+pub const PRIXPTR: &[u8; 4] = b"llX\0";
 pub const SCNd8: &[u8; 4] = b"hhd\0";
-pub const SCNi8: &[u8; 4] = b"hhi\0";
-pub const SCNo8: &[u8; 4] = b"hho\0";
-pub const SCNu8: &[u8; 4] = b"hhu\0";
-pub const SCNx8: &[u8; 4] = b"hhx\0";
 pub const SCNd16: &[u8; 3] = b"hd\0";
-pub const SCNi16: &[u8; 3] = b"hi\0";
-pub const SCNo16: &[u8; 3] = b"ho\0";
-pub const SCNu16: &[u8; 3] = b"hu\0";
-pub const SCNx16: &[u8; 3] = b"hx\0";
 pub const SCNd32: &[u8; 2] = b"d\0";
-pub const SCNi32: &[u8; 2] = b"i\0";
-pub const SCNo32: &[u8; 2] = b"o\0";
-pub const SCNu32: &[u8; 2] = b"u\0";
-pub const SCNx32: &[u8; 2] = b"x\0";
 pub const SCNd64: &[u8; 4] = b"lld\0";
-pub const SCNi64: &[u8; 4] = b"lli\0";
-pub const SCNo64: &[u8; 4] = b"llo\0";
-pub const SCNu64: &[u8; 4] = b"llu\0";
-pub const SCNx64: &[u8; 4] = b"llx\0";
 pub const SCNdLEAST8: &[u8; 4] = b"hhd\0";
-pub const SCNiLEAST8: &[u8; 4] = b"hhi\0";
-pub const SCNoLEAST8: &[u8; 4] = b"hho\0";
-pub const SCNuLEAST8: &[u8; 4] = b"hhu\0";
-pub const SCNxLEAST8: &[u8; 4] = b"hhx\0";
 pub const SCNdLEAST16: &[u8; 3] = b"hd\0";
-pub const SCNiLEAST16: &[u8; 3] = b"hi\0";
-pub const SCNoLEAST16: &[u8; 3] = b"ho\0";
-pub const SCNuLEAST16: &[u8; 3] = b"hu\0";
-pub const SCNxLEAST16: &[u8; 3] = b"hx\0";
 pub const SCNdLEAST32: &[u8; 2] = b"d\0";
-pub const SCNiLEAST32: &[u8; 2] = b"i\0";
-pub const SCNoLEAST32: &[u8; 2] = b"o\0";
-pub const SCNuLEAST32: &[u8; 2] = b"u\0";
-pub const SCNxLEAST32: &[u8; 2] = b"x\0";
 pub const SCNdLEAST64: &[u8; 4] = b"lld\0";
-pub const SCNiLEAST64: &[u8; 4] = b"lli\0";
-pub const SCNoLEAST64: &[u8; 4] = b"llo\0";
-pub const SCNuLEAST64: &[u8; 4] = b"llu\0";
-pub const SCNxLEAST64: &[u8; 4] = b"llx\0";
 pub const SCNdFAST8: &[u8; 4] = b"hhd\0";
-pub const SCNiFAST8: &[u8; 4] = b"hhi\0";
-pub const SCNoFAST8: &[u8; 4] = b"hho\0";
-pub const SCNuFAST8: &[u8; 4] = b"hhu\0";
-pub const SCNxFAST8: &[u8; 4] = b"hhx\0";
-pub const SCNdFAST16: &[u8; 3] = b"hd\0";
-pub const SCNiFAST16: &[u8; 3] = b"hi\0";
-pub const SCNoFAST16: &[u8; 3] = b"ho\0";
-pub const SCNuFAST16: &[u8; 3] = b"hu\0";
-pub const SCNxFAST16: &[u8; 3] = b"hx\0";
+pub const SCNdFAST16: &[u8; 2] = b"d\0";
 pub const SCNdFAST32: &[u8; 2] = b"d\0";
-pub const SCNiFAST32: &[u8; 2] = b"i\0";
-pub const SCNoFAST32: &[u8; 2] = b"o\0";
-pub const SCNuFAST32: &[u8; 2] = b"u\0";
-pub const SCNxFAST32: &[u8; 2] = b"x\0";
 pub const SCNdFAST64: &[u8; 4] = b"lld\0";
+pub const SCNdMAX: &[u8; 4] = b"lld\0";
+pub const SCNdPTR: &[u8; 4] = b"lld\0";
+pub const SCNi8: &[u8; 4] = b"hhi\0";
+pub const SCNi16: &[u8; 3] = b"hi\0";
+pub const SCNi32: &[u8; 2] = b"i\0";
+pub const SCNi64: &[u8; 4] = b"lli\0";
+pub const SCNiLEAST8: &[u8; 4] = b"hhi\0";
+pub const SCNiLEAST16: &[u8; 3] = b"hi\0";
+pub const SCNiLEAST32: &[u8; 2] = b"i\0";
+pub const SCNiLEAST64: &[u8; 4] = b"lli\0";
+pub const SCNiFAST8: &[u8; 4] = b"hhi\0";
+pub const SCNiFAST16: &[u8; 2] = b"i\0";
+pub const SCNiFAST32: &[u8; 2] = b"i\0";
 pub const SCNiFAST64: &[u8; 4] = b"lli\0";
+pub const SCNiMAX: &[u8; 4] = b"lli\0";
+pub const SCNiPTR: &[u8; 4] = b"lli\0";
+pub const SCNo8: &[u8; 4] = b"hho\0";
+pub const SCNo16: &[u8; 3] = b"ho\0";
+pub const SCNo32: &[u8; 2] = b"o\0";
+pub const SCNo64: &[u8; 4] = b"llo\0";
+pub const SCNoLEAST8: &[u8; 4] = b"hho\0";
+pub const SCNoLEAST16: &[u8; 3] = b"ho\0";
+pub const SCNoLEAST32: &[u8; 2] = b"o\0";
+pub const SCNoLEAST64: &[u8; 4] = b"llo\0";
+pub const SCNoFAST8: &[u8; 4] = b"hho\0";
+pub const SCNoFAST16: &[u8; 2] = b"o\0";
+pub const SCNoFAST32: &[u8; 2] = b"o\0";
 pub const SCNoFAST64: &[u8; 4] = b"llo\0";
+pub const SCNoMAX: &[u8; 4] = b"llo\0";
+pub const SCNoPTR: &[u8; 4] = b"llo\0";
+pub const SCNu8: &[u8; 4] = b"hhu\0";
+pub const SCNu16: &[u8; 3] = b"hu\0";
+pub const SCNu32: &[u8; 2] = b"u\0";
+pub const SCNu64: &[u8; 4] = b"llu\0";
+pub const SCNuLEAST8: &[u8; 4] = b"hhu\0";
+pub const SCNuLEAST16: &[u8; 3] = b"hu\0";
+pub const SCNuLEAST32: &[u8; 2] = b"u\0";
+pub const SCNuLEAST64: &[u8; 4] = b"llu\0";
+pub const SCNuFAST8: &[u8; 4] = b"hhu\0";
+pub const SCNuFAST16: &[u8; 2] = b"u\0";
+pub const SCNuFAST32: &[u8; 2] = b"u\0";
 pub const SCNuFAST64: &[u8; 4] = b"llu\0";
+pub const SCNuMAX: &[u8; 4] = b"llu\0";
+pub const SCNuPTR: &[u8; 4] = b"llu\0";
+pub const SCNx8: &[u8; 4] = b"hhx\0";
+pub const SCNx16: &[u8; 3] = b"hx\0";
+pub const SCNx32: &[u8; 2] = b"x\0";
+pub const SCNx64: &[u8; 4] = b"llx\0";
+pub const SCNxLEAST8: &[u8; 4] = b"hhx\0";
+pub const SCNxLEAST16: &[u8; 3] = b"hx\0";
+pub const SCNxLEAST32: &[u8; 2] = b"x\0";
+pub const SCNxLEAST64: &[u8; 4] = b"llx\0";
+pub const SCNxFAST8: &[u8; 4] = b"hhx\0";
+pub const SCNxFAST16: &[u8; 2] = b"x\0";
+pub const SCNxFAST32: &[u8; 2] = b"x\0";
 pub const SCNxFAST64: &[u8; 4] = b"llx\0";
-pub const SCNdPTR: &[u8; 3] = b"ld\0";
-pub const SCNiPTR: &[u8; 3] = b"li\0";
-pub const SCNoPTR: &[u8; 3] = b"lo\0";
-pub const SCNuPTR: &[u8; 3] = b"lu\0";
-pub const SCNxPTR: &[u8; 3] = b"lx\0";
-pub const SCNdMAX: &[u8; 3] = b"jd\0";
-pub const SCNiMAX: &[u8; 3] = b"ji\0";
-pub const SCNoMAX: &[u8; 3] = b"jo\0";
-pub const SCNuMAX: &[u8; 3] = b"ju\0";
-pub const SCNxMAX: &[u8; 3] = b"jx\0";
+pub const SCNxMAX: &[u8; 4] = b"llx\0";
+pub const SCNxPTR: &[u8; 4] = b"llx\0";
 pub const SCIP_EVENTTYPE_FORMAT: &[u8; 4] = b"llx\0";
 pub const SCIP_VARTYPE_BINARY_CHAR: u8 = 66u8;
 pub const SCIP_VARTYPE_INTEGER_CHAR: u8 = 73u8;
@@ -1231,8 +696,88 @@ pub const SCIP_EXPRPRINT_ALL: u32 = 255;
 pub const SCIP_NLPPARAM_DEFAULT_VERBLEVEL: u32 = 0;
 pub const SCIP_DECOMP_LINKVAR: i32 = -1;
 pub const SCIP_DECOMP_LINKCONS: i32 = -2;
-pub const __GNUC_VA_LIST: u32 = 1;
-pub const __HAS_FIXED_CHK_PROTOTYPES: u32 = 1;
+pub const EPERM: u32 = 1;
+pub const ENOENT: u32 = 2;
+pub const ESRCH: u32 = 3;
+pub const EINTR: u32 = 4;
+pub const EIO: u32 = 5;
+pub const ENXIO: u32 = 6;
+pub const E2BIG: u32 = 7;
+pub const ENOEXEC: u32 = 8;
+pub const EBADF: u32 = 9;
+pub const ECHILD: u32 = 10;
+pub const EAGAIN: u32 = 11;
+pub const ENOMEM: u32 = 12;
+pub const EACCES: u32 = 13;
+pub const EFAULT: u32 = 14;
+pub const EBUSY: u32 = 16;
+pub const EEXIST: u32 = 17;
+pub const EXDEV: u32 = 18;
+pub const ENODEV: u32 = 19;
+pub const ENOTDIR: u32 = 20;
+pub const EISDIR: u32 = 21;
+pub const ENFILE: u32 = 23;
+pub const EMFILE: u32 = 24;
+pub const ENOTTY: u32 = 25;
+pub const EFBIG: u32 = 27;
+pub const ENOSPC: u32 = 28;
+pub const ESPIPE: u32 = 29;
+pub const EROFS: u32 = 30;
+pub const EMLINK: u32 = 31;
+pub const EPIPE: u32 = 32;
+pub const EDOM: u32 = 33;
+pub const EDEADLK: u32 = 36;
+pub const ENAMETOOLONG: u32 = 38;
+pub const ENOLCK: u32 = 39;
+pub const ENOSYS: u32 = 40;
+pub const ENOTEMPTY: u32 = 41;
+pub const EINVAL: u32 = 22;
+pub const ERANGE: u32 = 34;
+pub const EILSEQ: u32 = 42;
+pub const STRUNCATE: u32 = 80;
+pub const EDEADLOCK: u32 = 36;
+pub const EADDRINUSE: u32 = 100;
+pub const EADDRNOTAVAIL: u32 = 101;
+pub const EAFNOSUPPORT: u32 = 102;
+pub const EALREADY: u32 = 103;
+pub const EBADMSG: u32 = 104;
+pub const ECANCELED: u32 = 105;
+pub const ECONNABORTED: u32 = 106;
+pub const ECONNREFUSED: u32 = 107;
+pub const ECONNRESET: u32 = 108;
+pub const EDESTADDRREQ: u32 = 109;
+pub const EHOSTUNREACH: u32 = 110;
+pub const EIDRM: u32 = 111;
+pub const EINPROGRESS: u32 = 112;
+pub const EISCONN: u32 = 113;
+pub const ELOOP: u32 = 114;
+pub const EMSGSIZE: u32 = 115;
+pub const ENETDOWN: u32 = 116;
+pub const ENETRESET: u32 = 117;
+pub const ENETUNREACH: u32 = 118;
+pub const ENOBUFS: u32 = 119;
+pub const ENODATA: u32 = 120;
+pub const ENOLINK: u32 = 121;
+pub const ENOMSG: u32 = 122;
+pub const ENOPROTOOPT: u32 = 123;
+pub const ENOSR: u32 = 124;
+pub const ENOSTR: u32 = 125;
+pub const ENOTCONN: u32 = 126;
+pub const ENOTRECOVERABLE: u32 = 127;
+pub const ENOTSOCK: u32 = 128;
+pub const ENOTSUP: u32 = 129;
+pub const EOPNOTSUPP: u32 = 130;
+pub const EOTHER: u32 = 131;
+pub const EOVERFLOW: u32 = 132;
+pub const EOWNERDEAD: u32 = 133;
+pub const EPROTO: u32 = 134;
+pub const EPROTONOSUPPORT: u32 = 135;
+pub const EPROTOTYPE: u32 = 136;
+pub const ETIME: u32 = 137;
+pub const ETIMEDOUT: u32 = 138;
+pub const ETXTBSY: u32 = 139;
+pub const EWOULDBLOCK: u32 = 140;
+pub const _NLSCMPERROR: u32 = 2147483647;
 pub const QUAD_EPSILON: f64 = 0.000000000001;
 pub const __bool_true_false_are_defined: u32 = 1;
 pub const true_: u32 = 1;
@@ -1251,1464 +796,799 @@ pub const SYM_COMPUTETIMING_BEFOREPRESOL: u32 = 0;
 pub const SYM_COMPUTETIMING_DURINGPRESOL: u32 = 1;
 pub const SYM_COMPUTETIMING_AFTERPRESOL: u32 = 2;
 pub const ARTIFICIALVARNAMEPREFIX: &[u8; 14] = b"andresultant_\0";
-pub type __int8_t = ::std::os::raw::c_schar;
-pub type __uint8_t = ::std::os::raw::c_uchar;
-pub type __int16_t = ::std::os::raw::c_short;
-pub type __uint16_t = ::std::os::raw::c_ushort;
-pub type __int32_t = ::std::os::raw::c_int;
-pub type __uint32_t = ::std::os::raw::c_uint;
-pub type __int64_t = ::std::os::raw::c_longlong;
-pub type __uint64_t = ::std::os::raw::c_ulonglong;
-pub type __darwin_intptr_t = ::std::os::raw::c_long;
-pub type __darwin_natural_t = ::std::os::raw::c_uint;
-pub type __darwin_ct_rune_t = ::std::os::raw::c_int;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union __mbstate_t {
-    pub __mbstate8: [::std::os::raw::c_char; 128usize],
-    pub _mbstateL: ::std::os::raw::c_longlong,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __mbstate_t"][::std::mem::size_of::<__mbstate_t>() - 128usize];
-    ["Alignment of __mbstate_t"][::std::mem::align_of::<__mbstate_t>() - 8usize];
-    ["Offset of field: __mbstate_t::__mbstate8"]
-        [::std::mem::offset_of!(__mbstate_t, __mbstate8) - 0usize];
-    ["Offset of field: __mbstate_t::_mbstateL"]
-        [::std::mem::offset_of!(__mbstate_t, _mbstateL) - 0usize];
-};
-pub type __darwin_mbstate_t = __mbstate_t;
-pub type __darwin_ptrdiff_t = ::std::os::raw::c_long;
-pub type __darwin_size_t = ::std::os::raw::c_ulong;
-pub type __darwin_va_list = __builtin_va_list;
-pub type __darwin_wchar_t = ::std::os::raw::c_int;
-pub type __darwin_rune_t = __darwin_wchar_t;
-pub type __darwin_wint_t = ::std::os::raw::c_int;
-pub type __darwin_clock_t = ::std::os::raw::c_ulong;
-pub type __darwin_socklen_t = __uint32_t;
-pub type __darwin_ssize_t = ::std::os::raw::c_long;
-pub type __darwin_time_t = ::std::os::raw::c_long;
-pub type __darwin_blkcnt_t = __int64_t;
-pub type __darwin_blksize_t = __int32_t;
-pub type __darwin_dev_t = __int32_t;
-pub type __darwin_fsblkcnt_t = ::std::os::raw::c_uint;
-pub type __darwin_fsfilcnt_t = ::std::os::raw::c_uint;
-pub type __darwin_gid_t = __uint32_t;
-pub type __darwin_id_t = __uint32_t;
-pub type __darwin_ino64_t = __uint64_t;
-pub type __darwin_ino_t = __darwin_ino64_t;
-pub type __darwin_mach_port_name_t = __darwin_natural_t;
-pub type __darwin_mach_port_t = __darwin_mach_port_name_t;
-pub type __darwin_mode_t = __uint16_t;
-pub type __darwin_off_t = __int64_t;
-pub type __darwin_pid_t = __int32_t;
-pub type __darwin_sigset_t = __uint32_t;
-pub type __darwin_suseconds_t = __int32_t;
-pub type __darwin_uid_t = __uint32_t;
-pub type __darwin_useconds_t = __uint32_t;
-pub type __darwin_uuid_t = [::std::os::raw::c_uchar; 16usize];
-pub type __darwin_uuid_string_t = [::std::os::raw::c_char; 37usize];
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_pthread_handler_rec {
-    pub __routine: ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
-    pub __arg: *mut ::std::os::raw::c_void,
-    pub __next: *mut __darwin_pthread_handler_rec,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __darwin_pthread_handler_rec"]
-        [::std::mem::size_of::<__darwin_pthread_handler_rec>() - 24usize];
-    ["Alignment of __darwin_pthread_handler_rec"]
-        [::std::mem::align_of::<__darwin_pthread_handler_rec>() - 8usize];
-    ["Offset of field: __darwin_pthread_handler_rec::__routine"]
-        [::std::mem::offset_of!(__darwin_pthread_handler_rec, __routine) - 0usize];
-    ["Offset of field: __darwin_pthread_handler_rec::__arg"]
-        [::std::mem::offset_of!(__darwin_pthread_handler_rec, __arg) - 8usize];
-    ["Offset of field: __darwin_pthread_handler_rec::__next"]
-        [::std::mem::offset_of!(__darwin_pthread_handler_rec, __next) - 16usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_attr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 56usize],
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of _opaque_pthread_attr_t"][::std::mem::size_of::<_opaque_pthread_attr_t>() - 64usize];
-    ["Alignment of _opaque_pthread_attr_t"]
-        [::std::mem::align_of::<_opaque_pthread_attr_t>() - 8usize];
-    ["Offset of field: _opaque_pthread_attr_t::__sig"]
-        [::std::mem::offset_of!(_opaque_pthread_attr_t, __sig) - 0usize];
-    ["Offset of field: _opaque_pthread_attr_t::__opaque"]
-        [::std::mem::offset_of!(_opaque_pthread_attr_t, __opaque) - 8usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_cond_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 40usize],
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of _opaque_pthread_cond_t"][::std::mem::size_of::<_opaque_pthread_cond_t>() - 48usize];
-    ["Alignment of _opaque_pthread_cond_t"]
-        [::std::mem::align_of::<_opaque_pthread_cond_t>() - 8usize];
-    ["Offset of field: _opaque_pthread_cond_t::__sig"]
-        [::std::mem::offset_of!(_opaque_pthread_cond_t, __sig) - 0usize];
-    ["Offset of field: _opaque_pthread_cond_t::__opaque"]
-        [::std::mem::offset_of!(_opaque_pthread_cond_t, __opaque) - 8usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_condattr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 8usize],
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of _opaque_pthread_condattr_t"]
-        [::std::mem::size_of::<_opaque_pthread_condattr_t>() - 16usize];
-    ["Alignment of _opaque_pthread_condattr_t"]
-        [::std::mem::align_of::<_opaque_pthread_condattr_t>() - 8usize];
-    ["Offset of field: _opaque_pthread_condattr_t::__sig"]
-        [::std::mem::offset_of!(_opaque_pthread_condattr_t, __sig) - 0usize];
-    ["Offset of field: _opaque_pthread_condattr_t::__opaque"]
-        [::std::mem::offset_of!(_opaque_pthread_condattr_t, __opaque) - 8usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_mutex_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 56usize],
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of _opaque_pthread_mutex_t"][::std::mem::size_of::<_opaque_pthread_mutex_t>() - 64usize];
-    ["Alignment of _opaque_pthread_mutex_t"]
-        [::std::mem::align_of::<_opaque_pthread_mutex_t>() - 8usize];
-    ["Offset of field: _opaque_pthread_mutex_t::__sig"]
-        [::std::mem::offset_of!(_opaque_pthread_mutex_t, __sig) - 0usize];
-    ["Offset of field: _opaque_pthread_mutex_t::__opaque"]
-        [::std::mem::offset_of!(_opaque_pthread_mutex_t, __opaque) - 8usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_mutexattr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 8usize],
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of _opaque_pthread_mutexattr_t"]
-        [::std::mem::size_of::<_opaque_pthread_mutexattr_t>() - 16usize];
-    ["Alignment of _opaque_pthread_mutexattr_t"]
-        [::std::mem::align_of::<_opaque_pthread_mutexattr_t>() - 8usize];
-    ["Offset of field: _opaque_pthread_mutexattr_t::__sig"]
-        [::std::mem::offset_of!(_opaque_pthread_mutexattr_t, __sig) - 0usize];
-    ["Offset of field: _opaque_pthread_mutexattr_t::__opaque"]
-        [::std::mem::offset_of!(_opaque_pthread_mutexattr_t, __opaque) - 8usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_once_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 8usize],
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of _opaque_pthread_once_t"][::std::mem::size_of::<_opaque_pthread_once_t>() - 16usize];
-    ["Alignment of _opaque_pthread_once_t"]
-        [::std::mem::align_of::<_opaque_pthread_once_t>() - 8usize];
-    ["Offset of field: _opaque_pthread_once_t::__sig"]
-        [::std::mem::offset_of!(_opaque_pthread_once_t, __sig) - 0usize];
-    ["Offset of field: _opaque_pthread_once_t::__opaque"]
-        [::std::mem::offset_of!(_opaque_pthread_once_t, __opaque) - 8usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_rwlock_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 192usize],
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of _opaque_pthread_rwlock_t"]
-        [::std::mem::size_of::<_opaque_pthread_rwlock_t>() - 200usize];
-    ["Alignment of _opaque_pthread_rwlock_t"]
-        [::std::mem::align_of::<_opaque_pthread_rwlock_t>() - 8usize];
-    ["Offset of field: _opaque_pthread_rwlock_t::__sig"]
-        [::std::mem::offset_of!(_opaque_pthread_rwlock_t, __sig) - 0usize];
-    ["Offset of field: _opaque_pthread_rwlock_t::__opaque"]
-        [::std::mem::offset_of!(_opaque_pthread_rwlock_t, __opaque) - 8usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_rwlockattr_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __opaque: [::std::os::raw::c_char; 16usize],
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of _opaque_pthread_rwlockattr_t"]
-        [::std::mem::size_of::<_opaque_pthread_rwlockattr_t>() - 24usize];
-    ["Alignment of _opaque_pthread_rwlockattr_t"]
-        [::std::mem::align_of::<_opaque_pthread_rwlockattr_t>() - 8usize];
-    ["Offset of field: _opaque_pthread_rwlockattr_t::__sig"]
-        [::std::mem::offset_of!(_opaque_pthread_rwlockattr_t, __sig) - 0usize];
-    ["Offset of field: _opaque_pthread_rwlockattr_t::__opaque"]
-        [::std::mem::offset_of!(_opaque_pthread_rwlockattr_t, __opaque) - 8usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _opaque_pthread_t {
-    pub __sig: ::std::os::raw::c_long,
-    pub __cleanup_stack: *mut __darwin_pthread_handler_rec,
-    pub __opaque: [::std::os::raw::c_char; 8176usize],
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of _opaque_pthread_t"][::std::mem::size_of::<_opaque_pthread_t>() - 8192usize];
-    ["Alignment of _opaque_pthread_t"][::std::mem::align_of::<_opaque_pthread_t>() - 8usize];
-    ["Offset of field: _opaque_pthread_t::__sig"]
-        [::std::mem::offset_of!(_opaque_pthread_t, __sig) - 0usize];
-    ["Offset of field: _opaque_pthread_t::__cleanup_stack"]
-        [::std::mem::offset_of!(_opaque_pthread_t, __cleanup_stack) - 8usize];
-    ["Offset of field: _opaque_pthread_t::__opaque"]
-        [::std::mem::offset_of!(_opaque_pthread_t, __opaque) - 16usize];
-};
-pub type __darwin_pthread_attr_t = _opaque_pthread_attr_t;
-pub type __darwin_pthread_cond_t = _opaque_pthread_cond_t;
-pub type __darwin_pthread_condattr_t = _opaque_pthread_condattr_t;
-pub type __darwin_pthread_key_t = ::std::os::raw::c_ulong;
-pub type __darwin_pthread_mutex_t = _opaque_pthread_mutex_t;
-pub type __darwin_pthread_mutexattr_t = _opaque_pthread_mutexattr_t;
-pub type __darwin_pthread_once_t = _opaque_pthread_once_t;
-pub type __darwin_pthread_rwlock_t = _opaque_pthread_rwlock_t;
-pub type __darwin_pthread_rwlockattr_t = _opaque_pthread_rwlockattr_t;
-pub type __darwin_pthread_t = *mut _opaque_pthread_t;
-pub type __darwin_nl_item = ::std::os::raw::c_int;
-pub type __darwin_wctrans_t = ::std::os::raw::c_int;
-pub type __darwin_wctype_t = __uint32_t;
-pub type u_int8_t = ::std::os::raw::c_uchar;
-pub type u_int16_t = ::std::os::raw::c_ushort;
-pub type u_int32_t = ::std::os::raw::c_uint;
-pub type u_int64_t = ::std::os::raw::c_ulonglong;
-pub type register_t = i64;
-pub type user_addr_t = u_int64_t;
-pub type user_size_t = u_int64_t;
-pub type user_ssize_t = i64;
-pub type user_long_t = i64;
-pub type user_ulong_t = u_int64_t;
-pub type user_time_t = i64;
-pub type user_off_t = i64;
-pub type syscall_arg_t = u_int64_t;
-pub type va_list = __darwin_va_list;
+pub type va_list = *mut ::std::os::raw::c_char;
 unsafe extern "C" {
-    pub fn renameat(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
-        arg4: *const ::std::os::raw::c_char,
+    pub fn __va_start(arg1: *mut *mut ::std::os::raw::c_char, ...);
+}
+pub type __vcrt_bool = bool;
+pub type wchar_t = ::std::os::raw::c_ushort;
+unsafe extern "C" {
+    pub fn __security_init_cookie();
+}
+unsafe extern "C" {
+    pub fn __security_check_cookie(_StackCookie: usize);
+}
+unsafe extern "C" {
+    pub fn __report_gsfailure(_StackCookie: usize) -> !;
+}
+unsafe extern "C" {
+    pub static mut __security_cookie: usize;
+}
+pub type __crt_bool = bool;
+unsafe extern "C" {
+    pub fn _invalid_parameter_noinfo();
+}
+unsafe extern "C" {
+    pub fn _invalid_parameter_noinfo_noreturn() -> !;
+}
+unsafe extern "C" {
+    pub fn _invoke_watson(
+        _Expression: *const wchar_t,
+        _FunctionName: *const wchar_t,
+        _FileName: *const wchar_t,
+        _LineNo: ::std::os::raw::c_uint,
+        _Reserved: usize,
+    ) -> !;
+}
+pub type errno_t = ::std::os::raw::c_int;
+pub type wint_t = ::std::os::raw::c_ushort;
+pub type wctype_t = ::std::os::raw::c_ushort;
+pub type __time32_t = ::std::os::raw::c_long;
+pub type __time64_t = ::std::os::raw::c_longlong;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __crt_locale_data_public {
+    pub _locale_pctype: *const ::std::os::raw::c_ushort,
+    pub _locale_mb_cur_max: ::std::os::raw::c_int,
+    pub _locale_lc_codepage: ::std::os::raw::c_uint,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of __crt_locale_data_public"]
+        [::std::mem::size_of::<__crt_locale_data_public>() - 16usize];
+    ["Alignment of __crt_locale_data_public"]
+        [::std::mem::align_of::<__crt_locale_data_public>() - 8usize];
+    ["Offset of field: __crt_locale_data_public::_locale_pctype"]
+        [::std::mem::offset_of!(__crt_locale_data_public, _locale_pctype) - 0usize];
+    ["Offset of field: __crt_locale_data_public::_locale_mb_cur_max"]
+        [::std::mem::offset_of!(__crt_locale_data_public, _locale_mb_cur_max) - 8usize];
+    ["Offset of field: __crt_locale_data_public::_locale_lc_codepage"]
+        [::std::mem::offset_of!(__crt_locale_data_public, _locale_lc_codepage) - 12usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __crt_locale_pointers {
+    pub locinfo: *mut __crt_locale_data,
+    pub mbcinfo: *mut __crt_multibyte_data,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of __crt_locale_pointers"][::std::mem::size_of::<__crt_locale_pointers>() - 16usize];
+    ["Alignment of __crt_locale_pointers"]
+        [::std::mem::align_of::<__crt_locale_pointers>() - 8usize];
+    ["Offset of field: __crt_locale_pointers::locinfo"]
+        [::std::mem::offset_of!(__crt_locale_pointers, locinfo) - 0usize];
+    ["Offset of field: __crt_locale_pointers::mbcinfo"]
+        [::std::mem::offset_of!(__crt_locale_pointers, mbcinfo) - 8usize];
+};
+pub type _locale_t = *mut __crt_locale_pointers;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _Mbstatet {
+    pub _Wchar: ::std::os::raw::c_ulong,
+    pub _Byte: ::std::os::raw::c_ushort,
+    pub _State: ::std::os::raw::c_ushort,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of _Mbstatet"][::std::mem::size_of::<_Mbstatet>() - 8usize];
+    ["Alignment of _Mbstatet"][::std::mem::align_of::<_Mbstatet>() - 4usize];
+    ["Offset of field: _Mbstatet::_Wchar"][::std::mem::offset_of!(_Mbstatet, _Wchar) - 0usize];
+    ["Offset of field: _Mbstatet::_Byte"][::std::mem::offset_of!(_Mbstatet, _Byte) - 4usize];
+    ["Offset of field: _Mbstatet::_State"][::std::mem::offset_of!(_Mbstatet, _State) - 6usize];
+};
+pub type mbstate_t = _Mbstatet;
+pub type time_t = __time64_t;
+pub type rsize_t = usize;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _iobuf {
+    pub _Placeholder: *mut ::std::os::raw::c_void,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of _iobuf"][::std::mem::size_of::<_iobuf>() - 8usize];
+    ["Alignment of _iobuf"][::std::mem::align_of::<_iobuf>() - 8usize];
+    ["Offset of field: _iobuf::_Placeholder"]
+        [::std::mem::offset_of!(_iobuf, _Placeholder) - 0usize];
+};
+pub type FILE = _iobuf;
+unsafe extern "C" {
+    pub fn __acrt_iob_func(_Ix: ::std::os::raw::c_uint) -> *mut FILE;
+}
+unsafe extern "C" {
+    pub fn fgetwc(_Stream: *mut FILE) -> wint_t;
+}
+unsafe extern "C" {
+    pub fn _fgetwchar() -> wint_t;
+}
+unsafe extern "C" {
+    pub fn fputwc(_Character: wchar_t, _Stream: *mut FILE) -> wint_t;
+}
+unsafe extern "C" {
+    pub fn _fputwchar(_Character: wchar_t) -> wint_t;
+}
+unsafe extern "C" {
+    pub fn getwc(_Stream: *mut FILE) -> wint_t;
+}
+unsafe extern "C" {
+    pub fn getwchar() -> wint_t;
+}
+unsafe extern "C" {
+    pub fn fgetws(
+        _Buffer: *mut wchar_t,
+        _BufferCount: ::std::os::raw::c_int,
+        _Stream: *mut FILE,
+    ) -> *mut wchar_t;
+}
+unsafe extern "C" {
+    pub fn fputws(_Buffer: *const wchar_t, _Stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _getws_s(_Buffer: *mut wchar_t, _BufferCount: usize) -> *mut wchar_t;
+}
+unsafe extern "C" {
+    pub fn putwc(_Character: wchar_t, _Stream: *mut FILE) -> wint_t;
+}
+unsafe extern "C" {
+    pub fn putwchar(_Character: wchar_t) -> wint_t;
+}
+unsafe extern "C" {
+    pub fn _putws(_Buffer: *const wchar_t) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn ungetwc(_Character: wint_t, _Stream: *mut FILE) -> wint_t;
+}
+unsafe extern "C" {
+    pub fn _wfdopen(_FileHandle: ::std::os::raw::c_int, _Mode: *const wchar_t) -> *mut FILE;
+}
+unsafe extern "C" {
+    pub fn _wfopen(_FileName: *const wchar_t, _Mode: *const wchar_t) -> *mut FILE;
+}
+unsafe extern "C" {
+    pub fn _wfopen_s(
+        _Stream: *mut *mut FILE,
+        _FileName: *const wchar_t,
+        _Mode: *const wchar_t,
+    ) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn _wfreopen(
+        _FileName: *const wchar_t,
+        _Mode: *const wchar_t,
+        _OldStream: *mut FILE,
+    ) -> *mut FILE;
+}
+unsafe extern "C" {
+    pub fn _wfreopen_s(
+        _Stream: *mut *mut FILE,
+        _FileName: *const wchar_t,
+        _Mode: *const wchar_t,
+        _OldStream: *mut FILE,
+    ) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn _wfsopen(
+        _FileName: *const wchar_t,
+        _Mode: *const wchar_t,
+        _ShFlag: ::std::os::raw::c_int,
+    ) -> *mut FILE;
+}
+unsafe extern "C" {
+    pub fn _wperror(_ErrorMessage: *const wchar_t);
+}
+unsafe extern "C" {
+    pub fn _wpopen(_Command: *const wchar_t, _Mode: *const wchar_t) -> *mut FILE;
+}
+unsafe extern "C" {
+    pub fn _wremove(_FileName: *const wchar_t) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _wtempnam(_Directory: *const wchar_t, _FilePrefix: *const wchar_t) -> *mut wchar_t;
+}
+unsafe extern "C" {
+    pub fn _wtmpnam_s(_Buffer: *mut wchar_t, _BufferCount: usize) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn _wtmpnam(_Buffer: *mut wchar_t) -> *mut wchar_t;
+}
+unsafe extern "C" {
+    pub fn _fgetwc_nolock(_Stream: *mut FILE) -> wint_t;
+}
+unsafe extern "C" {
+    pub fn _fputwc_nolock(_Character: wchar_t, _Stream: *mut FILE) -> wint_t;
+}
+unsafe extern "C" {
+    pub fn _getwc_nolock(_Stream: *mut FILE) -> wint_t;
+}
+unsafe extern "C" {
+    pub fn _putwc_nolock(_Character: wchar_t, _Stream: *mut FILE) -> wint_t;
+}
+unsafe extern "C" {
+    pub fn _ungetwc_nolock(_Character: wint_t, _Stream: *mut FILE) -> wint_t;
+}
+unsafe extern "C" {
+    pub fn __stdio_common_vfwprintf(
+        _Options: ::std::os::raw::c_ulonglong,
+        _Stream: *mut FILE,
+        _Format: *const wchar_t,
+        _Locale: _locale_t,
+        _ArgList: va_list,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn renamex_np(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_uint,
+    pub fn __stdio_common_vfwprintf_s(
+        _Options: ::std::os::raw::c_ulonglong,
+        _Stream: *mut FILE,
+        _Format: *const wchar_t,
+        _Locale: _locale_t,
+        _ArgList: va_list,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn renameatx_np(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
-        arg4: *const ::std::os::raw::c_char,
-        arg5: ::std::os::raw::c_uint,
+    pub fn __stdio_common_vfwprintf_p(
+        _Options: ::std::os::raw::c_ulonglong,
+        _Stream: *mut FILE,
+        _Format: *const wchar_t,
+        _Locale: _locale_t,
+        _ArgList: va_list,
     ) -> ::std::os::raw::c_int;
 }
-pub type fpos_t = __darwin_off_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __sbuf {
-    pub _base: *mut ::std::os::raw::c_uchar,
-    pub _size: ::std::os::raw::c_int,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __sbuf"][::std::mem::size_of::<__sbuf>() - 16usize];
-    ["Alignment of __sbuf"][::std::mem::align_of::<__sbuf>() - 8usize];
-    ["Offset of field: __sbuf::_base"][::std::mem::offset_of!(__sbuf, _base) - 0usize];
-    ["Offset of field: __sbuf::_size"][::std::mem::offset_of!(__sbuf, _size) - 8usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __sFILEX {
-    _unused: [u8; 0],
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __sFILE {
-    pub _p: *mut ::std::os::raw::c_uchar,
-    pub _r: ::std::os::raw::c_int,
-    pub _w: ::std::os::raw::c_int,
-    pub _flags: ::std::os::raw::c_short,
-    pub _file: ::std::os::raw::c_short,
-    pub _bf: __sbuf,
-    pub _lbfsize: ::std::os::raw::c_int,
-    pub _cookie: *mut ::std::os::raw::c_void,
-    pub _close: ::std::option::Option<
-        unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
-    >,
-    pub _read: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: *mut ::std::os::raw::c_char,
-            arg3: ::std::os::raw::c_int,
-        ) -> ::std::os::raw::c_int,
-    >,
-    pub _seek: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: fpos_t,
-            arg3: ::std::os::raw::c_int,
-        ) -> fpos_t,
-    >,
-    pub _write: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: *const ::std::os::raw::c_char,
-            arg3: ::std::os::raw::c_int,
-        ) -> ::std::os::raw::c_int,
-    >,
-    pub _ub: __sbuf,
-    pub _extra: *mut __sFILEX,
-    pub _ur: ::std::os::raw::c_int,
-    pub _ubuf: [::std::os::raw::c_uchar; 3usize],
-    pub _nbuf: [::std::os::raw::c_uchar; 1usize],
-    pub _lb: __sbuf,
-    pub _blksize: ::std::os::raw::c_int,
-    pub _offset: fpos_t,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __sFILE"][::std::mem::size_of::<__sFILE>() - 152usize];
-    ["Alignment of __sFILE"][::std::mem::align_of::<__sFILE>() - 8usize];
-    ["Offset of field: __sFILE::_p"][::std::mem::offset_of!(__sFILE, _p) - 0usize];
-    ["Offset of field: __sFILE::_r"][::std::mem::offset_of!(__sFILE, _r) - 8usize];
-    ["Offset of field: __sFILE::_w"][::std::mem::offset_of!(__sFILE, _w) - 12usize];
-    ["Offset of field: __sFILE::_flags"][::std::mem::offset_of!(__sFILE, _flags) - 16usize];
-    ["Offset of field: __sFILE::_file"][::std::mem::offset_of!(__sFILE, _file) - 18usize];
-    ["Offset of field: __sFILE::_bf"][::std::mem::offset_of!(__sFILE, _bf) - 24usize];
-    ["Offset of field: __sFILE::_lbfsize"][::std::mem::offset_of!(__sFILE, _lbfsize) - 40usize];
-    ["Offset of field: __sFILE::_cookie"][::std::mem::offset_of!(__sFILE, _cookie) - 48usize];
-    ["Offset of field: __sFILE::_close"][::std::mem::offset_of!(__sFILE, _close) - 56usize];
-    ["Offset of field: __sFILE::_read"][::std::mem::offset_of!(__sFILE, _read) - 64usize];
-    ["Offset of field: __sFILE::_seek"][::std::mem::offset_of!(__sFILE, _seek) - 72usize];
-    ["Offset of field: __sFILE::_write"][::std::mem::offset_of!(__sFILE, _write) - 80usize];
-    ["Offset of field: __sFILE::_ub"][::std::mem::offset_of!(__sFILE, _ub) - 88usize];
-    ["Offset of field: __sFILE::_extra"][::std::mem::offset_of!(__sFILE, _extra) - 104usize];
-    ["Offset of field: __sFILE::_ur"][::std::mem::offset_of!(__sFILE, _ur) - 112usize];
-    ["Offset of field: __sFILE::_ubuf"][::std::mem::offset_of!(__sFILE, _ubuf) - 116usize];
-    ["Offset of field: __sFILE::_nbuf"][::std::mem::offset_of!(__sFILE, _nbuf) - 119usize];
-    ["Offset of field: __sFILE::_lb"][::std::mem::offset_of!(__sFILE, _lb) - 120usize];
-    ["Offset of field: __sFILE::_blksize"][::std::mem::offset_of!(__sFILE, _blksize) - 136usize];
-    ["Offset of field: __sFILE::_offset"][::std::mem::offset_of!(__sFILE, _offset) - 144usize];
-};
-pub type FILE = __sFILE;
 unsafe extern "C" {
-    pub static mut __stdinp: *mut FILE;
+    pub fn __stdio_common_vfwscanf(
+        _Options: ::std::os::raw::c_ulonglong,
+        _Stream: *mut FILE,
+        _Format: *const wchar_t,
+        _Locale: _locale_t,
+        _ArgList: va_list,
+    ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub static mut __stdoutp: *mut FILE;
+    pub fn __stdio_common_vswprintf(
+        _Options: ::std::os::raw::c_ulonglong,
+        _Buffer: *mut wchar_t,
+        _BufferCount: usize,
+        _Format: *const wchar_t,
+        _Locale: _locale_t,
+        _ArgList: va_list,
+    ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub static mut __stderrp: *mut FILE;
+    pub fn __stdio_common_vswprintf_s(
+        _Options: ::std::os::raw::c_ulonglong,
+        _Buffer: *mut wchar_t,
+        _BufferCount: usize,
+        _Format: *const wchar_t,
+        _Locale: _locale_t,
+        _ArgList: va_list,
+    ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn clearerr(arg1: *mut FILE);
+    pub fn __stdio_common_vsnwprintf_s(
+        _Options: ::std::os::raw::c_ulonglong,
+        _Buffer: *mut wchar_t,
+        _BufferCount: usize,
+        _MaxCount: usize,
+        _Format: *const wchar_t,
+        _Locale: _locale_t,
+        _ArgList: va_list,
+    ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn fclose(arg1: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn __stdio_common_vswprintf_p(
+        _Options: ::std::os::raw::c_ulonglong,
+        _Buffer: *mut wchar_t,
+        _BufferCount: usize,
+        _Format: *const wchar_t,
+        _Locale: _locale_t,
+        _ArgList: va_list,
+    ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn feof(arg1: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn __stdio_common_vswscanf(
+        _Options: ::std::os::raw::c_ulonglong,
+        _Buffer: *const wchar_t,
+        _BufferCount: usize,
+        _Format: *const wchar_t,
+        _Locale: _locale_t,
+        _ArgList: va_list,
+    ) -> ::std::os::raw::c_int;
+}
+pub type fpos_t = ::std::os::raw::c_longlong;
+unsafe extern "C" {
+    pub fn _get_stream_buffer_pointers(
+        _Stream: *mut FILE,
+        _Base: *mut *mut *mut ::std::os::raw::c_char,
+        _Pointer: *mut *mut *mut ::std::os::raw::c_char,
+        _Count: *mut *mut ::std::os::raw::c_int,
+    ) -> errno_t;
 }
 unsafe extern "C" {
-    pub fn ferror(arg1: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn clearerr_s(_Stream: *mut FILE) -> errno_t;
 }
 unsafe extern "C" {
-    pub fn fflush(arg1: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn fopen_s(
+        _Stream: *mut *mut FILE,
+        _FileName: *const ::std::os::raw::c_char,
+        _Mode: *const ::std::os::raw::c_char,
+    ) -> errno_t;
 }
 unsafe extern "C" {
-    pub fn fgetc(arg1: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn fread_s(
+        _Buffer: *mut ::std::os::raw::c_void,
+        _BufferSize: usize,
+        _ElementSize: usize,
+        _ElementCount: usize,
+        _Stream: *mut FILE,
+    ) -> usize;
 }
 unsafe extern "C" {
-    pub fn fgetpos(arg1: *mut FILE, arg2: *mut fpos_t) -> ::std::os::raw::c_int;
+    pub fn freopen_s(
+        _Stream: *mut *mut FILE,
+        _FileName: *const ::std::os::raw::c_char,
+        _Mode: *const ::std::os::raw::c_char,
+        _OldStream: *mut FILE,
+    ) -> errno_t;
 }
 unsafe extern "C" {
-    pub fn fgets(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
-        arg3: *mut FILE,
+    pub fn gets_s(
+        _Buffer: *mut ::std::os::raw::c_char,
+        _Size: rsize_t,
     ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn fopen(
-        __filename: *const ::std::os::raw::c_char,
-        __mode: *const ::std::os::raw::c_char,
+    pub fn tmpfile_s(_Stream: *mut *mut FILE) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn tmpnam_s(_Buffer: *mut ::std::os::raw::c_char, _Size: rsize_t) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn clearerr(_Stream: *mut FILE);
+}
+unsafe extern "C" {
+    pub fn fclose(_Stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _fcloseall() -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _fdopen(
+        _FileHandle: ::std::os::raw::c_int,
+        _Mode: *const ::std::os::raw::c_char,
     ) -> *mut FILE;
 }
 unsafe extern "C" {
-    pub fn fprintf(
-        arg1: *mut FILE,
-        arg2: *const ::std::os::raw::c_char,
-        ...
+    pub fn feof(_Stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn ferror(_Stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn fflush(_Stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn fgetc(_Stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _fgetchar() -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn fgetpos(_Stream: *mut FILE, _Position: *mut fpos_t) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn fgets(
+        _Buffer: *mut ::std::os::raw::c_char,
+        _MaxCount: ::std::os::raw::c_int,
+        _Stream: *mut FILE,
+    ) -> *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn _fileno(_Stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _flushall() -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn fopen(
+        _FileName: *const ::std::os::raw::c_char,
+        _Mode: *const ::std::os::raw::c_char,
+    ) -> *mut FILE;
+}
+unsafe extern "C" {
+    pub fn fputc(_Character: ::std::os::raw::c_int, _Stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _fputchar(_Character: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn fputs(
+        _Buffer: *const ::std::os::raw::c_char,
+        _Stream: *mut FILE,
     ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn fputc(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn fputs(arg1: *const ::std::os::raw::c_char, arg2: *mut FILE) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
     pub fn fread(
-        __ptr: *mut ::std::os::raw::c_void,
-        __size: ::std::os::raw::c_ulong,
-        __nitems: ::std::os::raw::c_ulong,
-        __stream: *mut FILE,
-    ) -> ::std::os::raw::c_ulong;
+        _Buffer: *mut ::std::os::raw::c_void,
+        _ElementSize: ::std::os::raw::c_ulonglong,
+        _ElementCount: ::std::os::raw::c_ulonglong,
+        _Stream: *mut FILE,
+    ) -> ::std::os::raw::c_ulonglong;
 }
 unsafe extern "C" {
     pub fn freopen(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut FILE,
+        _FileName: *const ::std::os::raw::c_char,
+        _Mode: *const ::std::os::raw::c_char,
+        _Stream: *mut FILE,
     ) -> *mut FILE;
 }
 unsafe extern "C" {
-    pub fn fscanf(
-        arg1: *mut FILE,
-        arg2: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
+    pub fn _fsopen(
+        _FileName: *const ::std::os::raw::c_char,
+        _Mode: *const ::std::os::raw::c_char,
+        _ShFlag: ::std::os::raw::c_int,
+    ) -> *mut FILE;
+}
+unsafe extern "C" {
+    pub fn fsetpos(_Stream: *mut FILE, _Position: *const fpos_t) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
     pub fn fseek(
-        arg1: *mut FILE,
-        arg2: ::std::os::raw::c_long,
-        arg3: ::std::os::raw::c_int,
+        _Stream: *mut FILE,
+        _Offset: ::std::os::raw::c_long,
+        _Origin: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn fsetpos(arg1: *mut FILE, arg2: *const fpos_t) -> ::std::os::raw::c_int;
+    pub fn _fseeki64(
+        _Stream: *mut FILE,
+        _Offset: ::std::os::raw::c_longlong,
+        _Origin: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn ftell(arg1: *mut FILE) -> ::std::os::raw::c_long;
+    pub fn ftell(_Stream: *mut FILE) -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn _ftelli64(_Stream: *mut FILE) -> ::std::os::raw::c_longlong;
 }
 unsafe extern "C" {
     pub fn fwrite(
-        __ptr: *const ::std::os::raw::c_void,
-        __size: ::std::os::raw::c_ulong,
-        __nitems: ::std::os::raw::c_ulong,
-        __stream: *mut FILE,
-    ) -> ::std::os::raw::c_ulong;
+        _Buffer: *const ::std::os::raw::c_void,
+        _ElementSize: ::std::os::raw::c_ulonglong,
+        _ElementCount: ::std::os::raw::c_ulonglong,
+        _Stream: *mut FILE,
+    ) -> ::std::os::raw::c_ulonglong;
 }
 unsafe extern "C" {
-    pub fn getc(arg1: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn getc(_Stream: *mut FILE) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
     pub fn getchar() -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn gets(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+    pub fn _getmaxstdio() -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn perror(arg1: *const ::std::os::raw::c_char);
+    pub fn _getw(_Stream: *mut FILE) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn printf(arg1: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
+    pub fn perror(_ErrorMessage: *const ::std::os::raw::c_char);
 }
 unsafe extern "C" {
-    pub fn putc(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn _pclose(_Stream: *mut FILE) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn putchar(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn _popen(
+        _Command: *const ::std::os::raw::c_char,
+        _Mode: *const ::std::os::raw::c_char,
+    ) -> *mut FILE;
 }
 unsafe extern "C" {
-    pub fn puts(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+    pub fn putc(_Character: ::std::os::raw::c_int, _Stream: *mut FILE) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn remove(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+    pub fn putchar(_Character: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn puts(_Buffer: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _putw(_Word: ::std::os::raw::c_int, _Stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn remove(_FileName: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
     pub fn rename(
-        __old: *const ::std::os::raw::c_char,
-        __new: *const ::std::os::raw::c_char,
+        _OldFileName: *const ::std::os::raw::c_char,
+        _NewFileName: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn rewind(arg1: *mut FILE);
+    pub fn _unlink(_FileName: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn scanf(arg1: *const ::std::os::raw::c_char, ...) -> ::std::os::raw::c_int;
+    pub fn unlink(_FileName: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn setbuf(arg1: *mut FILE, arg2: *mut ::std::os::raw::c_char);
+    pub fn rewind(_Stream: *mut FILE);
+}
+unsafe extern "C" {
+    pub fn _rmtmp() -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn setbuf(_Stream: *mut FILE, _Buffer: *mut ::std::os::raw::c_char);
+}
+unsafe extern "C" {
+    pub fn _setmaxstdio(_Maximum: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
     pub fn setvbuf(
-        arg1: *mut FILE,
-        arg2: *mut ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
-        arg4: usize,
+        _Stream: *mut FILE,
+        _Buffer: *mut ::std::os::raw::c_char,
+        _Mode: ::std::os::raw::c_int,
+        _Size: usize,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn sprintf(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn sscanf(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
+    pub fn _tempnam(
+        _DirectoryName: *const ::std::os::raw::c_char,
+        _FilePrefix: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     pub fn tmpfile() -> *mut FILE;
 }
 unsafe extern "C" {
-    pub fn tmpnam(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+    pub fn tmpnam(_Buffer: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn ungetc(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn ungetc(_Character: ::std::os::raw::c_int, _Stream: *mut FILE) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn vfprintf(
-        arg1: *mut FILE,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: __builtin_va_list,
+    pub fn _lock_file(_Stream: *mut FILE);
+}
+unsafe extern "C" {
+    pub fn _unlock_file(_Stream: *mut FILE);
+}
+unsafe extern "C" {
+    pub fn _fclose_nolock(_Stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _fflush_nolock(_Stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _fgetc_nolock(_Stream: *mut FILE) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _fputc_nolock(
+        _Character: ::std::os::raw::c_int,
+        _Stream: *mut FILE,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn vprintf(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: __builtin_va_list,
+    pub fn _fread_nolock(
+        _Buffer: *mut ::std::os::raw::c_void,
+        _ElementSize: usize,
+        _ElementCount: usize,
+        _Stream: *mut FILE,
+    ) -> usize;
+}
+unsafe extern "C" {
+    pub fn _fread_nolock_s(
+        _Buffer: *mut ::std::os::raw::c_void,
+        _BufferSize: usize,
+        _ElementSize: usize,
+        _ElementCount: usize,
+        _Stream: *mut FILE,
+    ) -> usize;
+}
+unsafe extern "C" {
+    pub fn _fseek_nolock(
+        _Stream: *mut FILE,
+        _Offset: ::std::os::raw::c_long,
+        _Origin: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn vsprintf(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: __builtin_va_list,
+    pub fn _fseeki64_nolock(
+        _Stream: *mut FILE,
+        _Offset: ::std::os::raw::c_longlong,
+        _Origin: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn ctermid(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+    pub fn _ftell_nolock(_Stream: *mut FILE) -> ::std::os::raw::c_long;
 }
 unsafe extern "C" {
-    pub fn fdopen(arg1: ::std::os::raw::c_int, arg2: *const ::std::os::raw::c_char) -> *mut FILE;
+    pub fn _ftelli64_nolock(_Stream: *mut FILE) -> ::std::os::raw::c_longlong;
 }
 unsafe extern "C" {
-    pub fn fileno(arg1: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn _fwrite_nolock(
+        _Buffer: *const ::std::os::raw::c_void,
+        _ElementSize: usize,
+        _ElementCount: usize,
+        _Stream: *mut FILE,
+    ) -> usize;
 }
 unsafe extern "C" {
-    pub fn pclose(arg1: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn _getc_nolock(_Stream: *mut FILE) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn popen(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-    ) -> *mut FILE;
-}
-unsafe extern "C" {
-    pub fn __srget(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn __svfscanf(
-        arg1: *mut FILE,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: va_list,
+    pub fn _putc_nolock(
+        _Character: ::std::os::raw::c_int,
+        _Stream: *mut FILE,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn __swbuf(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn _ungetc_nolock(
+        _Character: ::std::os::raw::c_int,
+        _Stream: *mut FILE,
+    ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn flockfile(arg1: *mut FILE);
+    pub fn __p__commode() -> *mut ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn ftrylockfile(arg1: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn __stdio_common_vfprintf(
+        _Options: ::std::os::raw::c_ulonglong,
+        _Stream: *mut FILE,
+        _Format: *const ::std::os::raw::c_char,
+        _Locale: _locale_t,
+        _ArgList: va_list,
+    ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn funlockfile(arg1: *mut FILE);
+    pub fn __stdio_common_vfprintf_s(
+        _Options: ::std::os::raw::c_ulonglong,
+        _Stream: *mut FILE,
+        _Format: *const ::std::os::raw::c_char,
+        _Locale: _locale_t,
+        _ArgList: va_list,
+    ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn getc_unlocked(arg1: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn __stdio_common_vfprintf_p(
+        _Options: ::std::os::raw::c_ulonglong,
+        _Stream: *mut FILE,
+        _Format: *const ::std::os::raw::c_char,
+        _Locale: _locale_t,
+        _ArgList: va_list,
+    ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn getchar_unlocked() -> ::std::os::raw::c_int;
+    pub fn _set_printf_count_output(_Value: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn putc_unlocked(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn _get_printf_count_output() -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn putchar_unlocked(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn __stdio_common_vfscanf(
+        _Options: ::std::os::raw::c_ulonglong,
+        _Stream: *mut FILE,
+        _Format: *const ::std::os::raw::c_char,
+        _Locale: _locale_t,
+        _Arglist: va_list,
+    ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn getw(arg1: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn __stdio_common_vsprintf(
+        _Options: ::std::os::raw::c_ulonglong,
+        _Buffer: *mut ::std::os::raw::c_char,
+        _BufferCount: usize,
+        _Format: *const ::std::os::raw::c_char,
+        _Locale: _locale_t,
+        _ArgList: va_list,
+    ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn putw(arg1: ::std::os::raw::c_int, arg2: *mut FILE) -> ::std::os::raw::c_int;
+    pub fn __stdio_common_vsprintf_s(
+        _Options: ::std::os::raw::c_ulonglong,
+        _Buffer: *mut ::std::os::raw::c_char,
+        _BufferCount: usize,
+        _Format: *const ::std::os::raw::c_char,
+        _Locale: _locale_t,
+        _ArgList: va_list,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn __stdio_common_vsnprintf_s(
+        _Options: ::std::os::raw::c_ulonglong,
+        _Buffer: *mut ::std::os::raw::c_char,
+        _BufferCount: usize,
+        _MaxCount: usize,
+        _Format: *const ::std::os::raw::c_char,
+        _Locale: _locale_t,
+        _ArgList: va_list,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn __stdio_common_vsprintf_p(
+        _Options: ::std::os::raw::c_ulonglong,
+        _Buffer: *mut ::std::os::raw::c_char,
+        _BufferCount: usize,
+        _Format: *const ::std::os::raw::c_char,
+        _Locale: _locale_t,
+        _ArgList: va_list,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn __stdio_common_vsscanf(
+        _Options: ::std::os::raw::c_ulonglong,
+        _Buffer: *const ::std::os::raw::c_char,
+        _BufferCount: usize,
+        _Format: *const ::std::os::raw::c_char,
+        _Locale: _locale_t,
+        _ArgList: va_list,
+    ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
     pub fn tempnam(
-        __dir: *const ::std::os::raw::c_char,
-        __prefix: *const ::std::os::raw::c_char,
+        _Directory: *const ::std::os::raw::c_char,
+        _FilePrefix: *const ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
-pub type off_t = __darwin_off_t;
 unsafe extern "C" {
-    pub fn fseeko(
-        __stream: *mut FILE,
-        __offset: off_t,
-        __whence: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
+    pub fn fcloseall() -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn ftello(__stream: *mut FILE) -> off_t;
-}
-unsafe extern "C" {
-    pub fn snprintf(
-        __str: *mut ::std::os::raw::c_char,
-        __size: ::std::os::raw::c_ulong,
-        __format: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn vfscanf(
-        __stream: *mut FILE,
-        __format: *const ::std::os::raw::c_char,
-        arg1: __builtin_va_list,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn vscanf(
-        __format: *const ::std::os::raw::c_char,
-        arg1: __builtin_va_list,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn vsnprintf(
-        __str: *mut ::std::os::raw::c_char,
-        __size: ::std::os::raw::c_ulong,
-        __format: *const ::std::os::raw::c_char,
-        arg1: __builtin_va_list,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn vsscanf(
-        __str: *const ::std::os::raw::c_char,
-        __format: *const ::std::os::raw::c_char,
-        arg1: __builtin_va_list,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn dprintf(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn vdprintf(
-        arg1: ::std::os::raw::c_int,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: va_list,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn getdelim(
-        __linep: *mut *mut ::std::os::raw::c_char,
-        __linecapp: *mut usize,
-        __delimiter: ::std::os::raw::c_int,
-        __stream: *mut FILE,
-    ) -> isize;
-}
-unsafe extern "C" {
-    pub fn getline(
-        __linep: *mut *mut ::std::os::raw::c_char,
-        __linecapp: *mut usize,
-        __stream: *mut FILE,
-    ) -> isize;
-}
-unsafe extern "C" {
-    pub fn fmemopen(
-        __buf: *mut ::std::os::raw::c_void,
-        __size: usize,
-        __mode: *const ::std::os::raw::c_char,
+    pub fn fdopen(
+        _FileHandle: ::std::os::raw::c_int,
+        _Format: *const ::std::os::raw::c_char,
     ) -> *mut FILE;
 }
 unsafe extern "C" {
-    pub fn open_memstream(
-        __bufp: *mut *mut ::std::os::raw::c_char,
-        __sizep: *mut usize,
-    ) -> *mut FILE;
+    pub fn fgetchar() -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub static sys_nerr: ::std::os::raw::c_int;
+    pub fn fileno(_Stream: *mut FILE) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub static sys_errlist: [*const ::std::os::raw::c_char; 0usize];
+    pub fn flushall() -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn asprintf(
-        arg1: *mut *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
+    pub fn fputchar(_Ch: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn ctermid_r(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+    pub fn getw(_Stream: *mut FILE) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn fgetln(arg1: *mut FILE, arg2: *mut usize) -> *mut ::std::os::raw::c_char;
+    pub fn putw(_Ch: ::std::os::raw::c_int, _Stream: *mut FILE) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn fmtcheck(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-    ) -> *const ::std::os::raw::c_char;
+    pub fn rmtmp() -> ::std::os::raw::c_int;
 }
-unsafe extern "C" {
-    pub fn fpurge(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn setbuffer(
-        arg1: *mut FILE,
-        arg2: *mut ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
-    );
-}
-unsafe extern "C" {
-    pub fn setlinebuf(arg1: *mut FILE) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn vasprintf(
-        arg1: *mut *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: va_list,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn funopen(
-        arg1: *const ::std::os::raw::c_void,
-        arg2: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: *mut ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int,
-        >,
-        arg3: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_char,
-                arg3: ::std::os::raw::c_int,
-            ) -> ::std::os::raw::c_int,
-        >,
-        arg4: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: fpos_t,
-                arg3: ::std::os::raw::c_int,
-            ) -> fpos_t,
-        >,
-        arg5: ::std::option::Option<
-            unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
-        >,
-    ) -> *mut FILE;
-}
-unsafe extern "C" {
-    pub fn __sprintf_chk(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
-        arg3: usize,
-        arg4: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn __snprintf_chk(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: usize,
-        arg3: ::std::os::raw::c_int,
-        arg4: usize,
-        arg5: *const ::std::os::raw::c_char,
-        ...
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn __vsprintf_chk(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
-        arg3: usize,
-        arg4: *const ::std::os::raw::c_char,
-        arg5: va_list,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn __vsnprintf_chk(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: usize,
-        arg3: ::std::os::raw::c_int,
-        arg4: usize,
-        arg5: *const ::std::os::raw::c_char,
-        arg6: va_list,
-    ) -> ::std::os::raw::c_int;
-}
-pub type int_least8_t = i8;
-pub type int_least16_t = i16;
-pub type int_least32_t = i32;
-pub type int_least64_t = i64;
-pub type uint_least8_t = u8;
-pub type uint_least16_t = u16;
-pub type uint_least32_t = u32;
-pub type uint_least64_t = u64;
-pub type int_fast8_t = i8;
-pub type int_fast16_t = i16;
-pub type int_fast32_t = i32;
-pub type int_fast64_t = i64;
-pub type uint_fast8_t = u8;
-pub type uint_fast16_t = u16;
-pub type uint_fast32_t = u32;
-pub type uint_fast64_t = u64;
-pub type intmax_t = ::std::os::raw::c_long;
-pub type uintmax_t = ::std::os::raw::c_ulong;
-pub type float_t = f32;
-pub type double_t = f64;
-unsafe extern "C" {
-    pub fn __math_errhandling() -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn __fpclassifyf(arg1: f32) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn __fpclassifyd(arg1: f64) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn __fpclassifyl(arg1: f64) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn acosf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn acos(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn acosl(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn asinf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn asin(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn asinl(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn atanf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn atan(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn atanl(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn atan2f(arg1: f32, arg2: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn atan2(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn atan2l(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn cosf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn cos(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn cosl(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn sinf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn sin(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn sinl(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn tanf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn tan(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn tanl(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn acoshf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn acosh(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn acoshl(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn asinhf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn asinh(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn asinhl(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn atanhf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn atanh(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn atanhl(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn coshf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn cosh(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn coshl(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn sinhf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn sinh(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn sinhl(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn tanhf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn tanh(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn tanhl(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn expf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn exp(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn expl(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn exp2f(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn exp2(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn exp2l(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn expm1f(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn expm1(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn expm1l(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn logf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn log(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn logl(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn log10f(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn log10(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn log10l(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn log2f(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn log2(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn log2l(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn log1pf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn log1p(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn log1pl(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn logbf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn logb(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn logbl(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn modff(arg1: f32, arg2: *mut f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn modf(arg1: f64, arg2: *mut f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn modfl(arg1: f64, arg2: *mut f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn ldexpf(arg1: f32, arg2: ::std::os::raw::c_int) -> f32;
-}
-unsafe extern "C" {
-    pub fn ldexp(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
-}
-unsafe extern "C" {
-    pub fn ldexpl(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
-}
-unsafe extern "C" {
-    pub fn frexpf(arg1: f32, arg2: *mut ::std::os::raw::c_int) -> f32;
-}
-unsafe extern "C" {
-    pub fn frexp(arg1: f64, arg2: *mut ::std::os::raw::c_int) -> f64;
-}
-unsafe extern "C" {
-    pub fn frexpl(arg1: f64, arg2: *mut ::std::os::raw::c_int) -> f64;
-}
-unsafe extern "C" {
-    pub fn ilogbf(arg1: f32) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn ilogb(arg1: f64) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn ilogbl(arg1: f64) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn scalbnf(arg1: f32, arg2: ::std::os::raw::c_int) -> f32;
-}
-unsafe extern "C" {
-    pub fn scalbn(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
-}
-unsafe extern "C" {
-    pub fn scalbnl(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
-}
-unsafe extern "C" {
-    pub fn scalblnf(arg1: f32, arg2: ::std::os::raw::c_long) -> f32;
-}
-unsafe extern "C" {
-    pub fn scalbln(arg1: f64, arg2: ::std::os::raw::c_long) -> f64;
-}
-unsafe extern "C" {
-    pub fn scalblnl(arg1: f64, arg2: ::std::os::raw::c_long) -> f64;
-}
-unsafe extern "C" {
-    pub fn fabsf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn fabs(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn fabsl(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn cbrtf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn cbrt(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn cbrtl(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn hypotf(arg1: f32, arg2: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn hypot(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn hypotl(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn powf(arg1: f32, arg2: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn pow(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn powl(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn sqrtf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn sqrt(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn sqrtl(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn erff(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn erf(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn erfl(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn erfcf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn erfc(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn erfcl(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn lgammaf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn lgamma(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn lgammal(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn tgammaf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn tgamma(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn tgammal(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn ceilf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn ceil(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn ceill(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn floorf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn floor(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn floorl(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn nearbyintf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn nearbyint(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn nearbyintl(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn rintf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn rint(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn rintl(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn lrintf(arg1: f32) -> ::std::os::raw::c_long;
-}
-unsafe extern "C" {
-    pub fn lrint(arg1: f64) -> ::std::os::raw::c_long;
-}
-unsafe extern "C" {
-    pub fn lrintl(arg1: f64) -> ::std::os::raw::c_long;
-}
-unsafe extern "C" {
-    pub fn roundf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn round(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn roundl(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn lroundf(arg1: f32) -> ::std::os::raw::c_long;
-}
-unsafe extern "C" {
-    pub fn lround(arg1: f64) -> ::std::os::raw::c_long;
-}
-unsafe extern "C" {
-    pub fn lroundl(arg1: f64) -> ::std::os::raw::c_long;
-}
-unsafe extern "C" {
-    pub fn llrintf(arg1: f32) -> ::std::os::raw::c_longlong;
-}
-unsafe extern "C" {
-    pub fn llrint(arg1: f64) -> ::std::os::raw::c_longlong;
-}
-unsafe extern "C" {
-    pub fn llrintl(arg1: f64) -> ::std::os::raw::c_longlong;
-}
-unsafe extern "C" {
-    pub fn llroundf(arg1: f32) -> ::std::os::raw::c_longlong;
-}
-unsafe extern "C" {
-    pub fn llround(arg1: f64) -> ::std::os::raw::c_longlong;
-}
-unsafe extern "C" {
-    pub fn llroundl(arg1: f64) -> ::std::os::raw::c_longlong;
-}
-unsafe extern "C" {
-    pub fn truncf(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn trunc(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn truncl(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn fmodf(arg1: f32, arg2: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn fmod(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn fmodl(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn remainderf(arg1: f32, arg2: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn remainder(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn remainderl(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn remquof(arg1: f32, arg2: f32, arg3: *mut ::std::os::raw::c_int) -> f32;
-}
-unsafe extern "C" {
-    pub fn remquo(arg1: f64, arg2: f64, arg3: *mut ::std::os::raw::c_int) -> f64;
-}
-unsafe extern "C" {
-    pub fn remquol(arg1: f64, arg2: f64, arg3: *mut ::std::os::raw::c_int) -> f64;
-}
-unsafe extern "C" {
-    pub fn copysignf(arg1: f32, arg2: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn copysign(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn copysignl(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn nanf(arg1: *const ::std::os::raw::c_char) -> f32;
-}
-unsafe extern "C" {
-    pub fn nan(arg1: *const ::std::os::raw::c_char) -> f64;
-}
-unsafe extern "C" {
-    pub fn nanl(arg1: *const ::std::os::raw::c_char) -> f64;
-}
-unsafe extern "C" {
-    pub fn nextafterf(arg1: f32, arg2: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn nextafter(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn nextafterl(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn nexttoward(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn nexttowardf(arg1: f32, arg2: f64) -> f32;
-}
-unsafe extern "C" {
-    pub fn nexttowardl(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn fdimf(arg1: f32, arg2: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn fdim(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn fdiml(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn fmaxf(arg1: f32, arg2: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn fmax(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn fmaxl(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn fminf(arg1: f32, arg2: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn fmin(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn fminl(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn fmaf(arg1: f32, arg2: f32, arg3: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn fma(arg1: f64, arg2: f64, arg3: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn fmal(arg1: f64, arg2: f64, arg3: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn __exp10f(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn __exp10(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn __cospif(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn __cospi(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn __sinpif(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn __sinpi(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn __tanpif(arg1: f32) -> f32;
-}
-unsafe extern "C" {
-    pub fn __tanpi(arg1: f64) -> f64;
-}
+pub type int_least8_t = ::std::os::raw::c_schar;
+pub type int_least16_t = ::std::os::raw::c_short;
+pub type int_least32_t = ::std::os::raw::c_int;
+pub type int_least64_t = ::std::os::raw::c_longlong;
+pub type uint_least8_t = ::std::os::raw::c_uchar;
+pub type uint_least16_t = ::std::os::raw::c_ushort;
+pub type uint_least32_t = ::std::os::raw::c_uint;
+pub type uint_least64_t = ::std::os::raw::c_ulonglong;
+pub type int_fast8_t = ::std::os::raw::c_schar;
+pub type int_fast16_t = ::std::os::raw::c_int;
+pub type int_fast32_t = ::std::os::raw::c_int;
+pub type int_fast64_t = ::std::os::raw::c_longlong;
+pub type uint_fast8_t = ::std::os::raw::c_uchar;
+pub type uint_fast16_t = ::std::os::raw::c_uint;
+pub type uint_fast32_t = ::std::os::raw::c_uint;
+pub type uint_fast64_t = ::std::os::raw::c_ulonglong;
+pub type intmax_t = ::std::os::raw::c_longlong;
+pub type uintmax_t = ::std::os::raw::c_ulonglong;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct __float2 {
-    pub __sinval: f32,
-    pub __cosval: f32,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __float2"][::std::mem::size_of::<__float2>() - 8usize];
-    ["Alignment of __float2"][::std::mem::align_of::<__float2>() - 4usize];
-    ["Offset of field: __float2::__sinval"][::std::mem::offset_of!(__float2, __sinval) - 0usize];
-    ["Offset of field: __float2::__cosval"][::std::mem::offset_of!(__float2, __cosval) - 4usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __double2 {
-    pub __sinval: f64,
-    pub __cosval: f64,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __double2"][::std::mem::size_of::<__double2>() - 16usize];
-    ["Alignment of __double2"][::std::mem::align_of::<__double2>() - 8usize];
-    ["Offset of field: __double2::__sinval"][::std::mem::offset_of!(__double2, __sinval) - 0usize];
-    ["Offset of field: __double2::__cosval"][::std::mem::offset_of!(__double2, __cosval) - 8usize];
-};
-unsafe extern "C" {
-    pub fn __sincosf_stret(arg1: f32) -> __float2;
-}
-unsafe extern "C" {
-    pub fn __sincos_stret(arg1: f64) -> __double2;
-}
-unsafe extern "C" {
-    pub fn __sincospif_stret(arg1: f32) -> __float2;
-}
-unsafe extern "C" {
-    pub fn __sincospi_stret(arg1: f64) -> __double2;
-}
-unsafe extern "C" {
-    pub fn j0(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn j1(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn jn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn y0(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn y1(arg1: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn yn(arg1: ::std::os::raw::c_int, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub fn scalb(arg1: f64, arg2: f64) -> f64;
-}
-unsafe extern "C" {
-    pub static mut signgam: ::std::os::raw::c_int;
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct exception {
+pub struct _exception {
     pub type_: ::std::os::raw::c_int,
     pub name: *mut ::std::os::raw::c_char,
     pub arg1: f64,
@@ -2717,2437 +1597,2338 @@ pub struct exception {
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of exception"][::std::mem::size_of::<exception>() - 40usize];
-    ["Alignment of exception"][::std::mem::align_of::<exception>() - 8usize];
-    ["Offset of field: exception::type_"][::std::mem::offset_of!(exception, type_) - 0usize];
-    ["Offset of field: exception::name"][::std::mem::offset_of!(exception, name) - 8usize];
-    ["Offset of field: exception::arg1"][::std::mem::offset_of!(exception, arg1) - 16usize];
-    ["Offset of field: exception::arg2"][::std::mem::offset_of!(exception, arg2) - 24usize];
-    ["Offset of field: exception::retval"][::std::mem::offset_of!(exception, retval) - 32usize];
+    ["Size of _exception"][::std::mem::size_of::<_exception>() - 40usize];
+    ["Alignment of _exception"][::std::mem::align_of::<_exception>() - 8usize];
+    ["Offset of field: _exception::type_"][::std::mem::offset_of!(_exception, type_) - 0usize];
+    ["Offset of field: _exception::name"][::std::mem::offset_of!(_exception, name) - 8usize];
+    ["Offset of field: _exception::arg1"][::std::mem::offset_of!(_exception, arg1) - 16usize];
+    ["Offset of field: _exception::arg2"][::std::mem::offset_of!(_exception, arg2) - 24usize];
+    ["Offset of field: _exception::retval"][::std::mem::offset_of!(_exception, retval) - 32usize];
 };
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _complex {
+    pub x: f64,
+    pub y: f64,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of _complex"][::std::mem::size_of::<_complex>() - 16usize];
+    ["Alignment of _complex"][::std::mem::align_of::<_complex>() - 8usize];
+    ["Offset of field: _complex::x"][::std::mem::offset_of!(_complex, x) - 0usize];
+    ["Offset of field: _complex::y"][::std::mem::offset_of!(_complex, y) - 8usize];
+};
+pub type float_t = f32;
+pub type double_t = f64;
 unsafe extern "C" {
-    pub fn __assert_rtn(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
-        arg4: *const ::std::os::raw::c_char,
-    ) -> !;
+    pub static _HUGE: f64;
 }
-pub const idtype_t_P_ALL: idtype_t = 0;
-pub const idtype_t_P_PID: idtype_t = 1;
-pub const idtype_t_P_PGID: idtype_t = 2;
-pub type idtype_t = ::std::os::raw::c_uint;
-pub type pid_t = __darwin_pid_t;
-pub type id_t = __darwin_id_t;
-pub type sig_atomic_t = ::std::os::raw::c_int;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_arm_exception_state {
-    pub __exception: __uint32_t,
-    pub __fsr: __uint32_t,
-    pub __far: __uint32_t,
+unsafe extern "C" {
+    pub fn _fperrraise(_Except: ::std::os::raw::c_int);
 }
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __darwin_arm_exception_state"]
-        [::std::mem::size_of::<__darwin_arm_exception_state>() - 12usize];
-    ["Alignment of __darwin_arm_exception_state"]
-        [::std::mem::align_of::<__darwin_arm_exception_state>() - 4usize];
-    ["Offset of field: __darwin_arm_exception_state::__exception"]
-        [::std::mem::offset_of!(__darwin_arm_exception_state, __exception) - 0usize];
-    ["Offset of field: __darwin_arm_exception_state::__fsr"]
-        [::std::mem::offset_of!(__darwin_arm_exception_state, __fsr) - 4usize];
-    ["Offset of field: __darwin_arm_exception_state::__far"]
-        [::std::mem::offset_of!(__darwin_arm_exception_state, __far) - 8usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_arm_exception_state64 {
-    pub __far: __uint64_t,
-    pub __esr: __uint32_t,
-    pub __exception: __uint32_t,
+unsafe extern "C" {
+    pub fn _dclass(_X: f64) -> ::std::os::raw::c_short;
 }
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __darwin_arm_exception_state64"]
-        [::std::mem::size_of::<__darwin_arm_exception_state64>() - 16usize];
-    ["Alignment of __darwin_arm_exception_state64"]
-        [::std::mem::align_of::<__darwin_arm_exception_state64>() - 8usize];
-    ["Offset of field: __darwin_arm_exception_state64::__far"]
-        [::std::mem::offset_of!(__darwin_arm_exception_state64, __far) - 0usize];
-    ["Offset of field: __darwin_arm_exception_state64::__esr"]
-        [::std::mem::offset_of!(__darwin_arm_exception_state64, __esr) - 8usize];
-    ["Offset of field: __darwin_arm_exception_state64::__exception"]
-        [::std::mem::offset_of!(__darwin_arm_exception_state64, __exception) - 12usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_arm_thread_state {
-    pub __r: [__uint32_t; 13usize],
-    pub __sp: __uint32_t,
-    pub __lr: __uint32_t,
-    pub __pc: __uint32_t,
-    pub __cpsr: __uint32_t,
+unsafe extern "C" {
+    pub fn _ldclass(_X: f64) -> ::std::os::raw::c_short;
 }
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __darwin_arm_thread_state"]
-        [::std::mem::size_of::<__darwin_arm_thread_state>() - 68usize];
-    ["Alignment of __darwin_arm_thread_state"]
-        [::std::mem::align_of::<__darwin_arm_thread_state>() - 4usize];
-    ["Offset of field: __darwin_arm_thread_state::__r"]
-        [::std::mem::offset_of!(__darwin_arm_thread_state, __r) - 0usize];
-    ["Offset of field: __darwin_arm_thread_state::__sp"]
-        [::std::mem::offset_of!(__darwin_arm_thread_state, __sp) - 52usize];
-    ["Offset of field: __darwin_arm_thread_state::__lr"]
-        [::std::mem::offset_of!(__darwin_arm_thread_state, __lr) - 56usize];
-    ["Offset of field: __darwin_arm_thread_state::__pc"]
-        [::std::mem::offset_of!(__darwin_arm_thread_state, __pc) - 60usize];
-    ["Offset of field: __darwin_arm_thread_state::__cpsr"]
-        [::std::mem::offset_of!(__darwin_arm_thread_state, __cpsr) - 64usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_arm_thread_state64 {
-    pub __x: [__uint64_t; 29usize],
-    pub __fp: __uint64_t,
-    pub __lr: __uint64_t,
-    pub __sp: __uint64_t,
-    pub __pc: __uint64_t,
-    pub __cpsr: __uint32_t,
-    pub __pad: __uint32_t,
+unsafe extern "C" {
+    pub fn _fdclass(_X: f32) -> ::std::os::raw::c_short;
 }
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __darwin_arm_thread_state64"]
-        [::std::mem::size_of::<__darwin_arm_thread_state64>() - 272usize];
-    ["Alignment of __darwin_arm_thread_state64"]
-        [::std::mem::align_of::<__darwin_arm_thread_state64>() - 8usize];
-    ["Offset of field: __darwin_arm_thread_state64::__x"]
-        [::std::mem::offset_of!(__darwin_arm_thread_state64, __x) - 0usize];
-    ["Offset of field: __darwin_arm_thread_state64::__fp"]
-        [::std::mem::offset_of!(__darwin_arm_thread_state64, __fp) - 232usize];
-    ["Offset of field: __darwin_arm_thread_state64::__lr"]
-        [::std::mem::offset_of!(__darwin_arm_thread_state64, __lr) - 240usize];
-    ["Offset of field: __darwin_arm_thread_state64::__sp"]
-        [::std::mem::offset_of!(__darwin_arm_thread_state64, __sp) - 248usize];
-    ["Offset of field: __darwin_arm_thread_state64::__pc"]
-        [::std::mem::offset_of!(__darwin_arm_thread_state64, __pc) - 256usize];
-    ["Offset of field: __darwin_arm_thread_state64::__cpsr"]
-        [::std::mem::offset_of!(__darwin_arm_thread_state64, __cpsr) - 264usize];
-    ["Offset of field: __darwin_arm_thread_state64::__pad"]
-        [::std::mem::offset_of!(__darwin_arm_thread_state64, __pad) - 268usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_arm_vfp_state {
-    pub __r: [__uint32_t; 64usize],
-    pub __fpscr: __uint32_t,
+unsafe extern "C" {
+    pub fn _dsign(_X: f64) -> ::std::os::raw::c_int;
 }
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __darwin_arm_vfp_state"][::std::mem::size_of::<__darwin_arm_vfp_state>() - 260usize];
-    ["Alignment of __darwin_arm_vfp_state"]
-        [::std::mem::align_of::<__darwin_arm_vfp_state>() - 4usize];
-    ["Offset of field: __darwin_arm_vfp_state::__r"]
-        [::std::mem::offset_of!(__darwin_arm_vfp_state, __r) - 0usize];
-    ["Offset of field: __darwin_arm_vfp_state::__fpscr"]
-        [::std::mem::offset_of!(__darwin_arm_vfp_state, __fpscr) - 256usize];
-};
-#[repr(C)]
-#[repr(align(16))]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_arm_neon_state64 {
-    pub __v: [__uint128_t; 32usize],
-    pub __fpsr: __uint32_t,
-    pub __fpcr: __uint32_t,
+unsafe extern "C" {
+    pub fn _ldsign(_X: f64) -> ::std::os::raw::c_int;
 }
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __darwin_arm_neon_state64"]
-        [::std::mem::size_of::<__darwin_arm_neon_state64>() - 528usize];
-    ["Alignment of __darwin_arm_neon_state64"]
-        [::std::mem::align_of::<__darwin_arm_neon_state64>() - 16usize];
-    ["Offset of field: __darwin_arm_neon_state64::__v"]
-        [::std::mem::offset_of!(__darwin_arm_neon_state64, __v) - 0usize];
-    ["Offset of field: __darwin_arm_neon_state64::__fpsr"]
-        [::std::mem::offset_of!(__darwin_arm_neon_state64, __fpsr) - 512usize];
-    ["Offset of field: __darwin_arm_neon_state64::__fpcr"]
-        [::std::mem::offset_of!(__darwin_arm_neon_state64, __fpcr) - 516usize];
-};
-#[repr(C)]
-#[repr(align(16))]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_arm_neon_state {
-    pub __v: [__uint128_t; 16usize],
-    pub __fpsr: __uint32_t,
-    pub __fpcr: __uint32_t,
+unsafe extern "C" {
+    pub fn _fdsign(_X: f32) -> ::std::os::raw::c_int;
 }
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __darwin_arm_neon_state"]
-        [::std::mem::size_of::<__darwin_arm_neon_state>() - 272usize];
-    ["Alignment of __darwin_arm_neon_state"]
-        [::std::mem::align_of::<__darwin_arm_neon_state>() - 16usize];
-    ["Offset of field: __darwin_arm_neon_state::__v"]
-        [::std::mem::offset_of!(__darwin_arm_neon_state, __v) - 0usize];
-    ["Offset of field: __darwin_arm_neon_state::__fpsr"]
-        [::std::mem::offset_of!(__darwin_arm_neon_state, __fpsr) - 256usize];
-    ["Offset of field: __darwin_arm_neon_state::__fpcr"]
-        [::std::mem::offset_of!(__darwin_arm_neon_state, __fpcr) - 260usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __arm_pagein_state {
-    pub __pagein_error: ::std::os::raw::c_int,
+unsafe extern "C" {
+    pub fn _dpcomp(_X: f64, _Y: f64) -> ::std::os::raw::c_int;
 }
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __arm_pagein_state"][::std::mem::size_of::<__arm_pagein_state>() - 4usize];
-    ["Alignment of __arm_pagein_state"][::std::mem::align_of::<__arm_pagein_state>() - 4usize];
-    ["Offset of field: __arm_pagein_state::__pagein_error"]
-        [::std::mem::offset_of!(__arm_pagein_state, __pagein_error) - 0usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __arm_legacy_debug_state {
-    pub __bvr: [__uint32_t; 16usize],
-    pub __bcr: [__uint32_t; 16usize],
-    pub __wvr: [__uint32_t; 16usize],
-    pub __wcr: [__uint32_t; 16usize],
+unsafe extern "C" {
+    pub fn _ldpcomp(_X: f64, _Y: f64) -> ::std::os::raw::c_int;
 }
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __arm_legacy_debug_state"]
-        [::std::mem::size_of::<__arm_legacy_debug_state>() - 256usize];
-    ["Alignment of __arm_legacy_debug_state"]
-        [::std::mem::align_of::<__arm_legacy_debug_state>() - 4usize];
-    ["Offset of field: __arm_legacy_debug_state::__bvr"]
-        [::std::mem::offset_of!(__arm_legacy_debug_state, __bvr) - 0usize];
-    ["Offset of field: __arm_legacy_debug_state::__bcr"]
-        [::std::mem::offset_of!(__arm_legacy_debug_state, __bcr) - 64usize];
-    ["Offset of field: __arm_legacy_debug_state::__wvr"]
-        [::std::mem::offset_of!(__arm_legacy_debug_state, __wvr) - 128usize];
-    ["Offset of field: __arm_legacy_debug_state::__wcr"]
-        [::std::mem::offset_of!(__arm_legacy_debug_state, __wcr) - 192usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_arm_debug_state32 {
-    pub __bvr: [__uint32_t; 16usize],
-    pub __bcr: [__uint32_t; 16usize],
-    pub __wvr: [__uint32_t; 16usize],
-    pub __wcr: [__uint32_t; 16usize],
-    pub __mdscr_el1: __uint64_t,
+unsafe extern "C" {
+    pub fn _fdpcomp(_X: f32, _Y: f32) -> ::std::os::raw::c_int;
 }
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __darwin_arm_debug_state32"]
-        [::std::mem::size_of::<__darwin_arm_debug_state32>() - 264usize];
-    ["Alignment of __darwin_arm_debug_state32"]
-        [::std::mem::align_of::<__darwin_arm_debug_state32>() - 8usize];
-    ["Offset of field: __darwin_arm_debug_state32::__bvr"]
-        [::std::mem::offset_of!(__darwin_arm_debug_state32, __bvr) - 0usize];
-    ["Offset of field: __darwin_arm_debug_state32::__bcr"]
-        [::std::mem::offset_of!(__darwin_arm_debug_state32, __bcr) - 64usize];
-    ["Offset of field: __darwin_arm_debug_state32::__wvr"]
-        [::std::mem::offset_of!(__darwin_arm_debug_state32, __wvr) - 128usize];
-    ["Offset of field: __darwin_arm_debug_state32::__wcr"]
-        [::std::mem::offset_of!(__darwin_arm_debug_state32, __wcr) - 192usize];
-    ["Offset of field: __darwin_arm_debug_state32::__mdscr_el1"]
-        [::std::mem::offset_of!(__darwin_arm_debug_state32, __mdscr_el1) - 256usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_arm_debug_state64 {
-    pub __bvr: [__uint64_t; 16usize],
-    pub __bcr: [__uint64_t; 16usize],
-    pub __wvr: [__uint64_t; 16usize],
-    pub __wcr: [__uint64_t; 16usize],
-    pub __mdscr_el1: __uint64_t,
+unsafe extern "C" {
+    pub fn _dtest(_Px: *mut f64) -> ::std::os::raw::c_short;
 }
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __darwin_arm_debug_state64"]
-        [::std::mem::size_of::<__darwin_arm_debug_state64>() - 520usize];
-    ["Alignment of __darwin_arm_debug_state64"]
-        [::std::mem::align_of::<__darwin_arm_debug_state64>() - 8usize];
-    ["Offset of field: __darwin_arm_debug_state64::__bvr"]
-        [::std::mem::offset_of!(__darwin_arm_debug_state64, __bvr) - 0usize];
-    ["Offset of field: __darwin_arm_debug_state64::__bcr"]
-        [::std::mem::offset_of!(__darwin_arm_debug_state64, __bcr) - 128usize];
-    ["Offset of field: __darwin_arm_debug_state64::__wvr"]
-        [::std::mem::offset_of!(__darwin_arm_debug_state64, __wvr) - 256usize];
-    ["Offset of field: __darwin_arm_debug_state64::__wcr"]
-        [::std::mem::offset_of!(__darwin_arm_debug_state64, __wcr) - 384usize];
-    ["Offset of field: __darwin_arm_debug_state64::__mdscr_el1"]
-        [::std::mem::offset_of!(__darwin_arm_debug_state64, __mdscr_el1) - 512usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_arm_cpmu_state64 {
-    pub __ctrs: [__uint64_t; 16usize],
+unsafe extern "C" {
+    pub fn _ldtest(_Px: *mut f64) -> ::std::os::raw::c_short;
 }
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __darwin_arm_cpmu_state64"]
-        [::std::mem::size_of::<__darwin_arm_cpmu_state64>() - 128usize];
-    ["Alignment of __darwin_arm_cpmu_state64"]
-        [::std::mem::align_of::<__darwin_arm_cpmu_state64>() - 8usize];
-    ["Offset of field: __darwin_arm_cpmu_state64::__ctrs"]
-        [::std::mem::offset_of!(__darwin_arm_cpmu_state64, __ctrs) - 0usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_mcontext32 {
-    pub __es: __darwin_arm_exception_state,
-    pub __ss: __darwin_arm_thread_state,
-    pub __fs: __darwin_arm_vfp_state,
+unsafe extern "C" {
+    pub fn _fdtest(_Px: *mut f32) -> ::std::os::raw::c_short;
 }
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __darwin_mcontext32"][::std::mem::size_of::<__darwin_mcontext32>() - 340usize];
-    ["Alignment of __darwin_mcontext32"][::std::mem::align_of::<__darwin_mcontext32>() - 4usize];
-    ["Offset of field: __darwin_mcontext32::__es"]
-        [::std::mem::offset_of!(__darwin_mcontext32, __es) - 0usize];
-    ["Offset of field: __darwin_mcontext32::__ss"]
-        [::std::mem::offset_of!(__darwin_mcontext32, __ss) - 12usize];
-    ["Offset of field: __darwin_mcontext32::__fs"]
-        [::std::mem::offset_of!(__darwin_mcontext32, __fs) - 80usize];
-};
-#[repr(C)]
-#[repr(align(16))]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_mcontext64 {
-    pub __es: __darwin_arm_exception_state64,
-    pub __ss: __darwin_arm_thread_state64,
-    pub __ns: __darwin_arm_neon_state64,
+unsafe extern "C" {
+    pub fn _d_int(_Px: *mut f64, _Xexp: ::std::os::raw::c_short) -> ::std::os::raw::c_short;
 }
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __darwin_mcontext64"][::std::mem::size_of::<__darwin_mcontext64>() - 816usize];
-    ["Alignment of __darwin_mcontext64"][::std::mem::align_of::<__darwin_mcontext64>() - 16usize];
-    ["Offset of field: __darwin_mcontext64::__es"]
-        [::std::mem::offset_of!(__darwin_mcontext64, __es) - 0usize];
-    ["Offset of field: __darwin_mcontext64::__ss"]
-        [::std::mem::offset_of!(__darwin_mcontext64, __ss) - 16usize];
-    ["Offset of field: __darwin_mcontext64::__ns"]
-        [::std::mem::offset_of!(__darwin_mcontext64, __ns) - 288usize];
-};
-pub type mcontext_t = *mut __darwin_mcontext64;
-pub type pthread_attr_t = __darwin_pthread_attr_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_sigaltstack {
-    pub ss_sp: *mut ::std::os::raw::c_void,
-    pub ss_size: __darwin_size_t,
-    pub ss_flags: ::std::os::raw::c_int,
+unsafe extern "C" {
+    pub fn _ld_int(_Px: *mut f64, _Xexp: ::std::os::raw::c_short) -> ::std::os::raw::c_short;
 }
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __darwin_sigaltstack"][::std::mem::size_of::<__darwin_sigaltstack>() - 24usize];
-    ["Alignment of __darwin_sigaltstack"][::std::mem::align_of::<__darwin_sigaltstack>() - 8usize];
-    ["Offset of field: __darwin_sigaltstack::ss_sp"]
-        [::std::mem::offset_of!(__darwin_sigaltstack, ss_sp) - 0usize];
-    ["Offset of field: __darwin_sigaltstack::ss_size"]
-        [::std::mem::offset_of!(__darwin_sigaltstack, ss_size) - 8usize];
-    ["Offset of field: __darwin_sigaltstack::ss_flags"]
-        [::std::mem::offset_of!(__darwin_sigaltstack, ss_flags) - 16usize];
-};
-pub type stack_t = __darwin_sigaltstack;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct __darwin_ucontext {
-    pub uc_onstack: ::std::os::raw::c_int,
-    pub uc_sigmask: __darwin_sigset_t,
-    pub uc_stack: __darwin_sigaltstack,
-    pub uc_link: *mut __darwin_ucontext,
-    pub uc_mcsize: __darwin_size_t,
-    pub uc_mcontext: *mut __darwin_mcontext64,
+unsafe extern "C" {
+    pub fn _fd_int(_Px: *mut f32, _Xexp: ::std::os::raw::c_short) -> ::std::os::raw::c_short;
 }
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __darwin_ucontext"][::std::mem::size_of::<__darwin_ucontext>() - 56usize];
-    ["Alignment of __darwin_ucontext"][::std::mem::align_of::<__darwin_ucontext>() - 8usize];
-    ["Offset of field: __darwin_ucontext::uc_onstack"]
-        [::std::mem::offset_of!(__darwin_ucontext, uc_onstack) - 0usize];
-    ["Offset of field: __darwin_ucontext::uc_sigmask"]
-        [::std::mem::offset_of!(__darwin_ucontext, uc_sigmask) - 4usize];
-    ["Offset of field: __darwin_ucontext::uc_stack"]
-        [::std::mem::offset_of!(__darwin_ucontext, uc_stack) - 8usize];
-    ["Offset of field: __darwin_ucontext::uc_link"]
-        [::std::mem::offset_of!(__darwin_ucontext, uc_link) - 32usize];
-    ["Offset of field: __darwin_ucontext::uc_mcsize"]
-        [::std::mem::offset_of!(__darwin_ucontext, uc_mcsize) - 40usize];
-    ["Offset of field: __darwin_ucontext::uc_mcontext"]
-        [::std::mem::offset_of!(__darwin_ucontext, uc_mcontext) - 48usize];
-};
-pub type ucontext_t = __darwin_ucontext;
-pub type sigset_t = __darwin_sigset_t;
-pub type uid_t = __darwin_uid_t;
+unsafe extern "C" {
+    pub fn _dscale(_Px: *mut f64, _Lexp: ::std::os::raw::c_long) -> ::std::os::raw::c_short;
+}
+unsafe extern "C" {
+    pub fn _ldscale(_Px: *mut f64, _Lexp: ::std::os::raw::c_long) -> ::std::os::raw::c_short;
+}
+unsafe extern "C" {
+    pub fn _fdscale(_Px: *mut f32, _Lexp: ::std::os::raw::c_long) -> ::std::os::raw::c_short;
+}
+unsafe extern "C" {
+    pub fn _dunscale(_Pex: *mut ::std::os::raw::c_short, _Px: *mut f64) -> ::std::os::raw::c_short;
+}
+unsafe extern "C" {
+    pub fn _ldunscale(_Pex: *mut ::std::os::raw::c_short, _Px: *mut f64)
+    -> ::std::os::raw::c_short;
+}
+unsafe extern "C" {
+    pub fn _fdunscale(_Pex: *mut ::std::os::raw::c_short, _Px: *mut f32)
+    -> ::std::os::raw::c_short;
+}
+unsafe extern "C" {
+    pub fn _dexp(_Px: *mut f64, _Y: f64, _Eoff: ::std::os::raw::c_long) -> ::std::os::raw::c_short;
+}
+unsafe extern "C" {
+    pub fn _ldexp(_Px: *mut f64, _Y: f64, _Eoff: ::std::os::raw::c_long)
+    -> ::std::os::raw::c_short;
+}
+unsafe extern "C" {
+    pub fn _fdexp(_Px: *mut f32, _Y: f32, _Eoff: ::std::os::raw::c_long)
+    -> ::std::os::raw::c_short;
+}
+unsafe extern "C" {
+    pub fn _dnorm(_Ps: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_short;
+}
+unsafe extern "C" {
+    pub fn _fdnorm(_Ps: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_short;
+}
+unsafe extern "C" {
+    pub fn _dpoly(_X: f64, _Tab: *const f64, _N: ::std::os::raw::c_int) -> f64;
+}
+unsafe extern "C" {
+    pub fn _ldpoly(_X: f64, _Tab: *const f64, _N: ::std::os::raw::c_int) -> f64;
+}
+unsafe extern "C" {
+    pub fn _fdpoly(_X: f32, _Tab: *const f32, _N: ::std::os::raw::c_int) -> f32;
+}
+unsafe extern "C" {
+    pub fn _dlog(_X: f64, _Baseflag: ::std::os::raw::c_int) -> f64;
+}
+unsafe extern "C" {
+    pub fn _ldlog(_X: f64, _Baseflag: ::std::os::raw::c_int) -> f64;
+}
+unsafe extern "C" {
+    pub fn _fdlog(_X: f32, _Baseflag: ::std::os::raw::c_int) -> f32;
+}
+unsafe extern "C" {
+    pub fn _dsin(_X: f64, _Qoff: ::std::os::raw::c_uint) -> f64;
+}
+unsafe extern "C" {
+    pub fn _ldsin(_X: f64, _Qoff: ::std::os::raw::c_uint) -> f64;
+}
+unsafe extern "C" {
+    pub fn _fdsin(_X: f32, _Qoff: ::std::os::raw::c_uint) -> f32;
+}
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub union sigval {
-    pub sival_int: ::std::os::raw::c_int,
-    pub sival_ptr: *mut ::std::os::raw::c_void,
+pub union _double_val {
+    pub _Sh: [::std::os::raw::c_ushort; 4usize],
+    pub _Val: f64,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of sigval"][::std::mem::size_of::<sigval>() - 8usize];
-    ["Alignment of sigval"][::std::mem::align_of::<sigval>() - 8usize];
-    ["Offset of field: sigval::sival_int"][::std::mem::offset_of!(sigval, sival_int) - 0usize];
-    ["Offset of field: sigval::sival_ptr"][::std::mem::offset_of!(sigval, sival_ptr) - 0usize];
+    ["Size of _double_val"][::std::mem::size_of::<_double_val>() - 8usize];
+    ["Alignment of _double_val"][::std::mem::align_of::<_double_val>() - 8usize];
+    ["Offset of field: _double_val::_Sh"][::std::mem::offset_of!(_double_val, _Sh) - 0usize];
+    ["Offset of field: _double_val::_Val"][::std::mem::offset_of!(_double_val, _Val) - 0usize];
 };
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub struct sigevent {
-    pub sigev_notify: ::std::os::raw::c_int,
-    pub sigev_signo: ::std::os::raw::c_int,
-    pub sigev_value: sigval,
-    pub sigev_notify_function: ::std::option::Option<unsafe extern "C" fn(arg1: sigval)>,
-    pub sigev_notify_attributes: *mut pthread_attr_t,
+pub union _float_val {
+    pub _Sh: [::std::os::raw::c_ushort; 2usize],
+    pub _Val: f32,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of sigevent"][::std::mem::size_of::<sigevent>() - 32usize];
-    ["Alignment of sigevent"][::std::mem::align_of::<sigevent>() - 8usize];
-    ["Offset of field: sigevent::sigev_notify"]
-        [::std::mem::offset_of!(sigevent, sigev_notify) - 0usize];
-    ["Offset of field: sigevent::sigev_signo"]
-        [::std::mem::offset_of!(sigevent, sigev_signo) - 4usize];
-    ["Offset of field: sigevent::sigev_value"]
-        [::std::mem::offset_of!(sigevent, sigev_value) - 8usize];
-    ["Offset of field: sigevent::sigev_notify_function"]
-        [::std::mem::offset_of!(sigevent, sigev_notify_function) - 16usize];
-    ["Offset of field: sigevent::sigev_notify_attributes"]
-        [::std::mem::offset_of!(sigevent, sigev_notify_attributes) - 24usize];
+    ["Size of _float_val"][::std::mem::size_of::<_float_val>() - 4usize];
+    ["Alignment of _float_val"][::std::mem::align_of::<_float_val>() - 4usize];
+    ["Offset of field: _float_val::_Sh"][::std::mem::offset_of!(_float_val, _Sh) - 0usize];
+    ["Offset of field: _float_val::_Val"][::std::mem::offset_of!(_float_val, _Val) - 0usize];
 };
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub struct __siginfo {
-    pub si_signo: ::std::os::raw::c_int,
-    pub si_errno: ::std::os::raw::c_int,
-    pub si_code: ::std::os::raw::c_int,
-    pub si_pid: pid_t,
-    pub si_uid: uid_t,
-    pub si_status: ::std::os::raw::c_int,
-    pub si_addr: *mut ::std::os::raw::c_void,
-    pub si_value: sigval,
-    pub si_band: ::std::os::raw::c_long,
-    pub __pad: [::std::os::raw::c_ulong; 7usize],
+pub union _ldouble_val {
+    pub _Sh: [::std::os::raw::c_ushort; 4usize],
+    pub _Val: f64,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of __siginfo"][::std::mem::size_of::<__siginfo>() - 104usize];
-    ["Alignment of __siginfo"][::std::mem::align_of::<__siginfo>() - 8usize];
-    ["Offset of field: __siginfo::si_signo"][::std::mem::offset_of!(__siginfo, si_signo) - 0usize];
-    ["Offset of field: __siginfo::si_errno"][::std::mem::offset_of!(__siginfo, si_errno) - 4usize];
-    ["Offset of field: __siginfo::si_code"][::std::mem::offset_of!(__siginfo, si_code) - 8usize];
-    ["Offset of field: __siginfo::si_pid"][::std::mem::offset_of!(__siginfo, si_pid) - 12usize];
-    ["Offset of field: __siginfo::si_uid"][::std::mem::offset_of!(__siginfo, si_uid) - 16usize];
-    ["Offset of field: __siginfo::si_status"]
-        [::std::mem::offset_of!(__siginfo, si_status) - 20usize];
-    ["Offset of field: __siginfo::si_addr"][::std::mem::offset_of!(__siginfo, si_addr) - 24usize];
-    ["Offset of field: __siginfo::si_value"][::std::mem::offset_of!(__siginfo, si_value) - 32usize];
-    ["Offset of field: __siginfo::si_band"][::std::mem::offset_of!(__siginfo, si_band) - 40usize];
-    ["Offset of field: __siginfo::__pad"][::std::mem::offset_of!(__siginfo, __pad) - 48usize];
-};
-pub type siginfo_t = __siginfo;
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union __sigaction_u {
-    pub __sa_handler: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    pub __sa_sigaction: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: ::std::os::raw::c_int,
-            arg2: *mut __siginfo,
-            arg3: *mut ::std::os::raw::c_void,
-        ),
-    >,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of __sigaction_u"][::std::mem::size_of::<__sigaction_u>() - 8usize];
-    ["Alignment of __sigaction_u"][::std::mem::align_of::<__sigaction_u>() - 8usize];
-    ["Offset of field: __sigaction_u::__sa_handler"]
-        [::std::mem::offset_of!(__sigaction_u, __sa_handler) - 0usize];
-    ["Offset of field: __sigaction_u::__sa_sigaction"]
-        [::std::mem::offset_of!(__sigaction_u, __sa_sigaction) - 0usize];
+    ["Size of _ldouble_val"][::std::mem::size_of::<_ldouble_val>() - 8usize];
+    ["Alignment of _ldouble_val"][::std::mem::align_of::<_ldouble_val>() - 8usize];
+    ["Offset of field: _ldouble_val::_Sh"][::std::mem::offset_of!(_ldouble_val, _Sh) - 0usize];
+    ["Offset of field: _ldouble_val::_Val"][::std::mem::offset_of!(_ldouble_val, _Val) - 0usize];
 };
 #[repr(C)]
 #[derive(Copy, Clone)]
-pub struct __sigaction {
-    pub __sigaction_u: __sigaction_u,
-    pub sa_tramp: ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: *mut ::std::os::raw::c_void,
-            arg2: ::std::os::raw::c_int,
-            arg3: ::std::os::raw::c_int,
-            arg4: *mut siginfo_t,
-            arg5: *mut ::std::os::raw::c_void,
-        ),
-    >,
-    pub sa_mask: sigset_t,
-    pub sa_flags: ::std::os::raw::c_int,
+pub union _float_const {
+    pub _Word: [::std::os::raw::c_ushort; 4usize],
+    pub _Float: f32,
+    pub _Double: f64,
+    pub _Long_double: f64,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of __sigaction"][::std::mem::size_of::<__sigaction>() - 24usize];
-    ["Alignment of __sigaction"][::std::mem::align_of::<__sigaction>() - 8usize];
-    ["Offset of field: __sigaction::__sigaction_u"]
-        [::std::mem::offset_of!(__sigaction, __sigaction_u) - 0usize];
-    ["Offset of field: __sigaction::sa_tramp"]
-        [::std::mem::offset_of!(__sigaction, sa_tramp) - 8usize];
-    ["Offset of field: __sigaction::sa_mask"]
-        [::std::mem::offset_of!(__sigaction, sa_mask) - 16usize];
-    ["Offset of field: __sigaction::sa_flags"]
-        [::std::mem::offset_of!(__sigaction, sa_flags) - 20usize];
-};
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct sigaction {
-    pub __sigaction_u: __sigaction_u,
-    pub sa_mask: sigset_t,
-    pub sa_flags: ::std::os::raw::c_int,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of sigaction"][::std::mem::size_of::<sigaction>() - 16usize];
-    ["Alignment of sigaction"][::std::mem::align_of::<sigaction>() - 8usize];
-    ["Offset of field: sigaction::__sigaction_u"]
-        [::std::mem::offset_of!(sigaction, __sigaction_u) - 0usize];
-    ["Offset of field: sigaction::sa_mask"][::std::mem::offset_of!(sigaction, sa_mask) - 8usize];
-    ["Offset of field: sigaction::sa_flags"][::std::mem::offset_of!(sigaction, sa_flags) - 12usize];
-};
-pub type sig_t = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sigvec {
-    pub sv_handler: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    pub sv_mask: ::std::os::raw::c_int,
-    pub sv_flags: ::std::os::raw::c_int,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of sigvec"][::std::mem::size_of::<sigvec>() - 16usize];
-    ["Alignment of sigvec"][::std::mem::align_of::<sigvec>() - 8usize];
-    ["Offset of field: sigvec::sv_handler"][::std::mem::offset_of!(sigvec, sv_handler) - 0usize];
-    ["Offset of field: sigvec::sv_mask"][::std::mem::offset_of!(sigvec, sv_mask) - 8usize];
-    ["Offset of field: sigvec::sv_flags"][::std::mem::offset_of!(sigvec, sv_flags) - 12usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct sigstack {
-    pub ss_sp: *mut ::std::os::raw::c_char,
-    pub ss_onstack: ::std::os::raw::c_int,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of sigstack"][::std::mem::size_of::<sigstack>() - 16usize];
-    ["Alignment of sigstack"][::std::mem::align_of::<sigstack>() - 8usize];
-    ["Offset of field: sigstack::ss_sp"][::std::mem::offset_of!(sigstack, ss_sp) - 0usize];
-    ["Offset of field: sigstack::ss_onstack"]
-        [::std::mem::offset_of!(sigstack, ss_onstack) - 8usize];
+    ["Size of _float_const"][::std::mem::size_of::<_float_const>() - 8usize];
+    ["Alignment of _float_const"][::std::mem::align_of::<_float_const>() - 8usize];
+    ["Offset of field: _float_const::_Word"][::std::mem::offset_of!(_float_const, _Word) - 0usize];
+    ["Offset of field: _float_const::_Float"]
+        [::std::mem::offset_of!(_float_const, _Float) - 0usize];
+    ["Offset of field: _float_const::_Double"]
+        [::std::mem::offset_of!(_float_const, _Double) - 0usize];
+    ["Offset of field: _float_const::_Long_double"]
+        [::std::mem::offset_of!(_float_const, _Long_double) - 0usize];
 };
 unsafe extern "C" {
-    pub fn signal(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-    ) -> ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: ::std::os::raw::c_int,
-            arg2: ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>,
-        ),
-    >;
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct timeval {
-    pub tv_sec: __darwin_time_t,
-    pub tv_usec: __darwin_suseconds_t,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of timeval"][::std::mem::size_of::<timeval>() - 16usize];
-    ["Alignment of timeval"][::std::mem::align_of::<timeval>() - 8usize];
-    ["Offset of field: timeval::tv_sec"][::std::mem::offset_of!(timeval, tv_sec) - 0usize];
-    ["Offset of field: timeval::tv_usec"][::std::mem::offset_of!(timeval, tv_usec) - 8usize];
-};
-pub type rlim_t = __uint64_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct rusage {
-    pub ru_utime: timeval,
-    pub ru_stime: timeval,
-    pub ru_maxrss: ::std::os::raw::c_long,
-    pub ru_ixrss: ::std::os::raw::c_long,
-    pub ru_idrss: ::std::os::raw::c_long,
-    pub ru_isrss: ::std::os::raw::c_long,
-    pub ru_minflt: ::std::os::raw::c_long,
-    pub ru_majflt: ::std::os::raw::c_long,
-    pub ru_nswap: ::std::os::raw::c_long,
-    pub ru_inblock: ::std::os::raw::c_long,
-    pub ru_oublock: ::std::os::raw::c_long,
-    pub ru_msgsnd: ::std::os::raw::c_long,
-    pub ru_msgrcv: ::std::os::raw::c_long,
-    pub ru_nsignals: ::std::os::raw::c_long,
-    pub ru_nvcsw: ::std::os::raw::c_long,
-    pub ru_nivcsw: ::std::os::raw::c_long,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of rusage"][::std::mem::size_of::<rusage>() - 144usize];
-    ["Alignment of rusage"][::std::mem::align_of::<rusage>() - 8usize];
-    ["Offset of field: rusage::ru_utime"][::std::mem::offset_of!(rusage, ru_utime) - 0usize];
-    ["Offset of field: rusage::ru_stime"][::std::mem::offset_of!(rusage, ru_stime) - 16usize];
-    ["Offset of field: rusage::ru_maxrss"][::std::mem::offset_of!(rusage, ru_maxrss) - 32usize];
-    ["Offset of field: rusage::ru_ixrss"][::std::mem::offset_of!(rusage, ru_ixrss) - 40usize];
-    ["Offset of field: rusage::ru_idrss"][::std::mem::offset_of!(rusage, ru_idrss) - 48usize];
-    ["Offset of field: rusage::ru_isrss"][::std::mem::offset_of!(rusage, ru_isrss) - 56usize];
-    ["Offset of field: rusage::ru_minflt"][::std::mem::offset_of!(rusage, ru_minflt) - 64usize];
-    ["Offset of field: rusage::ru_majflt"][::std::mem::offset_of!(rusage, ru_majflt) - 72usize];
-    ["Offset of field: rusage::ru_nswap"][::std::mem::offset_of!(rusage, ru_nswap) - 80usize];
-    ["Offset of field: rusage::ru_inblock"][::std::mem::offset_of!(rusage, ru_inblock) - 88usize];
-    ["Offset of field: rusage::ru_oublock"][::std::mem::offset_of!(rusage, ru_oublock) - 96usize];
-    ["Offset of field: rusage::ru_msgsnd"][::std::mem::offset_of!(rusage, ru_msgsnd) - 104usize];
-    ["Offset of field: rusage::ru_msgrcv"][::std::mem::offset_of!(rusage, ru_msgrcv) - 112usize];
-    ["Offset of field: rusage::ru_nsignals"]
-        [::std::mem::offset_of!(rusage, ru_nsignals) - 120usize];
-    ["Offset of field: rusage::ru_nvcsw"][::std::mem::offset_of!(rusage, ru_nvcsw) - 128usize];
-    ["Offset of field: rusage::ru_nivcsw"][::std::mem::offset_of!(rusage, ru_nivcsw) - 136usize];
-};
-pub type rusage_info_t = *mut ::std::os::raw::c_void;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct rusage_info_v0 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of rusage_info_v0"][::std::mem::size_of::<rusage_info_v0>() - 96usize];
-    ["Alignment of rusage_info_v0"][::std::mem::align_of::<rusage_info_v0>() - 8usize];
-    ["Offset of field: rusage_info_v0::ri_uuid"]
-        [::std::mem::offset_of!(rusage_info_v0, ri_uuid) - 0usize];
-    ["Offset of field: rusage_info_v0::ri_user_time"]
-        [::std::mem::offset_of!(rusage_info_v0, ri_user_time) - 16usize];
-    ["Offset of field: rusage_info_v0::ri_system_time"]
-        [::std::mem::offset_of!(rusage_info_v0, ri_system_time) - 24usize];
-    ["Offset of field: rusage_info_v0::ri_pkg_idle_wkups"]
-        [::std::mem::offset_of!(rusage_info_v0, ri_pkg_idle_wkups) - 32usize];
-    ["Offset of field: rusage_info_v0::ri_interrupt_wkups"]
-        [::std::mem::offset_of!(rusage_info_v0, ri_interrupt_wkups) - 40usize];
-    ["Offset of field: rusage_info_v0::ri_pageins"]
-        [::std::mem::offset_of!(rusage_info_v0, ri_pageins) - 48usize];
-    ["Offset of field: rusage_info_v0::ri_wired_size"]
-        [::std::mem::offset_of!(rusage_info_v0, ri_wired_size) - 56usize];
-    ["Offset of field: rusage_info_v0::ri_resident_size"]
-        [::std::mem::offset_of!(rusage_info_v0, ri_resident_size) - 64usize];
-    ["Offset of field: rusage_info_v0::ri_phys_footprint"]
-        [::std::mem::offset_of!(rusage_info_v0, ri_phys_footprint) - 72usize];
-    ["Offset of field: rusage_info_v0::ri_proc_start_abstime"]
-        [::std::mem::offset_of!(rusage_info_v0, ri_proc_start_abstime) - 80usize];
-    ["Offset of field: rusage_info_v0::ri_proc_exit_abstime"]
-        [::std::mem::offset_of!(rusage_info_v0, ri_proc_exit_abstime) - 88usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct rusage_info_v1 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of rusage_info_v1"][::std::mem::size_of::<rusage_info_v1>() - 144usize];
-    ["Alignment of rusage_info_v1"][::std::mem::align_of::<rusage_info_v1>() - 8usize];
-    ["Offset of field: rusage_info_v1::ri_uuid"]
-        [::std::mem::offset_of!(rusage_info_v1, ri_uuid) - 0usize];
-    ["Offset of field: rusage_info_v1::ri_user_time"]
-        [::std::mem::offset_of!(rusage_info_v1, ri_user_time) - 16usize];
-    ["Offset of field: rusage_info_v1::ri_system_time"]
-        [::std::mem::offset_of!(rusage_info_v1, ri_system_time) - 24usize];
-    ["Offset of field: rusage_info_v1::ri_pkg_idle_wkups"]
-        [::std::mem::offset_of!(rusage_info_v1, ri_pkg_idle_wkups) - 32usize];
-    ["Offset of field: rusage_info_v1::ri_interrupt_wkups"]
-        [::std::mem::offset_of!(rusage_info_v1, ri_interrupt_wkups) - 40usize];
-    ["Offset of field: rusage_info_v1::ri_pageins"]
-        [::std::mem::offset_of!(rusage_info_v1, ri_pageins) - 48usize];
-    ["Offset of field: rusage_info_v1::ri_wired_size"]
-        [::std::mem::offset_of!(rusage_info_v1, ri_wired_size) - 56usize];
-    ["Offset of field: rusage_info_v1::ri_resident_size"]
-        [::std::mem::offset_of!(rusage_info_v1, ri_resident_size) - 64usize];
-    ["Offset of field: rusage_info_v1::ri_phys_footprint"]
-        [::std::mem::offset_of!(rusage_info_v1, ri_phys_footprint) - 72usize];
-    ["Offset of field: rusage_info_v1::ri_proc_start_abstime"]
-        [::std::mem::offset_of!(rusage_info_v1, ri_proc_start_abstime) - 80usize];
-    ["Offset of field: rusage_info_v1::ri_proc_exit_abstime"]
-        [::std::mem::offset_of!(rusage_info_v1, ri_proc_exit_abstime) - 88usize];
-    ["Offset of field: rusage_info_v1::ri_child_user_time"]
-        [::std::mem::offset_of!(rusage_info_v1, ri_child_user_time) - 96usize];
-    ["Offset of field: rusage_info_v1::ri_child_system_time"]
-        [::std::mem::offset_of!(rusage_info_v1, ri_child_system_time) - 104usize];
-    ["Offset of field: rusage_info_v1::ri_child_pkg_idle_wkups"]
-        [::std::mem::offset_of!(rusage_info_v1, ri_child_pkg_idle_wkups) - 112usize];
-    ["Offset of field: rusage_info_v1::ri_child_interrupt_wkups"]
-        [::std::mem::offset_of!(rusage_info_v1, ri_child_interrupt_wkups) - 120usize];
-    ["Offset of field: rusage_info_v1::ri_child_pageins"]
-        [::std::mem::offset_of!(rusage_info_v1, ri_child_pageins) - 128usize];
-    ["Offset of field: rusage_info_v1::ri_child_elapsed_abstime"]
-        [::std::mem::offset_of!(rusage_info_v1, ri_child_elapsed_abstime) - 136usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct rusage_info_v2 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of rusage_info_v2"][::std::mem::size_of::<rusage_info_v2>() - 160usize];
-    ["Alignment of rusage_info_v2"][::std::mem::align_of::<rusage_info_v2>() - 8usize];
-    ["Offset of field: rusage_info_v2::ri_uuid"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_uuid) - 0usize];
-    ["Offset of field: rusage_info_v2::ri_user_time"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_user_time) - 16usize];
-    ["Offset of field: rusage_info_v2::ri_system_time"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_system_time) - 24usize];
-    ["Offset of field: rusage_info_v2::ri_pkg_idle_wkups"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_pkg_idle_wkups) - 32usize];
-    ["Offset of field: rusage_info_v2::ri_interrupt_wkups"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_interrupt_wkups) - 40usize];
-    ["Offset of field: rusage_info_v2::ri_pageins"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_pageins) - 48usize];
-    ["Offset of field: rusage_info_v2::ri_wired_size"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_wired_size) - 56usize];
-    ["Offset of field: rusage_info_v2::ri_resident_size"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_resident_size) - 64usize];
-    ["Offset of field: rusage_info_v2::ri_phys_footprint"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_phys_footprint) - 72usize];
-    ["Offset of field: rusage_info_v2::ri_proc_start_abstime"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_proc_start_abstime) - 80usize];
-    ["Offset of field: rusage_info_v2::ri_proc_exit_abstime"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_proc_exit_abstime) - 88usize];
-    ["Offset of field: rusage_info_v2::ri_child_user_time"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_child_user_time) - 96usize];
-    ["Offset of field: rusage_info_v2::ri_child_system_time"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_child_system_time) - 104usize];
-    ["Offset of field: rusage_info_v2::ri_child_pkg_idle_wkups"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_child_pkg_idle_wkups) - 112usize];
-    ["Offset of field: rusage_info_v2::ri_child_interrupt_wkups"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_child_interrupt_wkups) - 120usize];
-    ["Offset of field: rusage_info_v2::ri_child_pageins"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_child_pageins) - 128usize];
-    ["Offset of field: rusage_info_v2::ri_child_elapsed_abstime"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_child_elapsed_abstime) - 136usize];
-    ["Offset of field: rusage_info_v2::ri_diskio_bytesread"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_diskio_bytesread) - 144usize];
-    ["Offset of field: rusage_info_v2::ri_diskio_byteswritten"]
-        [::std::mem::offset_of!(rusage_info_v2, ri_diskio_byteswritten) - 152usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct rusage_info_v3 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-    pub ri_cpu_time_qos_default: u64,
-    pub ri_cpu_time_qos_maintenance: u64,
-    pub ri_cpu_time_qos_background: u64,
-    pub ri_cpu_time_qos_utility: u64,
-    pub ri_cpu_time_qos_legacy: u64,
-    pub ri_cpu_time_qos_user_initiated: u64,
-    pub ri_cpu_time_qos_user_interactive: u64,
-    pub ri_billed_system_time: u64,
-    pub ri_serviced_system_time: u64,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of rusage_info_v3"][::std::mem::size_of::<rusage_info_v3>() - 232usize];
-    ["Alignment of rusage_info_v3"][::std::mem::align_of::<rusage_info_v3>() - 8usize];
-    ["Offset of field: rusage_info_v3::ri_uuid"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_uuid) - 0usize];
-    ["Offset of field: rusage_info_v3::ri_user_time"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_user_time) - 16usize];
-    ["Offset of field: rusage_info_v3::ri_system_time"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_system_time) - 24usize];
-    ["Offset of field: rusage_info_v3::ri_pkg_idle_wkups"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_pkg_idle_wkups) - 32usize];
-    ["Offset of field: rusage_info_v3::ri_interrupt_wkups"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_interrupt_wkups) - 40usize];
-    ["Offset of field: rusage_info_v3::ri_pageins"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_pageins) - 48usize];
-    ["Offset of field: rusage_info_v3::ri_wired_size"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_wired_size) - 56usize];
-    ["Offset of field: rusage_info_v3::ri_resident_size"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_resident_size) - 64usize];
-    ["Offset of field: rusage_info_v3::ri_phys_footprint"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_phys_footprint) - 72usize];
-    ["Offset of field: rusage_info_v3::ri_proc_start_abstime"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_proc_start_abstime) - 80usize];
-    ["Offset of field: rusage_info_v3::ri_proc_exit_abstime"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_proc_exit_abstime) - 88usize];
-    ["Offset of field: rusage_info_v3::ri_child_user_time"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_child_user_time) - 96usize];
-    ["Offset of field: rusage_info_v3::ri_child_system_time"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_child_system_time) - 104usize];
-    ["Offset of field: rusage_info_v3::ri_child_pkg_idle_wkups"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_child_pkg_idle_wkups) - 112usize];
-    ["Offset of field: rusage_info_v3::ri_child_interrupt_wkups"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_child_interrupt_wkups) - 120usize];
-    ["Offset of field: rusage_info_v3::ri_child_pageins"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_child_pageins) - 128usize];
-    ["Offset of field: rusage_info_v3::ri_child_elapsed_abstime"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_child_elapsed_abstime) - 136usize];
-    ["Offset of field: rusage_info_v3::ri_diskio_bytesread"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_diskio_bytesread) - 144usize];
-    ["Offset of field: rusage_info_v3::ri_diskio_byteswritten"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_diskio_byteswritten) - 152usize];
-    ["Offset of field: rusage_info_v3::ri_cpu_time_qos_default"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_cpu_time_qos_default) - 160usize];
-    ["Offset of field: rusage_info_v3::ri_cpu_time_qos_maintenance"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_cpu_time_qos_maintenance) - 168usize];
-    ["Offset of field: rusage_info_v3::ri_cpu_time_qos_background"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_cpu_time_qos_background) - 176usize];
-    ["Offset of field: rusage_info_v3::ri_cpu_time_qos_utility"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_cpu_time_qos_utility) - 184usize];
-    ["Offset of field: rusage_info_v3::ri_cpu_time_qos_legacy"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_cpu_time_qos_legacy) - 192usize];
-    ["Offset of field: rusage_info_v3::ri_cpu_time_qos_user_initiated"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_cpu_time_qos_user_initiated) - 200usize];
-    ["Offset of field: rusage_info_v3::ri_cpu_time_qos_user_interactive"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_cpu_time_qos_user_interactive) - 208usize];
-    ["Offset of field: rusage_info_v3::ri_billed_system_time"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_billed_system_time) - 216usize];
-    ["Offset of field: rusage_info_v3::ri_serviced_system_time"]
-        [::std::mem::offset_of!(rusage_info_v3, ri_serviced_system_time) - 224usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct rusage_info_v4 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-    pub ri_cpu_time_qos_default: u64,
-    pub ri_cpu_time_qos_maintenance: u64,
-    pub ri_cpu_time_qos_background: u64,
-    pub ri_cpu_time_qos_utility: u64,
-    pub ri_cpu_time_qos_legacy: u64,
-    pub ri_cpu_time_qos_user_initiated: u64,
-    pub ri_cpu_time_qos_user_interactive: u64,
-    pub ri_billed_system_time: u64,
-    pub ri_serviced_system_time: u64,
-    pub ri_logical_writes: u64,
-    pub ri_lifetime_max_phys_footprint: u64,
-    pub ri_instructions: u64,
-    pub ri_cycles: u64,
-    pub ri_billed_energy: u64,
-    pub ri_serviced_energy: u64,
-    pub ri_interval_max_phys_footprint: u64,
-    pub ri_runnable_time: u64,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of rusage_info_v4"][::std::mem::size_of::<rusage_info_v4>() - 296usize];
-    ["Alignment of rusage_info_v4"][::std::mem::align_of::<rusage_info_v4>() - 8usize];
-    ["Offset of field: rusage_info_v4::ri_uuid"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_uuid) - 0usize];
-    ["Offset of field: rusage_info_v4::ri_user_time"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_user_time) - 16usize];
-    ["Offset of field: rusage_info_v4::ri_system_time"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_system_time) - 24usize];
-    ["Offset of field: rusage_info_v4::ri_pkg_idle_wkups"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_pkg_idle_wkups) - 32usize];
-    ["Offset of field: rusage_info_v4::ri_interrupt_wkups"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_interrupt_wkups) - 40usize];
-    ["Offset of field: rusage_info_v4::ri_pageins"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_pageins) - 48usize];
-    ["Offset of field: rusage_info_v4::ri_wired_size"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_wired_size) - 56usize];
-    ["Offset of field: rusage_info_v4::ri_resident_size"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_resident_size) - 64usize];
-    ["Offset of field: rusage_info_v4::ri_phys_footprint"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_phys_footprint) - 72usize];
-    ["Offset of field: rusage_info_v4::ri_proc_start_abstime"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_proc_start_abstime) - 80usize];
-    ["Offset of field: rusage_info_v4::ri_proc_exit_abstime"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_proc_exit_abstime) - 88usize];
-    ["Offset of field: rusage_info_v4::ri_child_user_time"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_child_user_time) - 96usize];
-    ["Offset of field: rusage_info_v4::ri_child_system_time"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_child_system_time) - 104usize];
-    ["Offset of field: rusage_info_v4::ri_child_pkg_idle_wkups"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_child_pkg_idle_wkups) - 112usize];
-    ["Offset of field: rusage_info_v4::ri_child_interrupt_wkups"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_child_interrupt_wkups) - 120usize];
-    ["Offset of field: rusage_info_v4::ri_child_pageins"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_child_pageins) - 128usize];
-    ["Offset of field: rusage_info_v4::ri_child_elapsed_abstime"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_child_elapsed_abstime) - 136usize];
-    ["Offset of field: rusage_info_v4::ri_diskio_bytesread"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_diskio_bytesread) - 144usize];
-    ["Offset of field: rusage_info_v4::ri_diskio_byteswritten"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_diskio_byteswritten) - 152usize];
-    ["Offset of field: rusage_info_v4::ri_cpu_time_qos_default"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_cpu_time_qos_default) - 160usize];
-    ["Offset of field: rusage_info_v4::ri_cpu_time_qos_maintenance"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_cpu_time_qos_maintenance) - 168usize];
-    ["Offset of field: rusage_info_v4::ri_cpu_time_qos_background"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_cpu_time_qos_background) - 176usize];
-    ["Offset of field: rusage_info_v4::ri_cpu_time_qos_utility"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_cpu_time_qos_utility) - 184usize];
-    ["Offset of field: rusage_info_v4::ri_cpu_time_qos_legacy"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_cpu_time_qos_legacy) - 192usize];
-    ["Offset of field: rusage_info_v4::ri_cpu_time_qos_user_initiated"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_cpu_time_qos_user_initiated) - 200usize];
-    ["Offset of field: rusage_info_v4::ri_cpu_time_qos_user_interactive"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_cpu_time_qos_user_interactive) - 208usize];
-    ["Offset of field: rusage_info_v4::ri_billed_system_time"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_billed_system_time) - 216usize];
-    ["Offset of field: rusage_info_v4::ri_serviced_system_time"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_serviced_system_time) - 224usize];
-    ["Offset of field: rusage_info_v4::ri_logical_writes"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_logical_writes) - 232usize];
-    ["Offset of field: rusage_info_v4::ri_lifetime_max_phys_footprint"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_lifetime_max_phys_footprint) - 240usize];
-    ["Offset of field: rusage_info_v4::ri_instructions"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_instructions) - 248usize];
-    ["Offset of field: rusage_info_v4::ri_cycles"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_cycles) - 256usize];
-    ["Offset of field: rusage_info_v4::ri_billed_energy"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_billed_energy) - 264usize];
-    ["Offset of field: rusage_info_v4::ri_serviced_energy"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_serviced_energy) - 272usize];
-    ["Offset of field: rusage_info_v4::ri_interval_max_phys_footprint"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_interval_max_phys_footprint) - 280usize];
-    ["Offset of field: rusage_info_v4::ri_runnable_time"]
-        [::std::mem::offset_of!(rusage_info_v4, ri_runnable_time) - 288usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct rusage_info_v5 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-    pub ri_cpu_time_qos_default: u64,
-    pub ri_cpu_time_qos_maintenance: u64,
-    pub ri_cpu_time_qos_background: u64,
-    pub ri_cpu_time_qos_utility: u64,
-    pub ri_cpu_time_qos_legacy: u64,
-    pub ri_cpu_time_qos_user_initiated: u64,
-    pub ri_cpu_time_qos_user_interactive: u64,
-    pub ri_billed_system_time: u64,
-    pub ri_serviced_system_time: u64,
-    pub ri_logical_writes: u64,
-    pub ri_lifetime_max_phys_footprint: u64,
-    pub ri_instructions: u64,
-    pub ri_cycles: u64,
-    pub ri_billed_energy: u64,
-    pub ri_serviced_energy: u64,
-    pub ri_interval_max_phys_footprint: u64,
-    pub ri_runnable_time: u64,
-    pub ri_flags: u64,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of rusage_info_v5"][::std::mem::size_of::<rusage_info_v5>() - 304usize];
-    ["Alignment of rusage_info_v5"][::std::mem::align_of::<rusage_info_v5>() - 8usize];
-    ["Offset of field: rusage_info_v5::ri_uuid"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_uuid) - 0usize];
-    ["Offset of field: rusage_info_v5::ri_user_time"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_user_time) - 16usize];
-    ["Offset of field: rusage_info_v5::ri_system_time"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_system_time) - 24usize];
-    ["Offset of field: rusage_info_v5::ri_pkg_idle_wkups"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_pkg_idle_wkups) - 32usize];
-    ["Offset of field: rusage_info_v5::ri_interrupt_wkups"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_interrupt_wkups) - 40usize];
-    ["Offset of field: rusage_info_v5::ri_pageins"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_pageins) - 48usize];
-    ["Offset of field: rusage_info_v5::ri_wired_size"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_wired_size) - 56usize];
-    ["Offset of field: rusage_info_v5::ri_resident_size"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_resident_size) - 64usize];
-    ["Offset of field: rusage_info_v5::ri_phys_footprint"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_phys_footprint) - 72usize];
-    ["Offset of field: rusage_info_v5::ri_proc_start_abstime"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_proc_start_abstime) - 80usize];
-    ["Offset of field: rusage_info_v5::ri_proc_exit_abstime"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_proc_exit_abstime) - 88usize];
-    ["Offset of field: rusage_info_v5::ri_child_user_time"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_child_user_time) - 96usize];
-    ["Offset of field: rusage_info_v5::ri_child_system_time"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_child_system_time) - 104usize];
-    ["Offset of field: rusage_info_v5::ri_child_pkg_idle_wkups"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_child_pkg_idle_wkups) - 112usize];
-    ["Offset of field: rusage_info_v5::ri_child_interrupt_wkups"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_child_interrupt_wkups) - 120usize];
-    ["Offset of field: rusage_info_v5::ri_child_pageins"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_child_pageins) - 128usize];
-    ["Offset of field: rusage_info_v5::ri_child_elapsed_abstime"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_child_elapsed_abstime) - 136usize];
-    ["Offset of field: rusage_info_v5::ri_diskio_bytesread"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_diskio_bytesread) - 144usize];
-    ["Offset of field: rusage_info_v5::ri_diskio_byteswritten"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_diskio_byteswritten) - 152usize];
-    ["Offset of field: rusage_info_v5::ri_cpu_time_qos_default"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_cpu_time_qos_default) - 160usize];
-    ["Offset of field: rusage_info_v5::ri_cpu_time_qos_maintenance"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_cpu_time_qos_maintenance) - 168usize];
-    ["Offset of field: rusage_info_v5::ri_cpu_time_qos_background"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_cpu_time_qos_background) - 176usize];
-    ["Offset of field: rusage_info_v5::ri_cpu_time_qos_utility"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_cpu_time_qos_utility) - 184usize];
-    ["Offset of field: rusage_info_v5::ri_cpu_time_qos_legacy"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_cpu_time_qos_legacy) - 192usize];
-    ["Offset of field: rusage_info_v5::ri_cpu_time_qos_user_initiated"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_cpu_time_qos_user_initiated) - 200usize];
-    ["Offset of field: rusage_info_v5::ri_cpu_time_qos_user_interactive"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_cpu_time_qos_user_interactive) - 208usize];
-    ["Offset of field: rusage_info_v5::ri_billed_system_time"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_billed_system_time) - 216usize];
-    ["Offset of field: rusage_info_v5::ri_serviced_system_time"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_serviced_system_time) - 224usize];
-    ["Offset of field: rusage_info_v5::ri_logical_writes"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_logical_writes) - 232usize];
-    ["Offset of field: rusage_info_v5::ri_lifetime_max_phys_footprint"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_lifetime_max_phys_footprint) - 240usize];
-    ["Offset of field: rusage_info_v5::ri_instructions"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_instructions) - 248usize];
-    ["Offset of field: rusage_info_v5::ri_cycles"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_cycles) - 256usize];
-    ["Offset of field: rusage_info_v5::ri_billed_energy"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_billed_energy) - 264usize];
-    ["Offset of field: rusage_info_v5::ri_serviced_energy"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_serviced_energy) - 272usize];
-    ["Offset of field: rusage_info_v5::ri_interval_max_phys_footprint"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_interval_max_phys_footprint) - 280usize];
-    ["Offset of field: rusage_info_v5::ri_runnable_time"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_runnable_time) - 288usize];
-    ["Offset of field: rusage_info_v5::ri_flags"]
-        [::std::mem::offset_of!(rusage_info_v5, ri_flags) - 296usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct rusage_info_v6 {
-    pub ri_uuid: [u8; 16usize],
-    pub ri_user_time: u64,
-    pub ri_system_time: u64,
-    pub ri_pkg_idle_wkups: u64,
-    pub ri_interrupt_wkups: u64,
-    pub ri_pageins: u64,
-    pub ri_wired_size: u64,
-    pub ri_resident_size: u64,
-    pub ri_phys_footprint: u64,
-    pub ri_proc_start_abstime: u64,
-    pub ri_proc_exit_abstime: u64,
-    pub ri_child_user_time: u64,
-    pub ri_child_system_time: u64,
-    pub ri_child_pkg_idle_wkups: u64,
-    pub ri_child_interrupt_wkups: u64,
-    pub ri_child_pageins: u64,
-    pub ri_child_elapsed_abstime: u64,
-    pub ri_diskio_bytesread: u64,
-    pub ri_diskio_byteswritten: u64,
-    pub ri_cpu_time_qos_default: u64,
-    pub ri_cpu_time_qos_maintenance: u64,
-    pub ri_cpu_time_qos_background: u64,
-    pub ri_cpu_time_qos_utility: u64,
-    pub ri_cpu_time_qos_legacy: u64,
-    pub ri_cpu_time_qos_user_initiated: u64,
-    pub ri_cpu_time_qos_user_interactive: u64,
-    pub ri_billed_system_time: u64,
-    pub ri_serviced_system_time: u64,
-    pub ri_logical_writes: u64,
-    pub ri_lifetime_max_phys_footprint: u64,
-    pub ri_instructions: u64,
-    pub ri_cycles: u64,
-    pub ri_billed_energy: u64,
-    pub ri_serviced_energy: u64,
-    pub ri_interval_max_phys_footprint: u64,
-    pub ri_runnable_time: u64,
-    pub ri_flags: u64,
-    pub ri_user_ptime: u64,
-    pub ri_system_ptime: u64,
-    pub ri_pinstructions: u64,
-    pub ri_pcycles: u64,
-    pub ri_energy_nj: u64,
-    pub ri_penergy_nj: u64,
-    pub ri_secure_time_in_system: u64,
-    pub ri_secure_ptime_in_system: u64,
-    pub ri_reserved: [u64; 12usize],
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of rusage_info_v6"][::std::mem::size_of::<rusage_info_v6>() - 464usize];
-    ["Alignment of rusage_info_v6"][::std::mem::align_of::<rusage_info_v6>() - 8usize];
-    ["Offset of field: rusage_info_v6::ri_uuid"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_uuid) - 0usize];
-    ["Offset of field: rusage_info_v6::ri_user_time"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_user_time) - 16usize];
-    ["Offset of field: rusage_info_v6::ri_system_time"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_system_time) - 24usize];
-    ["Offset of field: rusage_info_v6::ri_pkg_idle_wkups"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_pkg_idle_wkups) - 32usize];
-    ["Offset of field: rusage_info_v6::ri_interrupt_wkups"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_interrupt_wkups) - 40usize];
-    ["Offset of field: rusage_info_v6::ri_pageins"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_pageins) - 48usize];
-    ["Offset of field: rusage_info_v6::ri_wired_size"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_wired_size) - 56usize];
-    ["Offset of field: rusage_info_v6::ri_resident_size"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_resident_size) - 64usize];
-    ["Offset of field: rusage_info_v6::ri_phys_footprint"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_phys_footprint) - 72usize];
-    ["Offset of field: rusage_info_v6::ri_proc_start_abstime"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_proc_start_abstime) - 80usize];
-    ["Offset of field: rusage_info_v6::ri_proc_exit_abstime"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_proc_exit_abstime) - 88usize];
-    ["Offset of field: rusage_info_v6::ri_child_user_time"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_child_user_time) - 96usize];
-    ["Offset of field: rusage_info_v6::ri_child_system_time"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_child_system_time) - 104usize];
-    ["Offset of field: rusage_info_v6::ri_child_pkg_idle_wkups"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_child_pkg_idle_wkups) - 112usize];
-    ["Offset of field: rusage_info_v6::ri_child_interrupt_wkups"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_child_interrupt_wkups) - 120usize];
-    ["Offset of field: rusage_info_v6::ri_child_pageins"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_child_pageins) - 128usize];
-    ["Offset of field: rusage_info_v6::ri_child_elapsed_abstime"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_child_elapsed_abstime) - 136usize];
-    ["Offset of field: rusage_info_v6::ri_diskio_bytesread"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_diskio_bytesread) - 144usize];
-    ["Offset of field: rusage_info_v6::ri_diskio_byteswritten"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_diskio_byteswritten) - 152usize];
-    ["Offset of field: rusage_info_v6::ri_cpu_time_qos_default"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_cpu_time_qos_default) - 160usize];
-    ["Offset of field: rusage_info_v6::ri_cpu_time_qos_maintenance"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_cpu_time_qos_maintenance) - 168usize];
-    ["Offset of field: rusage_info_v6::ri_cpu_time_qos_background"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_cpu_time_qos_background) - 176usize];
-    ["Offset of field: rusage_info_v6::ri_cpu_time_qos_utility"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_cpu_time_qos_utility) - 184usize];
-    ["Offset of field: rusage_info_v6::ri_cpu_time_qos_legacy"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_cpu_time_qos_legacy) - 192usize];
-    ["Offset of field: rusage_info_v6::ri_cpu_time_qos_user_initiated"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_cpu_time_qos_user_initiated) - 200usize];
-    ["Offset of field: rusage_info_v6::ri_cpu_time_qos_user_interactive"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_cpu_time_qos_user_interactive) - 208usize];
-    ["Offset of field: rusage_info_v6::ri_billed_system_time"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_billed_system_time) - 216usize];
-    ["Offset of field: rusage_info_v6::ri_serviced_system_time"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_serviced_system_time) - 224usize];
-    ["Offset of field: rusage_info_v6::ri_logical_writes"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_logical_writes) - 232usize];
-    ["Offset of field: rusage_info_v6::ri_lifetime_max_phys_footprint"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_lifetime_max_phys_footprint) - 240usize];
-    ["Offset of field: rusage_info_v6::ri_instructions"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_instructions) - 248usize];
-    ["Offset of field: rusage_info_v6::ri_cycles"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_cycles) - 256usize];
-    ["Offset of field: rusage_info_v6::ri_billed_energy"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_billed_energy) - 264usize];
-    ["Offset of field: rusage_info_v6::ri_serviced_energy"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_serviced_energy) - 272usize];
-    ["Offset of field: rusage_info_v6::ri_interval_max_phys_footprint"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_interval_max_phys_footprint) - 280usize];
-    ["Offset of field: rusage_info_v6::ri_runnable_time"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_runnable_time) - 288usize];
-    ["Offset of field: rusage_info_v6::ri_flags"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_flags) - 296usize];
-    ["Offset of field: rusage_info_v6::ri_user_ptime"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_user_ptime) - 304usize];
-    ["Offset of field: rusage_info_v6::ri_system_ptime"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_system_ptime) - 312usize];
-    ["Offset of field: rusage_info_v6::ri_pinstructions"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_pinstructions) - 320usize];
-    ["Offset of field: rusage_info_v6::ri_pcycles"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_pcycles) - 328usize];
-    ["Offset of field: rusage_info_v6::ri_energy_nj"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_energy_nj) - 336usize];
-    ["Offset of field: rusage_info_v6::ri_penergy_nj"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_penergy_nj) - 344usize];
-    ["Offset of field: rusage_info_v6::ri_secure_time_in_system"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_secure_time_in_system) - 352usize];
-    ["Offset of field: rusage_info_v6::ri_secure_ptime_in_system"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_secure_ptime_in_system) - 360usize];
-    ["Offset of field: rusage_info_v6::ri_reserved"]
-        [::std::mem::offset_of!(rusage_info_v6, ri_reserved) - 368usize];
-};
-pub type rusage_info_current = rusage_info_v6;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct rlimit {
-    pub rlim_cur: rlim_t,
-    pub rlim_max: rlim_t,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of rlimit"][::std::mem::size_of::<rlimit>() - 16usize];
-    ["Alignment of rlimit"][::std::mem::align_of::<rlimit>() - 8usize];
-    ["Offset of field: rlimit::rlim_cur"][::std::mem::offset_of!(rlimit, rlim_cur) - 0usize];
-    ["Offset of field: rlimit::rlim_max"][::std::mem::offset_of!(rlimit, rlim_max) - 8usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct proc_rlimit_control_wakeupmon {
-    pub wm_flags: u32,
-    pub wm_rate: i32,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of proc_rlimit_control_wakeupmon"]
-        [::std::mem::size_of::<proc_rlimit_control_wakeupmon>() - 8usize];
-    ["Alignment of proc_rlimit_control_wakeupmon"]
-        [::std::mem::align_of::<proc_rlimit_control_wakeupmon>() - 4usize];
-    ["Offset of field: proc_rlimit_control_wakeupmon::wm_flags"]
-        [::std::mem::offset_of!(proc_rlimit_control_wakeupmon, wm_flags) - 0usize];
-    ["Offset of field: proc_rlimit_control_wakeupmon::wm_rate"]
-        [::std::mem::offset_of!(proc_rlimit_control_wakeupmon, wm_rate) - 4usize];
-};
-unsafe extern "C" {
-    pub fn getpriority(arg1: ::std::os::raw::c_int, arg2: id_t) -> ::std::os::raw::c_int;
+    pub static _Denorm_C: _float_const;
 }
 unsafe extern "C" {
-    pub fn getiopolicy_np(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
+    pub static _Inf_C: _float_const;
 }
 unsafe extern "C" {
-    pub fn getrlimit(arg1: ::std::os::raw::c_int, arg2: *mut rlimit) -> ::std::os::raw::c_int;
+    pub static _Nan_C: _float_const;
 }
 unsafe extern "C" {
-    pub fn getrusage(arg1: ::std::os::raw::c_int, arg2: *mut rusage) -> ::std::os::raw::c_int;
+    pub static _Snan_C: _float_const;
 }
 unsafe extern "C" {
-    pub fn setpriority(
-        arg1: ::std::os::raw::c_int,
-        arg2: id_t,
-        arg3: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
+    pub static _Hugeval_C: _float_const;
 }
 unsafe extern "C" {
-    pub fn setiopolicy_np(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-        arg3: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
+    pub static _FDenorm_C: _float_const;
 }
 unsafe extern "C" {
-    pub fn setrlimit(arg1: ::std::os::raw::c_int, arg2: *const rlimit) -> ::std::os::raw::c_int;
-}
-#[repr(C, packed)]
-#[derive(Debug, Copy, Clone)]
-pub struct _OSUnalignedU16 {
-    pub __val: u16,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of _OSUnalignedU16"][::std::mem::size_of::<_OSUnalignedU16>() - 2usize];
-    ["Alignment of _OSUnalignedU16"][::std::mem::align_of::<_OSUnalignedU16>() - 1usize];
-    ["Offset of field: _OSUnalignedU16::__val"]
-        [::std::mem::offset_of!(_OSUnalignedU16, __val) - 0usize];
-};
-#[repr(C, packed)]
-#[derive(Debug, Copy, Clone)]
-pub struct _OSUnalignedU32 {
-    pub __val: u32,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of _OSUnalignedU32"][::std::mem::size_of::<_OSUnalignedU32>() - 4usize];
-    ["Alignment of _OSUnalignedU32"][::std::mem::align_of::<_OSUnalignedU32>() - 1usize];
-    ["Offset of field: _OSUnalignedU32::__val"]
-        [::std::mem::offset_of!(_OSUnalignedU32, __val) - 0usize];
-};
-#[repr(C, packed)]
-#[derive(Debug, Copy, Clone)]
-pub struct _OSUnalignedU64 {
-    pub __val: u64,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of _OSUnalignedU64"][::std::mem::size_of::<_OSUnalignedU64>() - 8usize];
-    ["Alignment of _OSUnalignedU64"][::std::mem::align_of::<_OSUnalignedU64>() - 1usize];
-    ["Offset of field: _OSUnalignedU64::__val"]
-        [::std::mem::offset_of!(_OSUnalignedU64, __val) - 0usize];
-};
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub union wait {
-    pub w_status: ::std::os::raw::c_int,
-    pub w_T: wait__bindgen_ty_1,
-    pub w_S: wait__bindgen_ty_2,
-}
-#[repr(C)]
-#[repr(align(4))]
-#[derive(Debug, Copy, Clone)]
-pub struct wait__bindgen_ty_1 {
-    pub _bitfield_align_1: [u16; 0],
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of wait__bindgen_ty_1"][::std::mem::size_of::<wait__bindgen_ty_1>() - 4usize];
-    ["Alignment of wait__bindgen_ty_1"][::std::mem::align_of::<wait__bindgen_ty_1>() - 4usize];
-};
-impl wait__bindgen_ty_1 {
-    #[inline]
-    pub fn w_Termsig(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 7u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Termsig(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(0usize, 7u8, val as u64)
-        }
-    }
-    #[inline]
-    pub unsafe fn w_Termsig_raw(this: *const Self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 4usize]>>::raw_get(
-                ::std::ptr::addr_of!((*this)._bitfield_1),
-                0usize,
-                7u8,
-            ) as u32)
-        }
-    }
-    #[inline]
-    pub unsafe fn set_w_Termsig_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            <__BindgenBitfieldUnit<[u8; 4usize]>>::raw_set(
-                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
-                0usize,
-                7u8,
-                val as u64,
-            )
-        }
-    }
-    #[inline]
-    pub fn w_Coredump(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(7usize, 1u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Coredump(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(7usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub unsafe fn w_Coredump_raw(this: *const Self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 4usize]>>::raw_get(
-                ::std::ptr::addr_of!((*this)._bitfield_1),
-                7usize,
-                1u8,
-            ) as u32)
-        }
-    }
-    #[inline]
-    pub unsafe fn set_w_Coredump_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            <__BindgenBitfieldUnit<[u8; 4usize]>>::raw_set(
-                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
-                7usize,
-                1u8,
-                val as u64,
-            )
-        }
-    }
-    #[inline]
-    pub fn w_Retcode(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 8u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Retcode(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(8usize, 8u8, val as u64)
-        }
-    }
-    #[inline]
-    pub unsafe fn w_Retcode_raw(this: *const Self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 4usize]>>::raw_get(
-                ::std::ptr::addr_of!((*this)._bitfield_1),
-                8usize,
-                8u8,
-            ) as u32)
-        }
-    }
-    #[inline]
-    pub unsafe fn set_w_Retcode_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            <__BindgenBitfieldUnit<[u8; 4usize]>>::raw_set(
-                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
-                8usize,
-                8u8,
-                val as u64,
-            )
-        }
-    }
-    #[inline]
-    pub fn w_Filler(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(16usize, 16u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Filler(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(16usize, 16u8, val as u64)
-        }
-    }
-    #[inline]
-    pub unsafe fn w_Filler_raw(this: *const Self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 4usize]>>::raw_get(
-                ::std::ptr::addr_of!((*this)._bitfield_1),
-                16usize,
-                16u8,
-            ) as u32)
-        }
-    }
-    #[inline]
-    pub unsafe fn set_w_Filler_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            <__BindgenBitfieldUnit<[u8; 4usize]>>::raw_set(
-                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
-                16usize,
-                16u8,
-                val as u64,
-            )
-        }
-    }
-    #[inline]
-    pub fn new_bitfield_1(
-        w_Termsig: ::std::os::raw::c_uint,
-        w_Coredump: ::std::os::raw::c_uint,
-        w_Retcode: ::std::os::raw::c_uint,
-        w_Filler: ::std::os::raw::c_uint,
-    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
-        __bindgen_bitfield_unit.set(0usize, 7u8, {
-            let w_Termsig: u32 = unsafe { ::std::mem::transmute(w_Termsig) };
-            w_Termsig as u64
-        });
-        __bindgen_bitfield_unit.set(7usize, 1u8, {
-            let w_Coredump: u32 = unsafe { ::std::mem::transmute(w_Coredump) };
-            w_Coredump as u64
-        });
-        __bindgen_bitfield_unit.set(8usize, 8u8, {
-            let w_Retcode: u32 = unsafe { ::std::mem::transmute(w_Retcode) };
-            w_Retcode as u64
-        });
-        __bindgen_bitfield_unit.set(16usize, 16u8, {
-            let w_Filler: u32 = unsafe { ::std::mem::transmute(w_Filler) };
-            w_Filler as u64
-        });
-        __bindgen_bitfield_unit
-    }
-}
-#[repr(C)]
-#[repr(align(4))]
-#[derive(Debug, Copy, Clone)]
-pub struct wait__bindgen_ty_2 {
-    pub _bitfield_align_1: [u16; 0],
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of wait__bindgen_ty_2"][::std::mem::size_of::<wait__bindgen_ty_2>() - 4usize];
-    ["Alignment of wait__bindgen_ty_2"][::std::mem::align_of::<wait__bindgen_ty_2>() - 4usize];
-};
-impl wait__bindgen_ty_2 {
-    #[inline]
-    pub fn w_Stopval(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 8u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Stopval(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(0usize, 8u8, val as u64)
-        }
-    }
-    #[inline]
-    pub unsafe fn w_Stopval_raw(this: *const Self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 4usize]>>::raw_get(
-                ::std::ptr::addr_of!((*this)._bitfield_1),
-                0usize,
-                8u8,
-            ) as u32)
-        }
-    }
-    #[inline]
-    pub unsafe fn set_w_Stopval_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            <__BindgenBitfieldUnit<[u8; 4usize]>>::raw_set(
-                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
-                0usize,
-                8u8,
-                val as u64,
-            )
-        }
-    }
-    #[inline]
-    pub fn w_Stopsig(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 8u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Stopsig(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(8usize, 8u8, val as u64)
-        }
-    }
-    #[inline]
-    pub unsafe fn w_Stopsig_raw(this: *const Self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 4usize]>>::raw_get(
-                ::std::ptr::addr_of!((*this)._bitfield_1),
-                8usize,
-                8u8,
-            ) as u32)
-        }
-    }
-    #[inline]
-    pub unsafe fn set_w_Stopsig_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            <__BindgenBitfieldUnit<[u8; 4usize]>>::raw_set(
-                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
-                8usize,
-                8u8,
-                val as u64,
-            )
-        }
-    }
-    #[inline]
-    pub fn w_Filler(&self) -> ::std::os::raw::c_uint {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(16usize, 16u8) as u32) }
-    }
-    #[inline]
-    pub fn set_w_Filler(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            self._bitfield_1.set(16usize, 16u8, val as u64)
-        }
-    }
-    #[inline]
-    pub unsafe fn w_Filler_raw(this: *const Self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 4usize]>>::raw_get(
-                ::std::ptr::addr_of!((*this)._bitfield_1),
-                16usize,
-                16u8,
-            ) as u32)
-        }
-    }
-    #[inline]
-    pub unsafe fn set_w_Filler_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = ::std::mem::transmute(val);
-            <__BindgenBitfieldUnit<[u8; 4usize]>>::raw_set(
-                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
-                16usize,
-                16u8,
-                val as u64,
-            )
-        }
-    }
-    #[inline]
-    pub fn new_bitfield_1(
-        w_Stopval: ::std::os::raw::c_uint,
-        w_Stopsig: ::std::os::raw::c_uint,
-        w_Filler: ::std::os::raw::c_uint,
-    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
-        __bindgen_bitfield_unit.set(0usize, 8u8, {
-            let w_Stopval: u32 = unsafe { ::std::mem::transmute(w_Stopval) };
-            w_Stopval as u64
-        });
-        __bindgen_bitfield_unit.set(8usize, 8u8, {
-            let w_Stopsig: u32 = unsafe { ::std::mem::transmute(w_Stopsig) };
-            w_Stopsig as u64
-        });
-        __bindgen_bitfield_unit.set(16usize, 16u8, {
-            let w_Filler: u32 = unsafe { ::std::mem::transmute(w_Filler) };
-            w_Filler as u64
-        });
-        __bindgen_bitfield_unit
-    }
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of wait"][::std::mem::size_of::<wait>() - 4usize];
-    ["Alignment of wait"][::std::mem::align_of::<wait>() - 4usize];
-    ["Offset of field: wait::w_status"][::std::mem::offset_of!(wait, w_status) - 0usize];
-    ["Offset of field: wait::w_T"][::std::mem::offset_of!(wait, w_T) - 0usize];
-    ["Offset of field: wait::w_S"][::std::mem::offset_of!(wait, w_S) - 0usize];
-};
-unsafe extern "C" {
-    pub fn wait(arg1: *mut ::std::os::raw::c_int) -> pid_t;
+    pub static _FInf_C: _float_const;
 }
 unsafe extern "C" {
-    pub fn waitpid(
-        arg1: pid_t,
-        arg2: *mut ::std::os::raw::c_int,
-        arg3: ::std::os::raw::c_int,
-    ) -> pid_t;
+    pub static _FNan_C: _float_const;
 }
 unsafe extern "C" {
-    pub fn waitid(
-        arg1: idtype_t,
-        arg2: id_t,
-        arg3: *mut siginfo_t,
-        arg4: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
+    pub static _FSnan_C: _float_const;
 }
 unsafe extern "C" {
-    pub fn wait3(
-        arg1: *mut ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-        arg3: *mut rusage,
-    ) -> pid_t;
+    pub static _LDenorm_C: _float_const;
 }
 unsafe extern "C" {
-    pub fn wait4(
-        arg1: pid_t,
-        arg2: *mut ::std::os::raw::c_int,
-        arg3: ::std::os::raw::c_int,
-        arg4: *mut rusage,
-    ) -> pid_t;
+    pub static _LInf_C: _float_const;
 }
 unsafe extern "C" {
-    pub fn alloca(arg1: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void;
-}
-pub type ct_rune_t = __darwin_ct_rune_t;
-pub type rune_t = __darwin_rune_t;
-pub type wchar_t = __darwin_wchar_t;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct div_t {
-    pub quot: ::std::os::raw::c_int,
-    pub rem: ::std::os::raw::c_int,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of div_t"][::std::mem::size_of::<div_t>() - 8usize];
-    ["Alignment of div_t"][::std::mem::align_of::<div_t>() - 4usize];
-    ["Offset of field: div_t::quot"][::std::mem::offset_of!(div_t, quot) - 0usize];
-    ["Offset of field: div_t::rem"][::std::mem::offset_of!(div_t, rem) - 4usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct ldiv_t {
-    pub quot: ::std::os::raw::c_long,
-    pub rem: ::std::os::raw::c_long,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of ldiv_t"][::std::mem::size_of::<ldiv_t>() - 16usize];
-    ["Alignment of ldiv_t"][::std::mem::align_of::<ldiv_t>() - 8usize];
-    ["Offset of field: ldiv_t::quot"][::std::mem::offset_of!(ldiv_t, quot) - 0usize];
-    ["Offset of field: ldiv_t::rem"][::std::mem::offset_of!(ldiv_t, rem) - 8usize];
-};
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct lldiv_t {
-    pub quot: ::std::os::raw::c_longlong,
-    pub rem: ::std::os::raw::c_longlong,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of lldiv_t"][::std::mem::size_of::<lldiv_t>() - 16usize];
-    ["Alignment of lldiv_t"][::std::mem::align_of::<lldiv_t>() - 8usize];
-    ["Offset of field: lldiv_t::quot"][::std::mem::offset_of!(lldiv_t, quot) - 0usize];
-    ["Offset of field: lldiv_t::rem"][::std::mem::offset_of!(lldiv_t, rem) - 8usize];
-};
-unsafe extern "C" {
-    pub static mut __mb_cur_max: ::std::os::raw::c_int;
-}
-pub type malloc_type_id_t = ::std::os::raw::c_ulonglong;
-unsafe extern "C" {
-    pub fn malloc_type_malloc(
-        size: usize,
-        type_id: malloc_type_id_t,
-    ) -> *mut ::std::os::raw::c_void;
+    pub static _LNan_C: _float_const;
 }
 unsafe extern "C" {
-    pub fn malloc_type_calloc(
-        count: usize,
-        size: usize,
-        type_id: malloc_type_id_t,
-    ) -> *mut ::std::os::raw::c_void;
+    pub static _LSnan_C: _float_const;
 }
 unsafe extern "C" {
-    pub fn malloc_type_free(ptr: *mut ::std::os::raw::c_void, type_id: malloc_type_id_t);
+    pub static _Eps_C: _float_const;
 }
 unsafe extern "C" {
-    pub fn malloc_type_realloc(
-        ptr: *mut ::std::os::raw::c_void,
-        size: usize,
-        type_id: malloc_type_id_t,
-    ) -> *mut ::std::os::raw::c_void;
+    pub static _Rteps_C: _float_const;
 }
 unsafe extern "C" {
-    pub fn malloc_type_valloc(
-        size: usize,
-        type_id: malloc_type_id_t,
-    ) -> *mut ::std::os::raw::c_void;
+    pub static _FEps_C: _float_const;
 }
 unsafe extern "C" {
-    pub fn malloc_type_aligned_alloc(
-        alignment: usize,
-        size: usize,
-        type_id: malloc_type_id_t,
-    ) -> *mut ::std::os::raw::c_void;
+    pub static _FRteps_C: _float_const;
 }
 unsafe extern "C" {
-    pub fn malloc_type_posix_memalign(
-        memptr: *mut *mut ::std::os::raw::c_void,
-        alignment: usize,
-        size: usize,
-        type_id: malloc_type_id_t,
-    ) -> ::std::os::raw::c_int;
-}
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _malloc_zone_t {
-    _unused: [u8; 0],
-}
-pub type malloc_zone_t = _malloc_zone_t;
-unsafe extern "C" {
-    pub fn malloc_type_zone_malloc(
-        zone: *mut malloc_zone_t,
-        size: usize,
-        type_id: malloc_type_id_t,
-    ) -> *mut ::std::os::raw::c_void;
+    pub static _LEps_C: _float_const;
 }
 unsafe extern "C" {
-    pub fn malloc_type_zone_calloc(
-        zone: *mut malloc_zone_t,
-        count: usize,
-        size: usize,
-        type_id: malloc_type_id_t,
-    ) -> *mut ::std::os::raw::c_void;
+    pub static _LRteps_C: _float_const;
 }
 unsafe extern "C" {
-    pub fn malloc_type_zone_free(
-        zone: *mut malloc_zone_t,
-        ptr: *mut ::std::os::raw::c_void,
-        type_id: malloc_type_id_t,
-    );
+    pub static _Zero_C: f64;
 }
 unsafe extern "C" {
-    pub fn malloc_type_zone_realloc(
-        zone: *mut malloc_zone_t,
-        ptr: *mut ::std::os::raw::c_void,
-        size: usize,
-        type_id: malloc_type_id_t,
-    ) -> *mut ::std::os::raw::c_void;
+    pub static _Xbig_C: f64;
 }
 unsafe extern "C" {
-    pub fn malloc_type_zone_valloc(
-        zone: *mut malloc_zone_t,
-        size: usize,
-        type_id: malloc_type_id_t,
-    ) -> *mut ::std::os::raw::c_void;
+    pub static _FZero_C: f32;
 }
 unsafe extern "C" {
-    pub fn malloc_type_zone_memalign(
-        zone: *mut malloc_zone_t,
-        alignment: usize,
-        size: usize,
-        type_id: malloc_type_id_t,
-    ) -> *mut ::std::os::raw::c_void;
+    pub static _FXbig_C: f32;
 }
 unsafe extern "C" {
-    pub fn malloc(__size: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void;
+    pub static _LZero_C: f64;
+}
+unsafe extern "C" {
+    pub static _LXbig_C: f64;
+}
+unsafe extern "C" {
+    pub fn abs(_X: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn labs(_X: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn llabs(_X: ::std::os::raw::c_longlong) -> ::std::os::raw::c_longlong;
+}
+unsafe extern "C" {
+    pub fn acos(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn asin(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn atan(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn atan2(_Y: f64, _X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn cos(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn cosh(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn exp(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn fabs(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn fmod(_X: f64, _Y: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn log(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn log10(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn pow(_X: f64, _Y: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn sin(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn sinh(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn sqrt(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn tan(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn tanh(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn acosh(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn asinh(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn atanh(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn atof(_String: *const ::std::os::raw::c_char) -> f64;
+}
+unsafe extern "C" {
+    pub fn _atof_l(_String: *const ::std::os::raw::c_char, _Locale: _locale_t) -> f64;
+}
+unsafe extern "C" {
+    pub fn _cabs(_Complex_value: _complex) -> f64;
+}
+unsafe extern "C" {
+    pub fn cbrt(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn ceil(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn _chgsign(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn copysign(_Number: f64, _Sign: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn _copysign(_Number: f64, _Sign: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn erf(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn erfc(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn exp2(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn expm1(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn fdim(_X: f64, _Y: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn floor(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn fma(_X: f64, _Y: f64, _Z: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn fmax(_X: f64, _Y: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn fmin(_X: f64, _Y: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn frexp(_X: f64, _Y: *mut ::std::os::raw::c_int) -> f64;
+}
+unsafe extern "C" {
+    pub fn hypot(_X: f64, _Y: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn _hypot(_X: f64, _Y: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn ilogb(_X: f64) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn ldexp(_X: f64, _Y: ::std::os::raw::c_int) -> f64;
+}
+unsafe extern "C" {
+    pub fn lgamma(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn llrint(_X: f64) -> ::std::os::raw::c_longlong;
+}
+unsafe extern "C" {
+    pub fn llround(_X: f64) -> ::std::os::raw::c_longlong;
+}
+unsafe extern "C" {
+    pub fn log1p(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn log2(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn logb(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn lrint(_X: f64) -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn lround(_X: f64) -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn _matherr(_Except: *mut _exception) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn modf(_X: f64, _Y: *mut f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn nan(_X: *const ::std::os::raw::c_char) -> f64;
+}
+unsafe extern "C" {
+    pub fn nearbyint(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn nextafter(_X: f64, _Y: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn nexttoward(_X: f64, _Y: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn remainder(_X: f64, _Y: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn remquo(_X: f64, _Y: f64, _Z: *mut ::std::os::raw::c_int) -> f64;
+}
+unsafe extern "C" {
+    pub fn rint(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn round(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn scalbln(_X: f64, _Y: ::std::os::raw::c_long) -> f64;
+}
+unsafe extern "C" {
+    pub fn scalbn(_X: f64, _Y: ::std::os::raw::c_int) -> f64;
+}
+unsafe extern "C" {
+    pub fn tgamma(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn trunc(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn _j0(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn _j1(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn _jn(_X: ::std::os::raw::c_int, _Y: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn _y0(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn _y1(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn _yn(_X: ::std::os::raw::c_int, _Y: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn acoshf(_X: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn asinhf(_X: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn atanhf(_X: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn cbrtf(_X: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn _chgsignf(_X: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn copysignf(_Number: f32, _Sign: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn _copysignf(_Number: f32, _Sign: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn erff(_X: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn erfcf(_X: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn expm1f(_X: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn exp2f(_X: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn fdimf(_X: f32, _Y: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn fmaf(_X: f32, _Y: f32, _Z: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn fmaxf(_X: f32, _Y: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn fminf(_X: f32, _Y: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn _hypotf(_X: f32, _Y: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn ilogbf(_X: f32) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn lgammaf(_X: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn llrintf(_X: f32) -> ::std::os::raw::c_longlong;
+}
+unsafe extern "C" {
+    pub fn llroundf(_X: f32) -> ::std::os::raw::c_longlong;
+}
+unsafe extern "C" {
+    pub fn log1pf(_X: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn log2f(_X: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn logbf(_X: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn lrintf(_X: f32) -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn lroundf(_X: f32) -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn nanf(_X: *const ::std::os::raw::c_char) -> f32;
+}
+unsafe extern "C" {
+    pub fn nearbyintf(_X: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn nextafterf(_X: f32, _Y: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn nexttowardf(_X: f32, _Y: f64) -> f32;
+}
+unsafe extern "C" {
+    pub fn remainderf(_X: f32, _Y: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn remquof(_X: f32, _Y: f32, _Z: *mut ::std::os::raw::c_int) -> f32;
+}
+unsafe extern "C" {
+    pub fn rintf(_X: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn roundf(_X: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn scalblnf(_X: f32, _Y: ::std::os::raw::c_long) -> f32;
+}
+unsafe extern "C" {
+    pub fn scalbnf(_X: f32, _Y: ::std::os::raw::c_int) -> f32;
+}
+unsafe extern "C" {
+    pub fn tgammaf(_X: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn truncf(_X: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn _logbf(_X: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn _nextafterf(_X: f32, _Y: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn _finitef(_X: f32) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _isnanf(_X: f32) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _fpclassf(_X: f32) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _set_FMA3_enable(_Flag: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _get_FMA3_enable() -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn acosf(_X: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn asinf(_X: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn atan2f(_Y: f32, _X: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn atanf(_X: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn ceilf(_X: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn cosf(_X: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn coshf(_X: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn expf(_X: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn floorf(_X: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn fmodf(_X: f32, _Y: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn log10f(_X: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn logf(_X: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn modff(_X: f32, _Y: *mut f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn powf(_X: f32, _Y: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn sinf(_X: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn sinhf(_X: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn sqrtf(_X: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn tanf(_X: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn tanhf(_X: f32) -> f32;
+}
+unsafe extern "C" {
+    pub fn acoshl(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn asinhl(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn atanhl(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn cbrtl(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn copysignl(_Number: f64, _Sign: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn erfl(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn erfcl(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn exp2l(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn expm1l(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn fdiml(_X: f64, _Y: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn fmal(_X: f64, _Y: f64, _Z: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn fmaxl(_X: f64, _Y: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn fminl(_X: f64, _Y: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn ilogbl(_X: f64) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn lgammal(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn llrintl(_X: f64) -> ::std::os::raw::c_longlong;
+}
+unsafe extern "C" {
+    pub fn llroundl(_X: f64) -> ::std::os::raw::c_longlong;
+}
+unsafe extern "C" {
+    pub fn log1pl(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn log2l(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn logbl(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn lrintl(_X: f64) -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn lroundl(_X: f64) -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn nanl(_X: *const ::std::os::raw::c_char) -> f64;
+}
+unsafe extern "C" {
+    pub fn nearbyintl(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn nextafterl(_X: f64, _Y: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn nexttowardl(_X: f64, _Y: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn remainderl(_X: f64, _Y: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn remquol(_X: f64, _Y: f64, _Z: *mut ::std::os::raw::c_int) -> f64;
+}
+unsafe extern "C" {
+    pub fn rintl(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn roundl(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn scalblnl(_X: f64, _Y: ::std::os::raw::c_long) -> f64;
+}
+unsafe extern "C" {
+    pub fn scalbnl(_X: f64, _Y: ::std::os::raw::c_int) -> f64;
+}
+unsafe extern "C" {
+    pub fn tgammal(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn truncl(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub static mut HUGE: f64;
+}
+unsafe extern "C" {
+    pub fn j0(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn j1(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn jn(_X: ::std::os::raw::c_int, _Y: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn y0(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn y1(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn yn(_X: ::std::os::raw::c_int, _Y: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn _clearfp() -> ::std::os::raw::c_uint;
+}
+unsafe extern "C" {
+    pub fn _controlfp(
+        _NewValue: ::std::os::raw::c_uint,
+        _Mask: ::std::os::raw::c_uint,
+    ) -> ::std::os::raw::c_uint;
+}
+unsafe extern "C" {
+    pub fn _set_controlfp(_NewValue: ::std::os::raw::c_uint, _Mask: ::std::os::raw::c_uint);
+}
+unsafe extern "C" {
+    pub fn _controlfp_s(
+        _CurrentState: *mut ::std::os::raw::c_uint,
+        _NewValue: ::std::os::raw::c_uint,
+        _Mask: ::std::os::raw::c_uint,
+    ) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn _statusfp() -> ::std::os::raw::c_uint;
+}
+unsafe extern "C" {
+    pub fn _fpreset();
+}
+unsafe extern "C" {
+    pub fn _control87(
+        _NewValue: ::std::os::raw::c_uint,
+        _Mask: ::std::os::raw::c_uint,
+    ) -> ::std::os::raw::c_uint;
+}
+unsafe extern "C" {
+    pub fn __fpecode() -> *mut ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn __fpe_flt_rounds() -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _scalb(_X: f64, _Y: ::std::os::raw::c_long) -> f64;
+}
+unsafe extern "C" {
+    pub fn _logb(_X: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn _nextafter(_X: f64, _Y: f64) -> f64;
+}
+unsafe extern "C" {
+    pub fn _finite(_X: f64) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _isnan(_X: f64) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _fpclass(_X: f64) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _scalbf(_X: f32, _Y: ::std::os::raw::c_long) -> f32;
+}
+unsafe extern "C" {
+    pub fn fpreset();
+}
+unsafe extern "C" {
+    pub fn _wassert(_Message: *const wchar_t, _File: *const wchar_t, _Line: ::std::os::raw::c_uint);
+}
+unsafe extern "C" {
+    pub fn _calloc_base(_Count: usize, _Size: usize) -> *mut ::std::os::raw::c_void;
 }
 unsafe extern "C" {
     pub fn calloc(
-        __count: ::std::os::raw::c_ulong,
-        __size: ::std::os::raw::c_ulong,
+        _Count: ::std::os::raw::c_ulonglong,
+        _Size: ::std::os::raw::c_ulonglong,
     ) -> *mut ::std::os::raw::c_void;
 }
 unsafe extern "C" {
-    pub fn free(arg1: *mut ::std::os::raw::c_void);
+    pub fn _callnewh(_Size: usize) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _expand(
+        _Block: *mut ::std::os::raw::c_void,
+        _Size: usize,
+    ) -> *mut ::std::os::raw::c_void;
+}
+unsafe extern "C" {
+    pub fn _free_base(_Block: *mut ::std::os::raw::c_void);
+}
+unsafe extern "C" {
+    pub fn free(_Block: *mut ::std::os::raw::c_void);
+}
+unsafe extern "C" {
+    pub fn _malloc_base(_Size: usize) -> *mut ::std::os::raw::c_void;
+}
+unsafe extern "C" {
+    pub fn malloc(_Size: ::std::os::raw::c_ulonglong) -> *mut ::std::os::raw::c_void;
+}
+unsafe extern "C" {
+    pub fn _msize_base(_Block: *mut ::std::os::raw::c_void) -> usize;
+}
+unsafe extern "C" {
+    pub fn _msize(_Block: *mut ::std::os::raw::c_void) -> usize;
+}
+unsafe extern "C" {
+    pub fn _realloc_base(
+        _Block: *mut ::std::os::raw::c_void,
+        _Size: usize,
+    ) -> *mut ::std::os::raw::c_void;
 }
 unsafe extern "C" {
     pub fn realloc(
-        __ptr: *mut ::std::os::raw::c_void,
-        __size: ::std::os::raw::c_ulong,
+        _Block: *mut ::std::os::raw::c_void,
+        _Size: ::std::os::raw::c_ulonglong,
     ) -> *mut ::std::os::raw::c_void;
 }
 unsafe extern "C" {
-    pub fn reallocf(
-        __ptr: *mut ::std::os::raw::c_void,
-        __size: usize,
+    pub fn _recalloc_base(
+        _Block: *mut ::std::os::raw::c_void,
+        _Count: usize,
+        _Size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 unsafe extern "C" {
-    pub fn valloc(arg1: usize) -> *mut ::std::os::raw::c_void;
-}
-unsafe extern "C" {
-    pub fn aligned_alloc(
-        __alignment: ::std::os::raw::c_ulong,
-        __size: ::std::os::raw::c_ulong,
+    pub fn _recalloc(
+        _Block: *mut ::std::os::raw::c_void,
+        _Count: usize,
+        _Size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 unsafe extern "C" {
-    pub fn posix_memalign(
-        __memptr: *mut *mut ::std::os::raw::c_void,
-        __alignment: usize,
-        __size: usize,
-    ) -> ::std::os::raw::c_int;
+    pub fn _aligned_free(_Block: *mut ::std::os::raw::c_void);
+}
+unsafe extern "C" {
+    pub fn _aligned_malloc(_Size: usize, _Alignment: usize) -> *mut ::std::os::raw::c_void;
+}
+unsafe extern "C" {
+    pub fn _aligned_offset_malloc(
+        _Size: usize,
+        _Alignment: usize,
+        _Offset: usize,
+    ) -> *mut ::std::os::raw::c_void;
+}
+unsafe extern "C" {
+    pub fn _aligned_msize(
+        _Block: *mut ::std::os::raw::c_void,
+        _Alignment: usize,
+        _Offset: usize,
+    ) -> usize;
+}
+unsafe extern "C" {
+    pub fn _aligned_offset_realloc(
+        _Block: *mut ::std::os::raw::c_void,
+        _Size: usize,
+        _Alignment: usize,
+        _Offset: usize,
+    ) -> *mut ::std::os::raw::c_void;
+}
+unsafe extern "C" {
+    pub fn _aligned_offset_recalloc(
+        _Block: *mut ::std::os::raw::c_void,
+        _Count: usize,
+        _Size: usize,
+        _Alignment: usize,
+        _Offset: usize,
+    ) -> *mut ::std::os::raw::c_void;
+}
+unsafe extern "C" {
+    pub fn _aligned_realloc(
+        _Block: *mut ::std::os::raw::c_void,
+        _Size: usize,
+        _Alignment: usize,
+    ) -> *mut ::std::os::raw::c_void;
+}
+unsafe extern "C" {
+    pub fn _aligned_recalloc(
+        _Block: *mut ::std::os::raw::c_void,
+        _Count: usize,
+        _Size: usize,
+        _Alignment: usize,
+    ) -> *mut ::std::os::raw::c_void;
+}
+pub type max_align_t = f64;
+pub type _CoreCrtSecureSearchSortCompareFunction = ::std::option::Option<
+    unsafe extern "C" fn(
+        arg1: *mut ::std::os::raw::c_void,
+        arg2: *const ::std::os::raw::c_void,
+        arg3: *const ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int,
+>;
+pub type _CoreCrtNonSecureSearchSortCompareFunction = ::std::option::Option<
+    unsafe extern "C" fn(
+        arg1: *const ::std::os::raw::c_void,
+        arg2: *const ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int,
+>;
+unsafe extern "C" {
+    pub fn bsearch_s(
+        _Key: *const ::std::os::raw::c_void,
+        _Base: *const ::std::os::raw::c_void,
+        _NumOfElements: rsize_t,
+        _SizeOfElements: rsize_t,
+        _CompareFunction: _CoreCrtSecureSearchSortCompareFunction,
+        _Context: *mut ::std::os::raw::c_void,
+    ) -> *mut ::std::os::raw::c_void;
+}
+unsafe extern "C" {
+    pub fn qsort_s(
+        _Base: *mut ::std::os::raw::c_void,
+        _NumOfElements: rsize_t,
+        _SizeOfElements: rsize_t,
+        _CompareFunction: _CoreCrtSecureSearchSortCompareFunction,
+        _Context: *mut ::std::os::raw::c_void,
+    );
+}
+unsafe extern "C" {
+    pub fn bsearch(
+        _Key: *const ::std::os::raw::c_void,
+        _Base: *const ::std::os::raw::c_void,
+        _NumOfElements: usize,
+        _SizeOfElements: usize,
+        _CompareFunction: _CoreCrtNonSecureSearchSortCompareFunction,
+    ) -> *mut ::std::os::raw::c_void;
+}
+unsafe extern "C" {
+    pub fn qsort(
+        _Base: *mut ::std::os::raw::c_void,
+        _NumOfElements: usize,
+        _SizeOfElements: usize,
+        _CompareFunction: _CoreCrtNonSecureSearchSortCompareFunction,
+    );
+}
+unsafe extern "C" {
+    pub fn _lfind_s(
+        _Key: *const ::std::os::raw::c_void,
+        _Base: *const ::std::os::raw::c_void,
+        _NumOfElements: *mut ::std::os::raw::c_uint,
+        _SizeOfElements: usize,
+        _CompareFunction: _CoreCrtSecureSearchSortCompareFunction,
+        _Context: *mut ::std::os::raw::c_void,
+    ) -> *mut ::std::os::raw::c_void;
+}
+unsafe extern "C" {
+    pub fn _lfind(
+        _Key: *const ::std::os::raw::c_void,
+        _Base: *const ::std::os::raw::c_void,
+        _NumOfElements: *mut ::std::os::raw::c_uint,
+        _SizeOfElements: ::std::os::raw::c_uint,
+        _CompareFunction: _CoreCrtNonSecureSearchSortCompareFunction,
+    ) -> *mut ::std::os::raw::c_void;
+}
+unsafe extern "C" {
+    pub fn _lsearch_s(
+        _Key: *const ::std::os::raw::c_void,
+        _Base: *mut ::std::os::raw::c_void,
+        _NumOfElements: *mut ::std::os::raw::c_uint,
+        _SizeOfElements: usize,
+        _CompareFunction: _CoreCrtSecureSearchSortCompareFunction,
+        _Context: *mut ::std::os::raw::c_void,
+    ) -> *mut ::std::os::raw::c_void;
+}
+unsafe extern "C" {
+    pub fn _lsearch(
+        _Key: *const ::std::os::raw::c_void,
+        _Base: *mut ::std::os::raw::c_void,
+        _NumOfElements: *mut ::std::os::raw::c_uint,
+        _SizeOfElements: ::std::os::raw::c_uint,
+        _CompareFunction: _CoreCrtNonSecureSearchSortCompareFunction,
+    ) -> *mut ::std::os::raw::c_void;
+}
+unsafe extern "C" {
+    pub fn lfind(
+        _Key: *const ::std::os::raw::c_void,
+        _Base: *const ::std::os::raw::c_void,
+        _NumOfElements: *mut ::std::os::raw::c_uint,
+        _SizeOfElements: ::std::os::raw::c_uint,
+        _CompareFunction: _CoreCrtNonSecureSearchSortCompareFunction,
+    ) -> *mut ::std::os::raw::c_void;
+}
+unsafe extern "C" {
+    pub fn lsearch(
+        _Key: *const ::std::os::raw::c_void,
+        _Base: *mut ::std::os::raw::c_void,
+        _NumOfElements: *mut ::std::os::raw::c_uint,
+        _SizeOfElements: ::std::os::raw::c_uint,
+        _CompareFunction: _CoreCrtNonSecureSearchSortCompareFunction,
+    ) -> *mut ::std::os::raw::c_void;
+}
+unsafe extern "C" {
+    pub fn _itow_s(
+        _Value: ::std::os::raw::c_int,
+        _Buffer: *mut wchar_t,
+        _BufferCount: usize,
+        _Radix: ::std::os::raw::c_int,
+    ) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn _itow(
+        _Value: ::std::os::raw::c_int,
+        _Buffer: *mut wchar_t,
+        _Radix: ::std::os::raw::c_int,
+    ) -> *mut wchar_t;
+}
+unsafe extern "C" {
+    pub fn _ltow_s(
+        _Value: ::std::os::raw::c_long,
+        _Buffer: *mut wchar_t,
+        _BufferCount: usize,
+        _Radix: ::std::os::raw::c_int,
+    ) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn _ltow(
+        _Value: ::std::os::raw::c_long,
+        _Buffer: *mut wchar_t,
+        _Radix: ::std::os::raw::c_int,
+    ) -> *mut wchar_t;
+}
+unsafe extern "C" {
+    pub fn _ultow_s(
+        _Value: ::std::os::raw::c_ulong,
+        _Buffer: *mut wchar_t,
+        _BufferCount: usize,
+        _Radix: ::std::os::raw::c_int,
+    ) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn _ultow(
+        _Value: ::std::os::raw::c_ulong,
+        _Buffer: *mut wchar_t,
+        _Radix: ::std::os::raw::c_int,
+    ) -> *mut wchar_t;
+}
+unsafe extern "C" {
+    pub fn wcstod(_String: *const wchar_t, _EndPtr: *mut *mut wchar_t) -> f64;
+}
+unsafe extern "C" {
+    pub fn _wcstod_l(
+        _String: *const wchar_t,
+        _EndPtr: *mut *mut wchar_t,
+        _Locale: _locale_t,
+    ) -> f64;
+}
+unsafe extern "C" {
+    pub fn wcstol(
+        _String: *const wchar_t,
+        _EndPtr: *mut *mut wchar_t,
+        _Radix: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn _wcstol_l(
+        _String: *const wchar_t,
+        _EndPtr: *mut *mut wchar_t,
+        _Radix: ::std::os::raw::c_int,
+        _Locale: _locale_t,
+    ) -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn wcstoll(
+        _String: *const wchar_t,
+        _EndPtr: *mut *mut wchar_t,
+        _Radix: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_longlong;
+}
+unsafe extern "C" {
+    pub fn _wcstoll_l(
+        _String: *const wchar_t,
+        _EndPtr: *mut *mut wchar_t,
+        _Radix: ::std::os::raw::c_int,
+        _Locale: _locale_t,
+    ) -> ::std::os::raw::c_longlong;
+}
+unsafe extern "C" {
+    pub fn wcstoul(
+        _String: *const wchar_t,
+        _EndPtr: *mut *mut wchar_t,
+        _Radix: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_ulong;
+}
+unsafe extern "C" {
+    pub fn _wcstoul_l(
+        _String: *const wchar_t,
+        _EndPtr: *mut *mut wchar_t,
+        _Radix: ::std::os::raw::c_int,
+        _Locale: _locale_t,
+    ) -> ::std::os::raw::c_ulong;
+}
+unsafe extern "C" {
+    pub fn wcstoull(
+        _String: *const wchar_t,
+        _EndPtr: *mut *mut wchar_t,
+        _Radix: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_ulonglong;
+}
+unsafe extern "C" {
+    pub fn _wcstoull_l(
+        _String: *const wchar_t,
+        _EndPtr: *mut *mut wchar_t,
+        _Radix: ::std::os::raw::c_int,
+        _Locale: _locale_t,
+    ) -> ::std::os::raw::c_ulonglong;
+}
+unsafe extern "C" {
+    pub fn wcstold(_String: *const wchar_t, _EndPtr: *mut *mut wchar_t) -> f64;
+}
+unsafe extern "C" {
+    pub fn _wcstold_l(
+        _String: *const wchar_t,
+        _EndPtr: *mut *mut wchar_t,
+        _Locale: _locale_t,
+    ) -> f64;
+}
+unsafe extern "C" {
+    pub fn wcstof(_String: *const wchar_t, _EndPtr: *mut *mut wchar_t) -> f32;
+}
+unsafe extern "C" {
+    pub fn _wcstof_l(
+        _String: *const wchar_t,
+        _EndPtr: *mut *mut wchar_t,
+        _Locale: _locale_t,
+    ) -> f32;
+}
+unsafe extern "C" {
+    pub fn _wtof(_String: *const wchar_t) -> f64;
+}
+unsafe extern "C" {
+    pub fn _wtof_l(_String: *const wchar_t, _Locale: _locale_t) -> f64;
+}
+unsafe extern "C" {
+    pub fn _wtoi(_String: *const wchar_t) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _wtoi_l(_String: *const wchar_t, _Locale: _locale_t) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _wtol(_String: *const wchar_t) -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn _wtol_l(_String: *const wchar_t, _Locale: _locale_t) -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn _wtoll(_String: *const wchar_t) -> ::std::os::raw::c_longlong;
+}
+unsafe extern "C" {
+    pub fn _wtoll_l(_String: *const wchar_t, _Locale: _locale_t) -> ::std::os::raw::c_longlong;
+}
+unsafe extern "C" {
+    pub fn _i64tow_s(
+        _Value: ::std::os::raw::c_longlong,
+        _Buffer: *mut wchar_t,
+        _BufferCount: usize,
+        _Radix: ::std::os::raw::c_int,
+    ) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn _i64tow(
+        _Value: ::std::os::raw::c_longlong,
+        _Buffer: *mut wchar_t,
+        _Radix: ::std::os::raw::c_int,
+    ) -> *mut wchar_t;
+}
+unsafe extern "C" {
+    pub fn _ui64tow_s(
+        _Value: ::std::os::raw::c_ulonglong,
+        _Buffer: *mut wchar_t,
+        _BufferCount: usize,
+        _Radix: ::std::os::raw::c_int,
+    ) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn _ui64tow(
+        _Value: ::std::os::raw::c_ulonglong,
+        _Buffer: *mut wchar_t,
+        _Radix: ::std::os::raw::c_int,
+    ) -> *mut wchar_t;
+}
+unsafe extern "C" {
+    pub fn _wtoi64(_String: *const wchar_t) -> ::std::os::raw::c_longlong;
+}
+unsafe extern "C" {
+    pub fn _wtoi64_l(_String: *const wchar_t, _Locale: _locale_t) -> ::std::os::raw::c_longlong;
+}
+unsafe extern "C" {
+    pub fn _wcstoi64(
+        _String: *const wchar_t,
+        _EndPtr: *mut *mut wchar_t,
+        _Radix: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_longlong;
+}
+unsafe extern "C" {
+    pub fn _wcstoi64_l(
+        _String: *const wchar_t,
+        _EndPtr: *mut *mut wchar_t,
+        _Radix: ::std::os::raw::c_int,
+        _Locale: _locale_t,
+    ) -> ::std::os::raw::c_longlong;
+}
+unsafe extern "C" {
+    pub fn _wcstoui64(
+        _String: *const wchar_t,
+        _EndPtr: *mut *mut wchar_t,
+        _Radix: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_ulonglong;
+}
+unsafe extern "C" {
+    pub fn _wcstoui64_l(
+        _String: *const wchar_t,
+        _EndPtr: *mut *mut wchar_t,
+        _Radix: ::std::os::raw::c_int,
+        _Locale: _locale_t,
+    ) -> ::std::os::raw::c_ulonglong;
+}
+unsafe extern "C" {
+    pub fn _wfullpath(
+        _Buffer: *mut wchar_t,
+        _Path: *const wchar_t,
+        _BufferCount: usize,
+    ) -> *mut wchar_t;
+}
+unsafe extern "C" {
+    pub fn _wmakepath_s(
+        _Buffer: *mut wchar_t,
+        _BufferCount: usize,
+        _Drive: *const wchar_t,
+        _Dir: *const wchar_t,
+        _Filename: *const wchar_t,
+        _Ext: *const wchar_t,
+    ) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn _wmakepath(
+        _Buffer: *mut wchar_t,
+        _Drive: *const wchar_t,
+        _Dir: *const wchar_t,
+        _Filename: *const wchar_t,
+        _Ext: *const wchar_t,
+    );
+}
+unsafe extern "C" {
+    pub fn _wsplitpath(
+        _FullPath: *const wchar_t,
+        _Drive: *mut wchar_t,
+        _Dir: *mut wchar_t,
+        _Filename: *mut wchar_t,
+        _Ext: *mut wchar_t,
+    );
+}
+unsafe extern "C" {
+    pub fn _wsplitpath_s(
+        _FullPath: *const wchar_t,
+        _Drive: *mut wchar_t,
+        _DriveCount: usize,
+        _Dir: *mut wchar_t,
+        _DirCount: usize,
+        _Filename: *mut wchar_t,
+        _FilenameCount: usize,
+        _Ext: *mut wchar_t,
+        _ExtCount: usize,
+    ) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn _wdupenv_s(
+        _Buffer: *mut *mut wchar_t,
+        _BufferCount: *mut usize,
+        _VarName: *const wchar_t,
+    ) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn _wgetenv(_VarName: *const wchar_t) -> *mut wchar_t;
+}
+unsafe extern "C" {
+    pub fn _wgetenv_s(
+        _RequiredCount: *mut usize,
+        _Buffer: *mut wchar_t,
+        _BufferCount: usize,
+        _VarName: *const wchar_t,
+    ) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn _wputenv(_EnvString: *const wchar_t) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _wputenv_s(_Name: *const wchar_t, _Value: *const wchar_t) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn _wsearchenv_s(
+        _Filename: *const wchar_t,
+        _VarName: *const wchar_t,
+        _Buffer: *mut wchar_t,
+        _BufferCount: usize,
+    ) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn _wsearchenv(
+        _Filename: *const wchar_t,
+        _VarName: *const wchar_t,
+        _ResultPath: *mut wchar_t,
+    );
+}
+unsafe extern "C" {
+    pub fn _wsystem(_Command: *const wchar_t) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _swab(
+        _Buf1: *mut ::std::os::raw::c_char,
+        _Buf2: *mut ::std::os::raw::c_char,
+        _SizeInBytes: ::std::os::raw::c_int,
+    );
+}
+unsafe extern "C" {
+    pub fn exit(_Code: ::std::os::raw::c_int) -> !;
+}
+unsafe extern "C" {
+    pub fn _exit(_Code: ::std::os::raw::c_int) -> !;
+}
+unsafe extern "C" {
+    pub fn _Exit(_Code: ::std::os::raw::c_int) -> !;
+}
+unsafe extern "C" {
+    pub fn quick_exit(_Code: ::std::os::raw::c_int) -> !;
 }
 unsafe extern "C" {
     pub fn abort() -> !;
 }
 unsafe extern "C" {
-    pub fn abs(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+    pub fn _set_abort_behavior(
+        _Flags: ::std::os::raw::c_uint,
+        _Mask: ::std::os::raw::c_uint,
+    ) -> ::std::os::raw::c_uint;
 }
+pub type _onexit_t = ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_int>;
 unsafe extern "C" {
     pub fn atexit(arg1: ::std::option::Option<unsafe extern "C" fn()>) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn atof(arg1: *const ::std::os::raw::c_char) -> f64;
+    pub fn _onexit(_Func: _onexit_t) -> _onexit_t;
 }
 unsafe extern "C" {
-    pub fn atoi(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn atol(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
-}
-unsafe extern "C" {
-    pub fn atoll(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_longlong;
-}
-unsafe extern "C" {
-    pub fn bsearch(
-        __key: *const ::std::os::raw::c_void,
-        __base: *const ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
-    ) -> *mut ::std::os::raw::c_void;
-}
-unsafe extern "C" {
-    pub fn div(arg1: ::std::os::raw::c_int, arg2: ::std::os::raw::c_int) -> div_t;
-}
-unsafe extern "C" {
-    pub fn exit(arg1: ::std::os::raw::c_int) -> !;
-}
-unsafe extern "C" {
-    pub fn getenv(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn labs(arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_long;
-}
-unsafe extern "C" {
-    pub fn ldiv(arg1: ::std::os::raw::c_long, arg2: ::std::os::raw::c_long) -> ldiv_t;
-}
-unsafe extern "C" {
-    pub fn llabs(arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_longlong;
-}
-unsafe extern "C" {
-    pub fn lldiv(arg1: ::std::os::raw::c_longlong, arg2: ::std::os::raw::c_longlong) -> lldiv_t;
-}
-unsafe extern "C" {
-    pub fn mblen(__s: *const ::std::os::raw::c_char, __n: usize) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn mbstowcs(arg1: *mut wchar_t, arg2: *const ::std::os::raw::c_char, arg3: usize) -> usize;
-}
-unsafe extern "C" {
-    pub fn mbtowc(
-        arg1: *mut wchar_t,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: usize,
+    pub fn at_quick_exit(
+        arg1: ::std::option::Option<unsafe extern "C" fn()>,
     ) -> ::std::os::raw::c_int;
 }
+pub type _purecall_handler = ::std::option::Option<unsafe extern "C" fn()>;
+pub type _invalid_parameter_handler = ::std::option::Option<
+    unsafe extern "C" fn(
+        arg1: *const wchar_t,
+        arg2: *const wchar_t,
+        arg3: *const wchar_t,
+        arg4: ::std::os::raw::c_uint,
+        arg5: usize,
+    ),
+>;
 unsafe extern "C" {
-    pub fn qsort(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
-    );
+    pub fn _set_purecall_handler(_Handler: _purecall_handler) -> _purecall_handler;
+}
+unsafe extern "C" {
+    pub fn _get_purecall_handler() -> _purecall_handler;
+}
+unsafe extern "C" {
+    pub fn _set_invalid_parameter_handler(
+        _Handler: _invalid_parameter_handler,
+    ) -> _invalid_parameter_handler;
+}
+unsafe extern "C" {
+    pub fn _get_invalid_parameter_handler() -> _invalid_parameter_handler;
+}
+unsafe extern "C" {
+    pub fn _set_thread_local_invalid_parameter_handler(
+        _Handler: _invalid_parameter_handler,
+    ) -> _invalid_parameter_handler;
+}
+unsafe extern "C" {
+    pub fn _get_thread_local_invalid_parameter_handler() -> _invalid_parameter_handler;
+}
+unsafe extern "C" {
+    pub fn _set_error_mode(_Mode: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _errno() -> *mut ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _set_errno(_Value: ::std::os::raw::c_int) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn _get_errno(_Value: *mut ::std::os::raw::c_int) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn __doserrno() -> *mut ::std::os::raw::c_ulong;
+}
+unsafe extern "C" {
+    pub fn _set_doserrno(_Value: ::std::os::raw::c_ulong) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn _get_doserrno(_Value: *mut ::std::os::raw::c_ulong) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn __sys_errlist() -> *mut *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn __sys_nerr() -> *mut ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn __p__pgmptr() -> *mut *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn __p__wpgmptr() -> *mut *mut wchar_t;
+}
+unsafe extern "C" {
+    pub fn __p__fmode() -> *mut ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _get_pgmptr(_Value: *mut *mut ::std::os::raw::c_char) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn _get_wpgmptr(_Value: *mut *mut wchar_t) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn _set_fmode(_Mode: ::std::os::raw::c_int) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn _get_fmode(_PMode: *mut ::std::os::raw::c_int) -> errno_t;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _div_t {
+    pub quot: ::std::os::raw::c_int,
+    pub rem: ::std::os::raw::c_int,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of _div_t"][::std::mem::size_of::<_div_t>() - 8usize];
+    ["Alignment of _div_t"][::std::mem::align_of::<_div_t>() - 4usize];
+    ["Offset of field: _div_t::quot"][::std::mem::offset_of!(_div_t, quot) - 0usize];
+    ["Offset of field: _div_t::rem"][::std::mem::offset_of!(_div_t, rem) - 4usize];
+};
+pub type div_t = _div_t;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _ldiv_t {
+    pub quot: ::std::os::raw::c_long,
+    pub rem: ::std::os::raw::c_long,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of _ldiv_t"][::std::mem::size_of::<_ldiv_t>() - 8usize];
+    ["Alignment of _ldiv_t"][::std::mem::align_of::<_ldiv_t>() - 4usize];
+    ["Offset of field: _ldiv_t::quot"][::std::mem::offset_of!(_ldiv_t, quot) - 0usize];
+    ["Offset of field: _ldiv_t::rem"][::std::mem::offset_of!(_ldiv_t, rem) - 4usize];
+};
+pub type ldiv_t = _ldiv_t;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _lldiv_t {
+    pub quot: ::std::os::raw::c_longlong,
+    pub rem: ::std::os::raw::c_longlong,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of _lldiv_t"][::std::mem::size_of::<_lldiv_t>() - 16usize];
+    ["Alignment of _lldiv_t"][::std::mem::align_of::<_lldiv_t>() - 8usize];
+    ["Offset of field: _lldiv_t::quot"][::std::mem::offset_of!(_lldiv_t, quot) - 0usize];
+    ["Offset of field: _lldiv_t::rem"][::std::mem::offset_of!(_lldiv_t, rem) - 8usize];
+};
+pub type lldiv_t = _lldiv_t;
+unsafe extern "C" {
+    pub fn _abs64(_Number: ::std::os::raw::c_longlong) -> ::std::os::raw::c_longlong;
+}
+unsafe extern "C" {
+    pub fn _byteswap_ushort(_Number: ::std::os::raw::c_ushort) -> ::std::os::raw::c_ushort;
+}
+unsafe extern "C" {
+    pub fn _byteswap_ulong(_Number: ::std::os::raw::c_ulong) -> ::std::os::raw::c_ulong;
+}
+unsafe extern "C" {
+    pub fn _byteswap_uint64(_Number: ::std::os::raw::c_ulonglong) -> ::std::os::raw::c_ulonglong;
+}
+unsafe extern "C" {
+    pub fn div(_Numerator: ::std::os::raw::c_int, _Denominator: ::std::os::raw::c_int) -> div_t;
+}
+unsafe extern "C" {
+    pub fn ldiv(_Numerator: ::std::os::raw::c_long, _Denominator: ::std::os::raw::c_long)
+    -> ldiv_t;
+}
+unsafe extern "C" {
+    pub fn lldiv(
+        _Numerator: ::std::os::raw::c_longlong,
+        _Denominator: ::std::os::raw::c_longlong,
+    ) -> lldiv_t;
+}
+unsafe extern "C" {
+    pub fn _rotl(
+        _Value: ::std::os::raw::c_uint,
+        _Shift: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_uint;
+}
+unsafe extern "C" {
+    pub fn _lrotl(
+        _Value: ::std::os::raw::c_ulong,
+        _Shift: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_ulong;
+}
+unsafe extern "C" {
+    pub fn _rotl64(
+        _Value: ::std::os::raw::c_ulonglong,
+        _Shift: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_ulonglong;
+}
+unsafe extern "C" {
+    pub fn _rotr(
+        _Value: ::std::os::raw::c_uint,
+        _Shift: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_uint;
+}
+unsafe extern "C" {
+    pub fn _lrotr(
+        _Value: ::std::os::raw::c_ulong,
+        _Shift: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_ulong;
+}
+unsafe extern "C" {
+    pub fn _rotr64(
+        _Value: ::std::os::raw::c_ulonglong,
+        _Shift: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_ulonglong;
+}
+unsafe extern "C" {
+    pub fn srand(_Seed: ::std::os::raw::c_uint);
 }
 unsafe extern "C" {
     pub fn rand() -> ::std::os::raw::c_int;
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _LDOUBLE {
+    pub ld: [::std::os::raw::c_uchar; 10usize],
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of _LDOUBLE"][::std::mem::size_of::<_LDOUBLE>() - 10usize];
+    ["Alignment of _LDOUBLE"][::std::mem::align_of::<_LDOUBLE>() - 1usize];
+    ["Offset of field: _LDOUBLE::ld"][::std::mem::offset_of!(_LDOUBLE, ld) - 0usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _CRT_DOUBLE {
+    pub x: f64,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of _CRT_DOUBLE"][::std::mem::size_of::<_CRT_DOUBLE>() - 8usize];
+    ["Alignment of _CRT_DOUBLE"][::std::mem::align_of::<_CRT_DOUBLE>() - 8usize];
+    ["Offset of field: _CRT_DOUBLE::x"][::std::mem::offset_of!(_CRT_DOUBLE, x) - 0usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _CRT_FLOAT {
+    pub f: f32,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of _CRT_FLOAT"][::std::mem::size_of::<_CRT_FLOAT>() - 4usize];
+    ["Alignment of _CRT_FLOAT"][::std::mem::align_of::<_CRT_FLOAT>() - 4usize];
+    ["Offset of field: _CRT_FLOAT::f"][::std::mem::offset_of!(_CRT_FLOAT, f) - 0usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _LONGDOUBLE {
+    pub x: f64,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of _LONGDOUBLE"][::std::mem::size_of::<_LONGDOUBLE>() - 8usize];
+    ["Alignment of _LONGDOUBLE"][::std::mem::align_of::<_LONGDOUBLE>() - 8usize];
+    ["Offset of field: _LONGDOUBLE::x"][::std::mem::offset_of!(_LONGDOUBLE, x) - 0usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _LDBL12 {
+    pub ld12: [::std::os::raw::c_uchar; 12usize],
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of _LDBL12"][::std::mem::size_of::<_LDBL12>() - 12usize];
+    ["Alignment of _LDBL12"][::std::mem::align_of::<_LDBL12>() - 1usize];
+    ["Offset of field: _LDBL12::ld12"][::std::mem::offset_of!(_LDBL12, ld12) - 0usize];
+};
 unsafe extern "C" {
-    pub fn srand(arg1: ::std::os::raw::c_uint);
+    pub fn atoi(_String: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn strtod(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *mut *mut ::std::os::raw::c_char,
-    ) -> f64;
+    pub fn atol(_String: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
 }
 unsafe extern "C" {
-    pub fn strtof(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *mut *mut ::std::os::raw::c_char,
-    ) -> f32;
+    pub fn atoll(_String: *const ::std::os::raw::c_char) -> ::std::os::raw::c_longlong;
 }
 unsafe extern "C" {
-    pub fn strtol(
-        __str: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
+    pub fn _atoi64(_String: *const ::std::os::raw::c_char) -> ::std::os::raw::c_longlong;
+}
+unsafe extern "C" {
+    pub fn _atoi_l(
+        _String: *const ::std::os::raw::c_char,
+        _Locale: _locale_t,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _atol_l(
+        _String: *const ::std::os::raw::c_char,
+        _Locale: _locale_t,
     ) -> ::std::os::raw::c_long;
 }
 unsafe extern "C" {
-    pub fn strtold(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *mut *mut ::std::os::raw::c_char,
+    pub fn _atoll_l(
+        _String: *const ::std::os::raw::c_char,
+        _Locale: _locale_t,
+    ) -> ::std::os::raw::c_longlong;
+}
+unsafe extern "C" {
+    pub fn _atoi64_l(
+        _String: *const ::std::os::raw::c_char,
+        _Locale: _locale_t,
+    ) -> ::std::os::raw::c_longlong;
+}
+unsafe extern "C" {
+    pub fn _atoflt(
+        _Result: *mut _CRT_FLOAT,
+        _String: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _atodbl(
+        _Result: *mut _CRT_DOUBLE,
+        _String: *mut ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _atoldbl(
+        _Result: *mut _LDOUBLE,
+        _String: *mut ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _atoflt_l(
+        _Result: *mut _CRT_FLOAT,
+        _String: *const ::std::os::raw::c_char,
+        _Locale: _locale_t,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _atodbl_l(
+        _Result: *mut _CRT_DOUBLE,
+        _String: *mut ::std::os::raw::c_char,
+        _Locale: _locale_t,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _atoldbl_l(
+        _Result: *mut _LDOUBLE,
+        _String: *mut ::std::os::raw::c_char,
+        _Locale: _locale_t,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn strtof(
+        _String: *const ::std::os::raw::c_char,
+        _EndPtr: *mut *mut ::std::os::raw::c_char,
+    ) -> f32;
+}
+unsafe extern "C" {
+    pub fn _strtof_l(
+        _String: *const ::std::os::raw::c_char,
+        _EndPtr: *mut *mut ::std::os::raw::c_char,
+        _Locale: _locale_t,
+    ) -> f32;
+}
+unsafe extern "C" {
+    pub fn strtod(
+        _String: *const ::std::os::raw::c_char,
+        _EndPtr: *mut *mut ::std::os::raw::c_char,
     ) -> f64;
 }
 unsafe extern "C" {
+    pub fn _strtod_l(
+        _String: *const ::std::os::raw::c_char,
+        _EndPtr: *mut *mut ::std::os::raw::c_char,
+        _Locale: _locale_t,
+    ) -> f64;
+}
+unsafe extern "C" {
+    pub fn strtold(
+        _String: *const ::std::os::raw::c_char,
+        _EndPtr: *mut *mut ::std::os::raw::c_char,
+    ) -> f64;
+}
+unsafe extern "C" {
+    pub fn _strtold_l(
+        _String: *const ::std::os::raw::c_char,
+        _EndPtr: *mut *mut ::std::os::raw::c_char,
+        _Locale: _locale_t,
+    ) -> f64;
+}
+unsafe extern "C" {
+    pub fn strtol(
+        _String: *const ::std::os::raw::c_char,
+        _EndPtr: *mut *mut ::std::os::raw::c_char,
+        _Radix: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
+    pub fn _strtol_l(
+        _String: *const ::std::os::raw::c_char,
+        _EndPtr: *mut *mut ::std::os::raw::c_char,
+        _Radix: ::std::os::raw::c_int,
+        _Locale: _locale_t,
+    ) -> ::std::os::raw::c_long;
+}
+unsafe extern "C" {
     pub fn strtoll(
-        __str: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
+        _String: *const ::std::os::raw::c_char,
+        _EndPtr: *mut *mut ::std::os::raw::c_char,
+        _Radix: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_longlong;
+}
+unsafe extern "C" {
+    pub fn _strtoll_l(
+        _String: *const ::std::os::raw::c_char,
+        _EndPtr: *mut *mut ::std::os::raw::c_char,
+        _Radix: ::std::os::raw::c_int,
+        _Locale: _locale_t,
     ) -> ::std::os::raw::c_longlong;
 }
 unsafe extern "C" {
     pub fn strtoul(
-        __str: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
+        _String: *const ::std::os::raw::c_char,
+        _EndPtr: *mut *mut ::std::os::raw::c_char,
+        _Radix: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_ulong;
+}
+unsafe extern "C" {
+    pub fn _strtoul_l(
+        _String: *const ::std::os::raw::c_char,
+        _EndPtr: *mut *mut ::std::os::raw::c_char,
+        _Radix: ::std::os::raw::c_int,
+        _Locale: _locale_t,
     ) -> ::std::os::raw::c_ulong;
 }
 unsafe extern "C" {
     pub fn strtoull(
-        __str: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
+        _String: *const ::std::os::raw::c_char,
+        _EndPtr: *mut *mut ::std::os::raw::c_char,
+        _Radix: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_ulonglong;
 }
 unsafe extern "C" {
-    pub fn system(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+    pub fn _strtoull_l(
+        _String: *const ::std::os::raw::c_char,
+        _EndPtr: *mut *mut ::std::os::raw::c_char,
+        _Radix: ::std::os::raw::c_int,
+        _Locale: _locale_t,
+    ) -> ::std::os::raw::c_ulonglong;
 }
 unsafe extern "C" {
-    pub fn wcstombs(arg1: *mut ::std::os::raw::c_char, arg2: *const wchar_t, arg3: usize) -> usize;
+    pub fn _strtoi64(
+        _String: *const ::std::os::raw::c_char,
+        _EndPtr: *mut *mut ::std::os::raw::c_char,
+        _Radix: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_longlong;
 }
 unsafe extern "C" {
-    pub fn wctomb(arg1: *mut ::std::os::raw::c_char, arg2: wchar_t) -> ::std::os::raw::c_int;
+    pub fn _strtoi64_l(
+        _String: *const ::std::os::raw::c_char,
+        _EndPtr: *mut *mut ::std::os::raw::c_char,
+        _Radix: ::std::os::raw::c_int,
+        _Locale: _locale_t,
+    ) -> ::std::os::raw::c_longlong;
 }
 unsafe extern "C" {
-    pub fn _Exit(arg1: ::std::os::raw::c_int) -> !;
+    pub fn _strtoui64(
+        _String: *const ::std::os::raw::c_char,
+        _EndPtr: *mut *mut ::std::os::raw::c_char,
+        _Radix: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_ulonglong;
 }
 unsafe extern "C" {
-    pub fn a64l(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_long;
+    pub fn _strtoui64_l(
+        _String: *const ::std::os::raw::c_char,
+        _EndPtr: *mut *mut ::std::os::raw::c_char,
+        _Radix: ::std::os::raw::c_int,
+        _Locale: _locale_t,
+    ) -> ::std::os::raw::c_ulonglong;
 }
 unsafe extern "C" {
-    pub fn drand48() -> f64;
+    pub fn _itoa_s(
+        _Value: ::std::os::raw::c_int,
+        _Buffer: *mut ::std::os::raw::c_char,
+        _BufferCount: usize,
+        _Radix: ::std::os::raw::c_int,
+    ) -> errno_t;
 }
 unsafe extern "C" {
-    pub fn ecvt(
-        arg1: f64,
-        arg2: ::std::os::raw::c_int,
-        arg3: *mut ::std::os::raw::c_int,
-        arg4: *mut ::std::os::raw::c_int,
+    pub fn _itoa(
+        _Value: ::std::os::raw::c_int,
+        _Buffer: *mut ::std::os::raw::c_char,
+        _Radix: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn erand48(arg1: *mut ::std::os::raw::c_ushort) -> f64;
+    pub fn _ltoa_s(
+        _Value: ::std::os::raw::c_long,
+        _Buffer: *mut ::std::os::raw::c_char,
+        _BufferCount: usize,
+        _Radix: ::std::os::raw::c_int,
+    ) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn _ltoa(
+        _Value: ::std::os::raw::c_long,
+        _Buffer: *mut ::std::os::raw::c_char,
+        _Radix: ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn _ultoa_s(
+        _Value: ::std::os::raw::c_ulong,
+        _Buffer: *mut ::std::os::raw::c_char,
+        _BufferCount: usize,
+        _Radix: ::std::os::raw::c_int,
+    ) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn _ultoa(
+        _Value: ::std::os::raw::c_ulong,
+        _Buffer: *mut ::std::os::raw::c_char,
+        _Radix: ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn _i64toa_s(
+        _Value: ::std::os::raw::c_longlong,
+        _Buffer: *mut ::std::os::raw::c_char,
+        _BufferCount: usize,
+        _Radix: ::std::os::raw::c_int,
+    ) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn _i64toa(
+        _Value: ::std::os::raw::c_longlong,
+        _Buffer: *mut ::std::os::raw::c_char,
+        _Radix: ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn _ui64toa_s(
+        _Value: ::std::os::raw::c_ulonglong,
+        _Buffer: *mut ::std::os::raw::c_char,
+        _BufferCount: usize,
+        _Radix: ::std::os::raw::c_int,
+    ) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn _ui64toa(
+        _Value: ::std::os::raw::c_ulonglong,
+        _Buffer: *mut ::std::os::raw::c_char,
+        _Radix: ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn _ecvt_s(
+        _Buffer: *mut ::std::os::raw::c_char,
+        _BufferCount: usize,
+        _Value: f64,
+        _DigitCount: ::std::os::raw::c_int,
+        _PtDec: *mut ::std::os::raw::c_int,
+        _PtSign: *mut ::std::os::raw::c_int,
+    ) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn _ecvt(
+        _Value: f64,
+        _DigitCount: ::std::os::raw::c_int,
+        _PtDec: *mut ::std::os::raw::c_int,
+        _PtSign: *mut ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn _fcvt_s(
+        _Buffer: *mut ::std::os::raw::c_char,
+        _BufferCount: usize,
+        _Value: f64,
+        _FractionalDigitCount: ::std::os::raw::c_int,
+        _PtDec: *mut ::std::os::raw::c_int,
+        _PtSign: *mut ::std::os::raw::c_int,
+    ) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn _fcvt(
+        _Value: f64,
+        _FractionalDigitCount: ::std::os::raw::c_int,
+        _PtDec: *mut ::std::os::raw::c_int,
+        _PtSign: *mut ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn _gcvt_s(
+        _Buffer: *mut ::std::os::raw::c_char,
+        _BufferCount: usize,
+        _Value: f64,
+        _DigitCount: ::std::os::raw::c_int,
+    ) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn _gcvt(
+        _Value: f64,
+        _DigitCount: ::std::os::raw::c_int,
+        _Buffer: *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn ___mb_cur_max_func() -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn ___mb_cur_max_l_func(_Locale: _locale_t) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn mblen(_Ch: *const ::std::os::raw::c_char, _MaxCount: usize) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _mblen_l(
+        _Ch: *const ::std::os::raw::c_char,
+        _MaxCount: usize,
+        _Locale: _locale_t,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _mbstrlen(_String: *const ::std::os::raw::c_char) -> usize;
+}
+unsafe extern "C" {
+    pub fn _mbstrlen_l(_String: *const ::std::os::raw::c_char, _Locale: _locale_t) -> usize;
+}
+unsafe extern "C" {
+    pub fn _mbstrnlen(_String: *const ::std::os::raw::c_char, _MaxCount: usize) -> usize;
+}
+unsafe extern "C" {
+    pub fn _mbstrnlen_l(
+        _String: *const ::std::os::raw::c_char,
+        _MaxCount: usize,
+        _Locale: _locale_t,
+    ) -> usize;
+}
+unsafe extern "C" {
+    pub fn mbtowc(
+        _DstCh: *mut wchar_t,
+        _SrcCh: *const ::std::os::raw::c_char,
+        _SrcSizeInBytes: usize,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _mbtowc_l(
+        _DstCh: *mut wchar_t,
+        _SrcCh: *const ::std::os::raw::c_char,
+        _SrcSizeInBytes: usize,
+        _Locale: _locale_t,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn mbstowcs_s(
+        _PtNumOfCharConverted: *mut usize,
+        _DstBuf: *mut wchar_t,
+        _SizeInWords: usize,
+        _SrcBuf: *const ::std::os::raw::c_char,
+        _MaxCount: usize,
+    ) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn mbstowcs(
+        _Dest: *mut wchar_t,
+        _Source: *const ::std::os::raw::c_char,
+        _MaxCount: usize,
+    ) -> usize;
+}
+unsafe extern "C" {
+    pub fn _mbstowcs_s_l(
+        _PtNumOfCharConverted: *mut usize,
+        _DstBuf: *mut wchar_t,
+        _SizeInWords: usize,
+        _SrcBuf: *const ::std::os::raw::c_char,
+        _MaxCount: usize,
+        _Locale: _locale_t,
+    ) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn _mbstowcs_l(
+        _Dest: *mut wchar_t,
+        _Source: *const ::std::os::raw::c_char,
+        _MaxCount: usize,
+        _Locale: _locale_t,
+    ) -> usize;
+}
+unsafe extern "C" {
+    pub fn wctomb(_MbCh: *mut ::std::os::raw::c_char, _WCh: wchar_t) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _wctomb_l(
+        _MbCh: *mut ::std::os::raw::c_char,
+        _WCh: wchar_t,
+        _Locale: _locale_t,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn wctomb_s(
+        _SizeConverted: *mut ::std::os::raw::c_int,
+        _MbCh: *mut ::std::os::raw::c_char,
+        _SizeInBytes: rsize_t,
+        _WCh: wchar_t,
+    ) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn _wctomb_s_l(
+        _SizeConverted: *mut ::std::os::raw::c_int,
+        _MbCh: *mut ::std::os::raw::c_char,
+        _SizeInBytes: usize,
+        _WCh: wchar_t,
+        _Locale: _locale_t,
+    ) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn wcstombs_s(
+        _PtNumOfCharConverted: *mut usize,
+        _Dst: *mut ::std::os::raw::c_char,
+        _DstSizeInBytes: usize,
+        _Src: *const wchar_t,
+        _MaxCountInBytes: usize,
+    ) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn wcstombs(
+        _Dest: *mut ::std::os::raw::c_char,
+        _Source: *const wchar_t,
+        _MaxCount: usize,
+    ) -> usize;
+}
+unsafe extern "C" {
+    pub fn _wcstombs_s_l(
+        _PtNumOfCharConverted: *mut usize,
+        _Dst: *mut ::std::os::raw::c_char,
+        _DstSizeInBytes: usize,
+        _Src: *const wchar_t,
+        _MaxCountInBytes: usize,
+        _Locale: _locale_t,
+    ) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn _wcstombs_l(
+        _Dest: *mut ::std::os::raw::c_char,
+        _Source: *const wchar_t,
+        _MaxCount: usize,
+        _Locale: _locale_t,
+    ) -> usize;
+}
+unsafe extern "C" {
+    pub fn _fullpath(
+        _Buffer: *mut ::std::os::raw::c_char,
+        _Path: *const ::std::os::raw::c_char,
+        _BufferCount: usize,
+    ) -> *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn _makepath_s(
+        _Buffer: *mut ::std::os::raw::c_char,
+        _BufferCount: usize,
+        _Drive: *const ::std::os::raw::c_char,
+        _Dir: *const ::std::os::raw::c_char,
+        _Filename: *const ::std::os::raw::c_char,
+        _Ext: *const ::std::os::raw::c_char,
+    ) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn _makepath(
+        _Buffer: *mut ::std::os::raw::c_char,
+        _Drive: *const ::std::os::raw::c_char,
+        _Dir: *const ::std::os::raw::c_char,
+        _Filename: *const ::std::os::raw::c_char,
+        _Ext: *const ::std::os::raw::c_char,
+    );
+}
+unsafe extern "C" {
+    pub fn _splitpath(
+        _FullPath: *const ::std::os::raw::c_char,
+        _Drive: *mut ::std::os::raw::c_char,
+        _Dir: *mut ::std::os::raw::c_char,
+        _Filename: *mut ::std::os::raw::c_char,
+        _Ext: *mut ::std::os::raw::c_char,
+    );
+}
+unsafe extern "C" {
+    pub fn _splitpath_s(
+        _FullPath: *const ::std::os::raw::c_char,
+        _Drive: *mut ::std::os::raw::c_char,
+        _DriveCount: usize,
+        _Dir: *mut ::std::os::raw::c_char,
+        _DirCount: usize,
+        _Filename: *mut ::std::os::raw::c_char,
+        _FilenameCount: usize,
+        _Ext: *mut ::std::os::raw::c_char,
+        _ExtCount: usize,
+    ) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn getenv_s(
+        _RequiredCount: *mut usize,
+        _Buffer: *mut ::std::os::raw::c_char,
+        _BufferCount: rsize_t,
+        _VarName: *const ::std::os::raw::c_char,
+    ) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn __p___argc() -> *mut ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn __p___argv() -> *mut *mut *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn __p___wargv() -> *mut *mut *mut wchar_t;
+}
+unsafe extern "C" {
+    pub fn __p__environ() -> *mut *mut *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn __p__wenviron() -> *mut *mut *mut wchar_t;
+}
+unsafe extern "C" {
+    pub fn getenv(_VarName: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn _dupenv_s(
+        _Buffer: *mut *mut ::std::os::raw::c_char,
+        _BufferCount: *mut usize,
+        _VarName: *const ::std::os::raw::c_char,
+    ) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn system(_Command: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _putenv(_EnvString: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _putenv_s(
+        _Name: *const ::std::os::raw::c_char,
+        _Value: *const ::std::os::raw::c_char,
+    ) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn _searchenv_s(
+        _Filename: *const ::std::os::raw::c_char,
+        _VarName: *const ::std::os::raw::c_char,
+        _Buffer: *mut ::std::os::raw::c_char,
+        _BufferCount: usize,
+    ) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn _searchenv(
+        _Filename: *const ::std::os::raw::c_char,
+        _VarName: *const ::std::os::raw::c_char,
+        _Buffer: *mut ::std::os::raw::c_char,
+    );
+}
+unsafe extern "C" {
+    pub fn _seterrormode(_Mode: ::std::os::raw::c_int);
+}
+unsafe extern "C" {
+    pub fn _beep(_Frequency: ::std::os::raw::c_uint, _Duration: ::std::os::raw::c_uint);
+}
+unsafe extern "C" {
+    pub fn _sleep(_Duration: ::std::os::raw::c_ulong);
+}
+unsafe extern "C" {
+    pub fn ecvt(
+        _Value: f64,
+        _DigitCount: ::std::os::raw::c_int,
+        _PtDec: *mut ::std::os::raw::c_int,
+        _PtSign: *mut ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     pub fn fcvt(
-        arg1: f64,
-        arg2: ::std::os::raw::c_int,
-        arg3: *mut ::std::os::raw::c_int,
-        arg4: *mut ::std::os::raw::c_int,
+        _Value: f64,
+        _FractionalDigitCount: ::std::os::raw::c_int,
+        _PtDec: *mut ::std::os::raw::c_int,
+        _PtSign: *mut ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     pub fn gcvt(
-        arg1: f64,
-        arg2: ::std::os::raw::c_int,
-        arg3: *mut ::std::os::raw::c_char,
+        _Value: f64,
+        _DigitCount: ::std::os::raw::c_int,
+        _DstBuf: *mut ::std::os::raw::c_char,
     ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn getsubopt(
-        arg1: *mut *mut ::std::os::raw::c_char,
-        arg2: *const *mut ::std::os::raw::c_char,
-        arg3: *mut *mut ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn grantpt(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn initstate(
-        arg1: ::std::os::raw::c_uint,
-        arg2: *mut ::std::os::raw::c_char,
-        arg3: usize,
+    pub fn itoa(
+        _Value: ::std::os::raw::c_int,
+        _Buffer: *mut ::std::os::raw::c_char,
+        _Radix: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn jrand48(arg1: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
-}
-unsafe extern "C" {
-    pub fn l64a(arg1: ::std::os::raw::c_long) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn lcong48(arg1: *mut ::std::os::raw::c_ushort);
-}
-unsafe extern "C" {
-    pub fn lrand48() -> ::std::os::raw::c_long;
-}
-unsafe extern "C" {
-    pub fn mktemp(arg1: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn mkstemp(arg1: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn mrand48() -> ::std::os::raw::c_long;
-}
-unsafe extern "C" {
-    pub fn nrand48(arg1: *mut ::std::os::raw::c_ushort) -> ::std::os::raw::c_long;
-}
-unsafe extern "C" {
-    pub fn posix_openpt(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn ptsname(arg1: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn ptsname_r(
-        fildes: ::std::os::raw::c_int,
-        buffer: *mut ::std::os::raw::c_char,
-        buflen: usize,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn putenv(arg1: *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn random() -> ::std::os::raw::c_long;
-}
-unsafe extern "C" {
-    pub fn rand_r(arg1: *mut ::std::os::raw::c_uint) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    #[link_name = "\u{1}_realpath$DARWIN_EXTSN"]
-    pub fn realpath(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *mut ::std::os::raw::c_char,
+    pub fn ltoa(
+        _Value: ::std::os::raw::c_long,
+        _Buffer: *mut ::std::os::raw::c_char,
+        _Radix: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn seed48(arg1: *mut ::std::os::raw::c_ushort) -> *mut ::std::os::raw::c_ushort;
-}
-unsafe extern "C" {
-    pub fn setenv(
-        __name: *const ::std::os::raw::c_char,
-        __value: *const ::std::os::raw::c_char,
-        __overwrite: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn setkey(arg1: *const ::std::os::raw::c_char);
-}
-unsafe extern "C" {
-    pub fn setstate(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn srand48(arg1: ::std::os::raw::c_long);
-}
-unsafe extern "C" {
-    pub fn srandom(arg1: ::std::os::raw::c_uint);
-}
-unsafe extern "C" {
-    pub fn unlockpt(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn unsetenv(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-pub type dev_t = __darwin_dev_t;
-pub type mode_t = __darwin_mode_t;
-unsafe extern "C" {
-    pub fn arc4random() -> u32;
-}
-unsafe extern "C" {
-    pub fn arc4random_addrandom(arg1: *mut ::std::os::raw::c_uchar, arg2: ::std::os::raw::c_int);
-}
-unsafe extern "C" {
-    pub fn arc4random_buf(__buf: *mut ::std::os::raw::c_void, __nbytes: usize);
-}
-unsafe extern "C" {
-    pub fn arc4random_stir();
-}
-unsafe extern "C" {
-    pub fn arc4random_uniform(__upper_bound: u32) -> u32;
-}
-unsafe extern "C" {
-    pub fn atexit_b(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn bsearch_b(
-        __key: *const ::std::os::raw::c_void,
-        __base: *const ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: *mut ::std::os::raw::c_void,
-    ) -> *mut ::std::os::raw::c_void;
-}
-unsafe extern "C" {
-    pub fn cgetcap(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn cgetclose() -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn cgetent(
-        arg1: *mut *mut ::std::os::raw::c_char,
-        arg2: *mut *mut ::std::os::raw::c_char,
-        arg3: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn cgetfirst(
-        arg1: *mut *mut ::std::os::raw::c_char,
-        arg2: *mut *mut ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn cgetmatch(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn cgetnext(
-        arg1: *mut *mut ::std::os::raw::c_char,
-        arg2: *mut *mut ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn cgetnum(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut ::std::os::raw::c_long,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn cgetset(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn cgetstr(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut *mut ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn cgetustr(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: *mut *mut ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn daemon(
-        arg1: ::std::os::raw::c_int,
-        arg2: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn devname(arg1: dev_t, arg2: mode_t) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn devname_r(
-        arg1: dev_t,
-        arg2: mode_t,
-        buf: *mut ::std::os::raw::c_char,
-        len: ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn getbsize(
-        arg1: *mut ::std::os::raw::c_int,
-        arg2: *mut ::std::os::raw::c_long,
-    ) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn getloadavg(arg1: *mut f64, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn getprogname() -> *const ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn setprogname(arg1: *const ::std::os::raw::c_char);
-}
-unsafe extern "C" {
-    pub fn heapsort(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn heapsort_b(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: *mut ::std::os::raw::c_void,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn mergesort(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn mergesort_b(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: *mut ::std::os::raw::c_void,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn psort(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *const ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
+    pub fn swab(
+        _Buf1: *mut ::std::os::raw::c_char,
+        _Buf2: *mut ::std::os::raw::c_char,
+        _SizeInBytes: ::std::os::raw::c_int,
     );
 }
 unsafe extern "C" {
-    pub fn psort_b(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: *mut ::std::os::raw::c_void,
-    );
+    pub fn ultoa(
+        _Value: ::std::os::raw::c_ulong,
+        _Buffer: *mut ::std::os::raw::c_char,
+        _Radix: ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn psort_r(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        arg1: *mut ::std::os::raw::c_void,
-        __compar: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-                arg3: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
-    );
+    pub fn putenv(_EnvString: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn qsort_b(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        __compar: *mut ::std::os::raw::c_void,
-    );
+    pub fn onexit(_Func: _onexit_t) -> _onexit_t;
 }
-unsafe extern "C" {
-    pub fn qsort_r(
-        __base: *mut ::std::os::raw::c_void,
-        __nel: usize,
-        __width: usize,
-        arg1: *mut ::std::os::raw::c_void,
-        __compar: ::std::option::Option<
-            unsafe extern "C" fn(
-                arg1: *mut ::std::os::raw::c_void,
-                arg2: *const ::std::os::raw::c_void,
-                arg3: *const ::std::os::raw::c_void,
-            ) -> ::std::os::raw::c_int,
-        >,
-    );
-}
-unsafe extern "C" {
-    pub fn radixsort(
-        __base: *mut *const ::std::os::raw::c_uchar,
-        __nel: ::std::os::raw::c_int,
-        __table: *const ::std::os::raw::c_uchar,
-        __endbyte: ::std::os::raw::c_uint,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn rpmatch(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn sradixsort(
-        __base: *mut *const ::std::os::raw::c_uchar,
-        __nel: ::std::os::raw::c_int,
-        __table: *const ::std::os::raw::c_uchar,
-        __endbyte: ::std::os::raw::c_uint,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn sranddev();
-}
-unsafe extern "C" {
-    pub fn srandomdev();
-}
-unsafe extern "C" {
-    pub fn strtonum(
-        __numstr: *const ::std::os::raw::c_char,
-        __minval: ::std::os::raw::c_longlong,
-        __maxval: ::std::os::raw::c_longlong,
-        __errstrp: *mut *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_longlong;
-}
-unsafe extern "C" {
-    pub fn strtoq(
-        __str: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_longlong;
-}
-unsafe extern "C" {
-    pub fn strtouq(
-        __str: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_ulonglong;
-}
-unsafe extern "C" {
-    pub static mut suboptarg: *mut ::std::os::raw::c_char;
-}
-pub type rsize_t = ::std::os::raw::c_ulong;
-pub type max_align_t = f64;
 unsafe extern "C" {
     #[doc = " allocates array and initializes it with 0; returns NULL if memory allocation failed"]
     pub fn BMSallocClearMemory_call(
@@ -5751,7 +4532,7 @@ pub const SCIP_Result_SCIP_SUCCESS: SCIP_Result = 17;
 #[doc = "< the processing of the branch-and-bound node should stopped and continued later"]
 pub const SCIP_Result_SCIP_DELAYNODE: SCIP_Result = 18;
 #[doc = " result codes for SCIP callback methods"]
-pub type SCIP_Result = ::std::os::raw::c_uint;
+pub type SCIP_Result = ::std::os::raw::c_int;
 #[doc = " result codes for SCIP callback methods"]
 pub use self::SCIP_Result as SCIP_RESULT;
 #[doc = "< use default clock type"]
@@ -5760,7 +4541,7 @@ pub const SCIP_ClockType_SCIP_CLOCKTYPE_DEFAULT: SCIP_ClockType = 0;
 pub const SCIP_ClockType_SCIP_CLOCKTYPE_CPU: SCIP_ClockType = 1;
 #[doc = "< use wall clock"]
 pub const SCIP_ClockType_SCIP_CLOCKTYPE_WALL: SCIP_ClockType = 2;
-pub type SCIP_ClockType = ::std::os::raw::c_uint;
+pub type SCIP_ClockType = ::std::os::raw::c_int;
 pub use self::SCIP_ClockType as SCIP_CLOCKTYPE;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -5791,7 +4572,7 @@ pub const SCIP_Confidencelevel_SCIP_CONFIDENCELEVEL_HIGH: SCIP_Confidencelevel =
 #[doc = "< (one-sided) confidence level 97.5 %, two-sided 95 %"]
 pub const SCIP_Confidencelevel_SCIP_CONFIDENCELEVEL_MAX: SCIP_Confidencelevel = 4;
 #[doc = " represents different confidence levels for (one-sided) hypothesis testing; in order to obtain two-sided confidence\n  levels, calculate 2 * c - 1, i.e., if the one-sided confidence level is 90 %, the two-sided level is 80 %"]
-pub type SCIP_Confidencelevel = ::std::os::raw::c_uint;
+pub type SCIP_Confidencelevel = ::std::os::raw::c_int;
 #[doc = " represents different confidence levels for (one-sided) hypothesis testing; in order to obtain two-sided confidence\n  levels, calculate 2 * c - 1, i.e., if the one-sided confidence level is 90 %, the two-sided level is 80 %"]
 pub use self::SCIP_Confidencelevel as SCIP_CONFIDENCELEVEL;
 #[doc = "< the hashmap did not store a single element yet, type unknown"]
@@ -5805,7 +4586,7 @@ pub const SCIP_Hashmaptype_SCIP_HASHMAPTYPE_INT: SCIP_Hashmaptype = 3;
 #[doc = "< the hashmap stores long ints"]
 pub const SCIP_Hashmaptype_SCIP_HASHMAPTYPE_LONG: SCIP_Hashmaptype = 4;
 #[doc = " type of hashmap: are pointers, reals or ints stored, or unknown"]
-pub type SCIP_Hashmaptype = ::std::os::raw::c_uint;
+pub type SCIP_Hashmaptype = ::std::os::raw::c_int;
 #[doc = " type of hashmap: are pointers, reals or ints stored, or unknown"]
 pub use self::SCIP_Hashmaptype as SCIP_HASHMAPTYPE;
 #[repr(C)]
@@ -5984,7 +4765,7 @@ pub const SCIP_ParamType_SCIP_PARAMTYPE_CHAR: SCIP_ParamType = 4;
 #[doc = "< strings: arrays of characters"]
 pub const SCIP_ParamType_SCIP_PARAMTYPE_STRING: SCIP_ParamType = 5;
 #[doc = " possible parameter types"]
-pub type SCIP_ParamType = ::std::os::raw::c_uint;
+pub type SCIP_ParamType = ::std::os::raw::c_int;
 #[doc = " possible parameter types"]
 pub use self::SCIP_ParamType as SCIP_PARAMTYPE;
 #[doc = "< use default values"]
@@ -5996,7 +4777,7 @@ pub const SCIP_ParamSetting_SCIP_PARAMSETTING_FAST: SCIP_ParamSetting = 2;
 #[doc = "< turn off"]
 pub const SCIP_ParamSetting_SCIP_PARAMSETTING_OFF: SCIP_ParamSetting = 3;
 #[doc = " possible parameter settings - used to determine the behavior of different SCIP components, e.g., heuristics, separators, ..."]
-pub type SCIP_ParamSetting = ::std::os::raw::c_uint;
+pub type SCIP_ParamSetting = ::std::os::raw::c_int;
 #[doc = " possible parameter settings - used to determine the behavior of different SCIP components, e.g., heuristics, separators, ..."]
 pub use self::SCIP_ParamSetting as SCIP_PARAMSETTING;
 #[doc = "< use default values"]
@@ -6024,7 +4805,7 @@ pub const SCIP_ParamEmphasis_SCIP_PARAMEMPHASIS_NUMERICS: SCIP_ParamEmphasis = 1
 #[doc = "< do not try to avoid running into memory limit"]
 pub const SCIP_ParamEmphasis_SCIP_PARAMEMPHASIS_BENCHMARK: SCIP_ParamEmphasis = 11;
 #[doc = " possible parameter emphases - used to determine the general SCIP behavior"]
-pub type SCIP_ParamEmphasis = ::std::os::raw::c_uint;
+pub type SCIP_ParamEmphasis = ::std::os::raw::c_int;
 #[doc = " possible parameter emphases - used to determine the general SCIP behavior"]
 pub use self::SCIP_ParamEmphasis as SCIP_PARAMEMPHASIS;
 #[repr(C)]
@@ -6045,51 +4826,84 @@ pub struct SCIP_ParamSet {
     _unused: [u8; 0],
 }
 pub type SCIP_PARAMSET = SCIP_ParamSet;
-unsafe extern "C" {
-    pub fn imaxabs(j: intmax_t) -> intmax_t;
-}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct imaxdiv_t {
+pub struct _Lldiv_t {
     pub quot: intmax_t,
     pub rem: intmax_t,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of imaxdiv_t"][::std::mem::size_of::<imaxdiv_t>() - 16usize];
-    ["Alignment of imaxdiv_t"][::std::mem::align_of::<imaxdiv_t>() - 8usize];
-    ["Offset of field: imaxdiv_t::quot"][::std::mem::offset_of!(imaxdiv_t, quot) - 0usize];
-    ["Offset of field: imaxdiv_t::rem"][::std::mem::offset_of!(imaxdiv_t, rem) - 8usize];
+    ["Size of _Lldiv_t"][::std::mem::size_of::<_Lldiv_t>() - 16usize];
+    ["Alignment of _Lldiv_t"][::std::mem::align_of::<_Lldiv_t>() - 8usize];
+    ["Offset of field: _Lldiv_t::quot"][::std::mem::offset_of!(_Lldiv_t, quot) - 0usize];
+    ["Offset of field: _Lldiv_t::rem"][::std::mem::offset_of!(_Lldiv_t, rem) - 8usize];
 };
+pub type imaxdiv_t = _Lldiv_t;
 unsafe extern "C" {
-    pub fn imaxdiv(__numer: intmax_t, __denom: intmax_t) -> imaxdiv_t;
+    pub fn imaxabs(_Number: intmax_t) -> intmax_t;
+}
+unsafe extern "C" {
+    pub fn imaxdiv(_Numerator: intmax_t, _Denominator: intmax_t) -> imaxdiv_t;
 }
 unsafe extern "C" {
     pub fn strtoimax(
-        __nptr: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
+        _String: *const ::std::os::raw::c_char,
+        _EndPtr: *mut *mut ::std::os::raw::c_char,
+        _Radix: ::std::os::raw::c_int,
+    ) -> intmax_t;
+}
+unsafe extern "C" {
+    pub fn _strtoimax_l(
+        _String: *const ::std::os::raw::c_char,
+        _EndPtr: *mut *mut ::std::os::raw::c_char,
+        _Radix: ::std::os::raw::c_int,
+        _Locale: _locale_t,
     ) -> intmax_t;
 }
 unsafe extern "C" {
     pub fn strtoumax(
-        __nptr: *const ::std::os::raw::c_char,
-        __endptr: *mut *mut ::std::os::raw::c_char,
-        __base: ::std::os::raw::c_int,
+        _String: *const ::std::os::raw::c_char,
+        _EndPtr: *mut *mut ::std::os::raw::c_char,
+        _Radix: ::std::os::raw::c_int,
+    ) -> uintmax_t;
+}
+unsafe extern "C" {
+    pub fn _strtoumax_l(
+        _String: *const ::std::os::raw::c_char,
+        _EndPtr: *mut *mut ::std::os::raw::c_char,
+        _Radix: ::std::os::raw::c_int,
+        _Locale: _locale_t,
     ) -> uintmax_t;
 }
 unsafe extern "C" {
     pub fn wcstoimax(
-        __nptr: *const wchar_t,
-        __endptr: *mut *mut wchar_t,
-        __base: ::std::os::raw::c_int,
+        _String: *const wchar_t,
+        _EndPtr: *mut *mut wchar_t,
+        _Radix: ::std::os::raw::c_int,
+    ) -> intmax_t;
+}
+unsafe extern "C" {
+    pub fn _wcstoimax_l(
+        _String: *const wchar_t,
+        _EndPtr: *mut *mut wchar_t,
+        _Radix: ::std::os::raw::c_int,
+        _Locale: _locale_t,
     ) -> intmax_t;
 }
 unsafe extern "C" {
     pub fn wcstoumax(
-        __nptr: *const wchar_t,
-        __endptr: *mut *mut wchar_t,
-        __base: ::std::os::raw::c_int,
+        _String: *const wchar_t,
+        _EndPtr: *mut *mut wchar_t,
+        _Radix: ::std::os::raw::c_int,
+    ) -> uintmax_t;
+}
+unsafe extern "C" {
+    pub fn _wcstoumax_l(
+        _String: *const wchar_t,
+        _EndPtr: *mut *mut wchar_t,
+        _Radix: ::std::os::raw::c_int,
+        _Locale: _locale_t,
     ) -> uintmax_t;
 }
 pub type SCIP_EVENTTYPE = u64;
@@ -6248,7 +5062,7 @@ pub const SCIP_LPSolStat_SCIP_LPSOLSTAT_TIMELIMIT: SCIP_LPSolStat = 6;
 #[doc = "< an error occured during optimization"]
 pub const SCIP_LPSolStat_SCIP_LPSOLSTAT_ERROR: SCIP_LPSolStat = 7;
 #[doc = " solution status after solving LP"]
-pub type SCIP_LPSolStat = ::std::os::raw::c_uint;
+pub type SCIP_LPSolStat = ::std::os::raw::c_int;
 #[doc = " solution status after solving LP"]
 pub use self::SCIP_LPSolStat as SCIP_LPSOLSTAT;
 #[doc = "< lower bound"]
@@ -6256,7 +5070,7 @@ pub const SCIP_BoundType_SCIP_BOUNDTYPE_LOWER: SCIP_BoundType = 0;
 #[doc = "< upper bound"]
 pub const SCIP_BoundType_SCIP_BOUNDTYPE_UPPER: SCIP_BoundType = 1;
 #[doc = " type of variable bound: lower or upper bound"]
-pub type SCIP_BoundType = ::std::os::raw::c_uint;
+pub type SCIP_BoundType = ::std::os::raw::c_int;
 #[doc = " type of variable bound: lower or upper bound"]
 pub use self::SCIP_BoundType as SCIP_BOUNDTYPE;
 #[doc = "< left hand side"]
@@ -6264,7 +5078,7 @@ pub const SCIP_SideType_SCIP_SIDETYPE_LEFT: SCIP_SideType = 0;
 #[doc = "< right hand side"]
 pub const SCIP_SideType_SCIP_SIDETYPE_RIGHT: SCIP_SideType = 1;
 #[doc = " type of row side: left hand or right hand side"]
-pub type SCIP_SideType = ::std::os::raw::c_uint;
+pub type SCIP_SideType = ::std::os::raw::c_int;
 #[doc = " type of row side: left hand or right hand side"]
 pub use self::SCIP_SideType as SCIP_SIDETYPE;
 #[doc = "< unspecified origin of row"]
@@ -6278,7 +5092,7 @@ pub const SCIP_RowOriginType_SCIP_ROWORIGINTYPE_SEPA: SCIP_RowOriginType = 3;
 #[doc = "< row created by reoptimization"]
 pub const SCIP_RowOriginType_SCIP_ROWORIGINTYPE_REOPT: SCIP_RowOriginType = 4;
 #[doc = " type of origin of row"]
-pub type SCIP_RowOriginType = ::std::os::raw::c_uint;
+pub type SCIP_RowOriginType = ::std::os::raw::c_int;
 #[doc = " type of origin of row"]
 pub use self::SCIP_RowOriginType as SCIP_ROWORIGINTYPE;
 #[doc = "< primal simplex"]
@@ -6290,7 +5104,7 @@ pub const SCIP_LPAlgo_SCIP_LPALGO_BARRIER: SCIP_LPAlgo = 2;
 #[doc = "< barrier algorithm with crossover"]
 pub const SCIP_LPAlgo_SCIP_LPALGO_BARRIERCROSSOVER: SCIP_LPAlgo = 3;
 #[doc = " type of LP algorithm"]
-pub type SCIP_LPAlgo = ::std::os::raw::c_uint;
+pub type SCIP_LPAlgo = ::std::os::raw::c_int;
 #[doc = " type of LP algorithm"]
 pub use self::SCIP_LPAlgo as SCIP_LPALGO;
 #[doc = " collected values of a column which depend on the LP solution\n  We store these values in each column to recover the LP solution at start of diving or probing mode, say, without\n  having to resolve the LP.  Note that we do not store the farkascoef value since we do expect a node with infeasible\n  LP to be pruned anyway."]
@@ -6332,7 +5146,7 @@ pub const SCIP_Varstatus_SCIP_VARSTATUS_MULTAGGR: SCIP_Varstatus = 5;
 #[doc = "< variable is the negation of an original or transformed variable"]
 pub const SCIP_Varstatus_SCIP_VARSTATUS_NEGATED: SCIP_Varstatus = 6;
 #[doc = " status of problem variables"]
-pub type SCIP_Varstatus = ::std::os::raw::c_uint;
+pub type SCIP_Varstatus = ::std::os::raw::c_int;
 #[doc = " status of problem variables"]
 pub use self::SCIP_Varstatus as SCIP_VARSTATUS;
 #[doc = "< binary variable: \\f$ x \\in \\{0,1\\} \\f$"]
@@ -6344,7 +5158,7 @@ pub const SCIP_Vartype_SCIP_VARTYPE_IMPLINT: SCIP_Vartype = 2;
 #[doc = "< continuous variable: \\f$ lb \\leq x \\leq ub \\f$"]
 pub const SCIP_Vartype_SCIP_VARTYPE_CONTINUOUS: SCIP_Vartype = 3;
 #[doc = " variable type"]
-pub type SCIP_Vartype = ::std::os::raw::c_uint;
+pub type SCIP_Vartype = ::std::os::raw::c_int;
 #[doc = " variable type"]
 pub use self::SCIP_Vartype as SCIP_VARTYPE;
 #[doc = "< The variable is not implied integral by other variables"]
@@ -6354,7 +5168,7 @@ pub const SCIP_ImplintType_SCIP_IMPLINTTYPE_WEAK: SCIP_ImplintType = 1;
 #[doc = "< The constraint handlers enforce that if the problem is relaxed\n   to have integrality constraints for the non-implied integral variables\n   only, in every feasible solution all strongly implied integral\n   variables have integer solution values.\n\n   @note This notion of implied integrality remains intact under the\n   addition of additional constraints to the problem.\n\n   Example: The variable z is strongly implied integral if we have the\n   constraint: 4x + 3y + z = 10, where x and y are integer variables."]
 pub const SCIP_ImplintType_SCIP_IMPLINTTYPE_STRONG: SCIP_ImplintType = 2;
 #[doc = " implied integral type"]
-pub type SCIP_ImplintType = ::std::os::raw::c_uint;
+pub type SCIP_ImplintType = ::std::os::raw::c_int;
 #[doc = " implied integral type"]
 pub use self::SCIP_ImplintType as SCIP_IMPLINTTYPE;
 #[doc = "< dynamic bound changes with size information of arrays"]
@@ -6364,7 +5178,7 @@ pub const SCIP_DomchgType_SCIP_DOMCHGTYPE_BOTH: SCIP_DomchgType = 1;
 #[doc = "< static domain changes without any hole changes"]
 pub const SCIP_DomchgType_SCIP_DOMCHGTYPE_BOUND: SCIP_DomchgType = 2;
 #[doc = " domain change data type"]
-pub type SCIP_DomchgType = ::std::os::raw::c_uint;
+pub type SCIP_DomchgType = ::std::os::raw::c_int;
 #[doc = " domain change data type"]
 pub use self::SCIP_DomchgType as SCIP_DOMCHGTYPE;
 #[doc = "< bound change was due to a branching decision"]
@@ -6374,14 +5188,14 @@ pub const SCIP_BoundchgType_SCIP_BOUNDCHGTYPE_CONSINFER: SCIP_BoundchgType = 1;
 #[doc = "< bound change was due to an inference of a domain propagator"]
 pub const SCIP_BoundchgType_SCIP_BOUNDCHGTYPE_PROPINFER: SCIP_BoundchgType = 2;
 #[doc = " bound change type"]
-pub type SCIP_BoundchgType = ::std::os::raw::c_uint;
+pub type SCIP_BoundchgType = ::std::os::raw::c_int;
 #[doc = " bound change type"]
 pub use self::SCIP_BoundchgType as SCIP_BOUNDCHGTYPE;
 #[doc = "< variable locks for model and check constraints"]
 pub const SCIP_LockType_SCIP_LOCKTYPE_MODEL: SCIP_LockType = 0;
 #[doc = "< variable locks for conflict constraints"]
 pub const SCIP_LockType_SCIP_LOCKTYPE_CONFLICT: SCIP_LockType = 1;
-pub type SCIP_LockType = ::std::os::raw::c_uint;
+pub type SCIP_LockType = ::std::os::raw::c_int;
 pub use self::SCIP_LockType as SCIP_LOCKTYPE;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -6569,7 +5383,7 @@ pub const SCIP_NodeType_SCIP_NODETYPE_FORK: SCIP_NodeType = 8;
 pub const SCIP_NodeType_SCIP_NODETYPE_SUBROOT: SCIP_NodeType = 9;
 #[doc = "< junction, fork, or subroot that was refocused for domain propagation"]
 pub const SCIP_NodeType_SCIP_NODETYPE_REFOCUSNODE: SCIP_NodeType = 10;
-pub type SCIP_NodeType = ::std::os::raw::c_uint;
+pub type SCIP_NodeType = ::std::os::raw::c_int;
 pub use self::SCIP_NodeType as SCIP_NODETYPE;
 #[doc = " probing node, possibly with solved LP, where bounds and constraints have been changed,\n  and rows and columns might have been added"]
 pub type SCIP_PROBINGNODE = SCIP_Probingnode;
@@ -6693,7 +5507,7 @@ pub const SCIP_ConflictType_SCIP_CONFTYPE_ALTINFPROOF: SCIP_ConflictType = 4;
 #[doc = "< alternative proof of a boundexceeding LP relaxation"]
 pub const SCIP_ConflictType_SCIP_CONFTYPE_ALTBNDPROOF: SCIP_ConflictType = 5;
 #[doc = " types of conflicts"]
-pub type SCIP_ConflictType = ::std::os::raw::c_uint;
+pub type SCIP_ConflictType = ::std::os::raw::c_int;
 #[doc = " types of conflicts"]
 pub use self::SCIP_ConflictType as SCIP_CONFTYPE;
 #[doc = "< no presolving"]
@@ -6705,7 +5519,7 @@ pub const SCIP_ConflictPresolStrat_SCIP_CONFPRES_ONLYGLOBAL: SCIP_ConflictPresol
 #[doc = "< keep variables contributing with its global bound and add a few\n   variables contributing with its local bound such that the\n   constraint is not globally redundant"]
 pub const SCIP_ConflictPresolStrat_SCIP_CONFPRES_BOTH: SCIP_ConflictPresolStrat = 3;
 #[doc = " dualray presolving strategy"]
-pub type SCIP_ConflictPresolStrat = ::std::os::raw::c_uint;
+pub type SCIP_ConflictPresolStrat = ::std::os::raw::c_int;
 #[doc = " dualray presolving strategy"]
 pub use self::SCIP_ConflictPresolStrat as SCIP_CONFPRES;
 #[doc = "< solution describes original variables; non-cached elements are zero"]
@@ -6725,7 +5539,7 @@ pub const SCIP_SolOrigin_SCIP_SOLORIGIN_PARTIAL: SCIP_SolOrigin = 6;
 #[doc = "< all non-cached elements in solution are unknown; they have to be treated\n   as being an arbitrary value in the variable's bounds"]
 pub const SCIP_SolOrigin_SCIP_SOLORIGIN_UNKNOWN: SCIP_SolOrigin = 7;
 #[doc = " origin of solution: where to retrieve uncached elements"]
-pub type SCIP_SolOrigin = ::std::os::raw::c_uint;
+pub type SCIP_SolOrigin = ::std::os::raw::c_int;
 #[doc = " origin of solution: where to retrieve uncached elements"]
 pub use self::SCIP_SolOrigin as SCIP_SOLORIGIN;
 #[repr(C)]
@@ -6753,7 +5567,7 @@ pub const SCIP_SolType_SCIP_SOLTYPE_STRONGBRANCH: SCIP_SolType = 4;
 #[doc = "< solution originates from a pseudo solution"]
 pub const SCIP_SolType_SCIP_SOLTYPE_PSEUDO: SCIP_SolType = 5;
 #[doc = " type of solution: heuristic or (LP) relaxation solution, or unspecified origin"]
-pub type SCIP_SolType = ::std::os::raw::c_uint;
+pub type SCIP_SolType = ::std::os::raw::c_int;
 #[doc = " type of solution: heuristic or (LP) relaxation solution, or unspecified origin"]
 pub use self::SCIP_SolType as SCIP_SOLTYPE;
 #[repr(C)]
@@ -6772,7 +5586,7 @@ pub const SCIP_DiveContext_SCIP_DIVECONTEXT_ADAPTIVE: SCIP_DiveContext = 2;
 #[doc = "< within the scheduler heuristic"]
 pub const SCIP_DiveContext_SCIP_DIVECONTEXT_SCHEDULER: SCIP_DiveContext = 3;
 #[doc = " context for diving statistics"]
-pub type SCIP_DiveContext = ::std::os::raw::c_uint;
+pub type SCIP_DiveContext = ::std::os::raw::c_int;
 #[doc = " context for diving statistics"]
 pub use self::SCIP_DiveContext as SCIP_DIVECONTEXT;
 #[repr(C)]
@@ -6876,7 +5690,7 @@ pub const SCIP_LinConstype_SCIP_LINCONSTYPE_MIXEDBINARY: SCIP_LinConstype = 15;
 #[doc = "< general linear constraints with no special structure"]
 pub const SCIP_LinConstype_SCIP_LINCONSTYPE_GENERAL: SCIP_LinConstype = 16;
 #[doc = " linear constraint types recognizable"]
-pub type SCIP_LinConstype = ::std::os::raw::c_uint;
+pub type SCIP_LinConstype = ::std::os::raw::c_int;
 #[doc = " linear constraint types recognizable"]
 pub use self::SCIP_LinConstype as SCIP_LINCONSTYPE;
 #[doc = "< a SCIP_Bool value"]
@@ -6898,7 +5712,7 @@ pub const SCIP_Datatree_Valuetype_SCIP_DATATREE_STRINGARRAY: SCIP_Datatree_Value
 #[doc = "< a SCIP_DATATREE object"]
 pub const SCIP_Datatree_Valuetype_SCIP_DATATREE_DATATREE: SCIP_Datatree_Valuetype = 8;
 #[doc = " type of values stored in a SCIP_DATATREE"]
-pub type SCIP_Datatree_Valuetype = ::std::os::raw::c_uint;
+pub type SCIP_Datatree_Valuetype = ::std::os::raw::c_int;
 #[doc = " type of values stored in a SCIP_DATATREE"]
 pub use self::SCIP_Datatree_Valuetype as SCIP_DATATREE_VALUETYPE;
 #[repr(C)]
@@ -6939,7 +5753,7 @@ pub const SCIP_DispStatus_SCIP_DISPSTATUS_AUTO: SCIP_DispStatus = 1;
 #[doc = "< display column is displayed"]
 pub const SCIP_DispStatus_SCIP_DISPSTATUS_ON: SCIP_DispStatus = 2;
 #[doc = " display activation status of display column"]
-pub type SCIP_DispStatus = ::std::os::raw::c_uint;
+pub type SCIP_DispStatus = ::std::os::raw::c_int;
 #[doc = " display activation status of display column"]
 pub use self::SCIP_DispStatus as SCIP_DISPSTATUS;
 #[doc = "< display column is displayed only in sequential mode"]
@@ -6949,7 +5763,7 @@ pub const SCIP_DispMode_SCIP_DISPMODE_CONCURRENT: SCIP_DispMode = 2;
 #[doc = "< display column is displayed in concurrent and sequential mode"]
 pub const SCIP_DispMode_SCIP_DISPMODE_ALL: SCIP_DispMode = 3;
 #[doc = " display activation status of display column"]
-pub type SCIP_DispMode = ::std::os::raw::c_uint;
+pub type SCIP_DispMode = ::std::os::raw::c_int;
 #[doc = " display activation status of display column"]
 pub use self::SCIP_DispMode as SCIP_DISPMODE;
 #[repr(C)]
@@ -6985,7 +5799,7 @@ pub const SCIP_IsFpRepresentable_SCIP_ISFPREPRESENTABLE_TRUE: SCIP_IsFpRepresent
 #[doc = "< is not representable"]
 pub const SCIP_IsFpRepresentable_SCIP_ISFPREPRESENTABLE_FALSE: SCIP_IsFpRepresentable = 2;
 #[doc = " information if a rational is exactly representable as a floating point number"]
-pub type SCIP_IsFpRepresentable = ::std::os::raw::c_uint;
+pub type SCIP_IsFpRepresentable = ::std::os::raw::c_int;
 #[doc = " information if a rational is exactly representable as a floating point number"]
 pub use self::SCIP_IsFpRepresentable as SCIP_ISFPREPRESENTABLE;
 #[doc = "< always round to nearest smaller double"]
@@ -6995,7 +5809,7 @@ pub const SCIP_RoundModeRational_SCIP_R_ROUND_UPWARDS: SCIP_RoundModeRational = 
 #[doc = "< always round to nearest double"]
 pub const SCIP_RoundModeRational_SCIP_R_ROUND_NEAREST: SCIP_RoundModeRational = 2;
 #[doc = " defines the possible rounding direction for a rational number, when converting to a double"]
-pub type SCIP_RoundModeRational = ::std::os::raw::c_uint;
+pub type SCIP_RoundModeRational = ::std::os::raw::c_int;
 #[doc = " defines the possible rounding direction for a rational number, when converting to a double"]
 pub use self::SCIP_RoundModeRational as SCIP_ROUNDMODE_RAT;
 #[doc = " interval given by infimum and supremum"]
@@ -7593,7 +6407,7 @@ pub const SCIP_EXPRCURV_SCIP_EXPRCURV_CONCAVE: SCIP_EXPRCURV = 2;
 #[doc = "< linear = convex and concave"]
 pub const SCIP_EXPRCURV_SCIP_EXPRCURV_LINEAR: SCIP_EXPRCURV = 3;
 #[doc = " curvature types"]
-pub type SCIP_EXPRCURV = ::std::os::raw::c_uint;
+pub type SCIP_EXPRCURV = ::std::os::raw::c_int;
 #[doc = "< unknown or non-monotone"]
 pub const SCIP_MONOTONE_SCIP_MONOTONE_UNKNOWN: SCIP_MONOTONE = 0;
 #[doc = "< increasing"]
@@ -7603,7 +6417,7 @@ pub const SCIP_MONOTONE_SCIP_MONOTONE_DEC: SCIP_MONOTONE = 2;
 #[doc = "< constant = increasing and decreasing"]
 pub const SCIP_MONOTONE_SCIP_MONOTONE_CONST: SCIP_MONOTONE = 3;
 #[doc = " monotonicity"]
-pub type SCIP_MONOTONE = ::std::os::raw::c_uint;
+pub type SCIP_MONOTONE = ::std::os::raw::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SCIP_Expr_OwnerData {
@@ -7664,7 +6478,7 @@ pub const SCIP_EXPRITER_TYPE_SCIP_EXPRITER_BFS: SCIP_EXPRITER_TYPE = 1;
 #[doc = "< depth-first search"]
 pub const SCIP_EXPRITER_TYPE_SCIP_EXPRITER_DFS: SCIP_EXPRITER_TYPE = 2;
 #[doc = " mode for expression iterator"]
-pub type SCIP_EXPRITER_TYPE = ::std::os::raw::c_uint;
+pub type SCIP_EXPRITER_TYPE = ::std::os::raw::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct SCIP_ExprIterData {
@@ -7705,7 +6519,7 @@ pub const SCIP_BranchDir_SCIP_BRANCHDIR_FIXED: SCIP_BranchDir = 2;
 #[doc = "< automatic setting for choosing bound changes"]
 pub const SCIP_BranchDir_SCIP_BRANCHDIR_AUTO: SCIP_BranchDir = 3;
 #[doc = " branching direction for branching on variables"]
-pub type SCIP_BranchDir = ::std::os::raw::c_uint;
+pub type SCIP_BranchDir = ::std::os::raw::c_int;
 #[doc = " branching direction for branching on variables"]
 pub use self::SCIP_BranchDir as SCIP_BRANCHDIR;
 #[repr(C)]
@@ -7863,7 +6677,7 @@ pub const SCIP_ReoptType_SCIP_REOPTTYPE_LEAF: SCIP_ReoptType = 5;
 pub const SCIP_ReoptType_SCIP_REOPTTYPE_PRUNED: SCIP_ReoptType = 6;
 #[doc = "< node is a leaf node and has an integral optimal LP solution"]
 pub const SCIP_ReoptType_SCIP_REOPTTYPE_FEASIBLE: SCIP_ReoptType = 7;
-pub type SCIP_ReoptType = ::std::os::raw::c_uint;
+pub type SCIP_ReoptType = ::std::os::raw::c_int;
 pub use self::SCIP_ReoptType as SCIP_REOPTTYPE;
 #[doc = "< constraint cutoffs an LP infeasible subtree"]
 pub const Reopt_ConsType_REOPT_CONSTYPE_INFSUBTREE: Reopt_ConsType = 0;
@@ -7873,7 +6687,7 @@ pub const Reopt_ConsType_REOPT_CONSTYPE_DUALREDS: Reopt_ConsType = 1;
 pub const Reopt_ConsType_REOPT_CONSTYPE_CUT: Reopt_ConsType = 2;
 #[doc = "< constraint was added by SCIP, e.g., a (local) conflict"]
 pub const Reopt_ConsType_REOPT_CONSTYPE_UNKNOWN: Reopt_ConsType = 3;
-pub type Reopt_ConsType = ::std::os::raw::c_uint;
+pub type Reopt_ConsType = ::std::os::raw::c_int;
 pub use self::Reopt_ConsType as REOPT_CONSTYPE;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -7948,7 +6762,7 @@ pub const SCIP_NlpParam_FastFail_SCIP_NLPPARAM_FASTFAIL_CONSERVATIVE: SCIP_NlpPa
 #[doc = "< stop if convergence rate is low"]
 pub const SCIP_NlpParam_FastFail_SCIP_NLPPARAM_FASTFAIL_AGGRESSIVE: SCIP_NlpParam_FastFail = 2;
 #[doc = " NLP solver fast-fail levels"]
-pub type SCIP_NlpParam_FastFail = ::std::os::raw::c_uint;
+pub type SCIP_NlpParam_FastFail = ::std::os::raw::c_int;
 #[doc = " NLP solver fast-fail levels"]
 pub use self::SCIP_NlpParam_FastFail as SCIP_NLPPARAM_FASTFAIL;
 #[doc = " parameters for NLP solve"]
@@ -8022,7 +6836,7 @@ pub const SCIP_NlpSolStat_SCIP_NLPSOLSTAT_UNBOUNDED: SCIP_NlpSolStat = 5;
 #[doc = "< unknown solution status (e.g., problem not solved yet)"]
 pub const SCIP_NlpSolStat_SCIP_NLPSOLSTAT_UNKNOWN: SCIP_NlpSolStat = 6;
 #[doc = " NLP solution status"]
-pub type SCIP_NlpSolStat = ::std::os::raw::c_uint;
+pub type SCIP_NlpSolStat = ::std::os::raw::c_int;
 #[doc = " NLP solution status"]
 pub use self::SCIP_NlpSolStat as SCIP_NLPSOLSTAT;
 #[doc = "< terminated successfully"]
@@ -8046,7 +6860,7 @@ pub const SCIP_NlpTermStat_SCIP_NLPTERMSTAT_LICENSEERROR: SCIP_NlpTermStat = 8;
 #[doc = "< other error (= this should never happen)"]
 pub const SCIP_NlpTermStat_SCIP_NLPTERMSTAT_OTHER: SCIP_NlpTermStat = 9;
 #[doc = " NLP solver termination status"]
-pub type SCIP_NlpTermStat = ::std::os::raw::c_uint;
+pub type SCIP_NlpTermStat = ::std::os::raw::c_int;
 #[doc = " NLP solver termination status"]
 pub use self::SCIP_NlpTermStat as SCIP_NLPTERMSTAT;
 #[doc = " Statistics from an NLP solve"]
@@ -8118,7 +6932,7 @@ pub const SCIP_Status_SCIP_STATUS_BESTSOLLIMIT: SCIP_Status = 29;
 #[doc = "< the solving process was interrupted because the restart limit was reached"]
 pub const SCIP_Status_SCIP_STATUS_RESTARTLIMIT: SCIP_Status = 30;
 #[doc = " SCIP solving status"]
-pub type SCIP_Status = ::std::os::raw::c_uint;
+pub type SCIP_Status = ::std::os::raw::c_int;
 #[doc = " SCIP solving status"]
 pub use self::SCIP_Status as SCIP_STATUS;
 #[repr(C)]
@@ -8130,7 +6944,7 @@ pub type SCIP_STAT = SCIP_Stat;
 pub const SCIP_Parallelmode_SCIP_PARA_OPPORTUNISTIC: SCIP_Parallelmode = 0;
 pub const SCIP_Parallelmode_SCIP_PARA_DETERMINISTIC: SCIP_Parallelmode = 1;
 #[doc = " The parallel mode"]
-pub type SCIP_Parallelmode = ::std::os::raw::c_uint;
+pub type SCIP_Parallelmode = ::std::os::raw::c_int;
 #[doc = " The parallel mode"]
 pub use self::SCIP_Parallelmode as SCIP_PARALLELMODE;
 #[repr(C)]
@@ -8183,7 +6997,7 @@ pub const SCIP_BendersEnfoType_SCIP_BENDERSENFOTYPE_RELAX: SCIP_BendersEnfoType 
 pub const SCIP_BendersEnfoType_SCIP_BENDERSENFOTYPE_PSEUDO: SCIP_BendersEnfoType = 3;
 #[doc = "< the Benders' subproblems are solved during the checking of a solution for feasibility"]
 pub const SCIP_BendersEnfoType_SCIP_BENDERSENFOTYPE_CHECK: SCIP_BendersEnfoType = 4;
-pub type SCIP_BendersEnfoType = ::std::os::raw::c_uint;
+pub type SCIP_BendersEnfoType = ::std::os::raw::c_int;
 pub use self::SCIP_BendersEnfoType as SCIP_BENDERSENFOTYPE;
 #[doc = "< the relaxation is solved in this iteration of the loop"]
 pub const SCIP_BendersSolveLoop_SCIP_BENDERSSOLVELOOP_CONVEX: SCIP_BendersSolveLoop = 0;
@@ -8193,7 +7007,7 @@ pub const SCIP_BendersSolveLoop_SCIP_BENDERSSOLVELOOP_CIP: SCIP_BendersSolveLoop
 pub const SCIP_BendersSolveLoop_SCIP_BENDERSSOLVELOOP_USERCONVEX: SCIP_BendersSolveLoop = 2;
 #[doc = "< the user defined solve function is called"]
 pub const SCIP_BendersSolveLoop_SCIP_BENDERSSOLVELOOP_USERCIP: SCIP_BendersSolveLoop = 3;
-pub type SCIP_BendersSolveLoop = ::std::os::raw::c_uint;
+pub type SCIP_BendersSolveLoop = ::std::os::raw::c_int;
 pub use self::SCIP_BendersSolveLoop as SCIP_BENDERSSOLVELOOP;
 #[doc = "< the subsystem status is unknown"]
 pub const SCIP_BendersSubStatus_SCIP_BENDERSSUBSTATUS_UNKNOWN: SCIP_BendersSubStatus = 0;
@@ -8203,7 +7017,7 @@ pub const SCIP_BendersSubStatus_SCIP_BENDERSSUBSTATUS_OPTIMAL: SCIP_BendersSubSt
 pub const SCIP_BendersSubStatus_SCIP_BENDERSSUBSTATUS_AUXVIOL: SCIP_BendersSubStatus = 2;
 #[doc = "< the subproblem is solved to be infeasible"]
 pub const SCIP_BendersSubStatus_SCIP_BENDERSSUBSTATUS_INFEAS: SCIP_BendersSubStatus = 3;
-pub type SCIP_BendersSubStatus = ::std::os::raw::c_uint;
+pub type SCIP_BendersSubStatus = ::std::os::raw::c_int;
 pub use self::SCIP_BendersSubStatus as SCIP_BENDERSSUBSTATUS;
 #[doc = "< the subproblem has convex constraints and continuous variables"]
 pub const SCIP_BendersSubType_SCIP_BENDERSSUBTYPE_CONVEXCONT: SCIP_BendersSubType = 0;
@@ -8215,13 +7029,13 @@ pub const SCIP_BendersSubType_SCIP_BENDERSSUBTYPE_NONCONVEXCONT: SCIP_BendersSub
 pub const SCIP_BendersSubType_SCIP_BENDERSSUBTYPE_NONCONVEXDIS: SCIP_BendersSubType = 3;
 #[doc = "< the default type before the type is known"]
 pub const SCIP_BendersSubType_SCIP_BENDERSSUBTYPE_UNKNOWN: SCIP_BendersSubType = 4;
-pub type SCIP_BendersSubType = ::std::os::raw::c_uint;
+pub type SCIP_BendersSubType = ::std::os::raw::c_int;
 pub use self::SCIP_BendersSubType as SCIP_BENDERSSUBTYPE;
 #[doc = "< the individual subproblem objectives are summed in the master problem"]
 pub const SCIP_BendersObjectiveType_SCIP_BENDERSOBJTYPE_SUM: SCIP_BendersObjectiveType = 0;
 #[doc = "< the minimum of the maximum subproblem objectives is computed in the master problem"]
 pub const SCIP_BendersObjectiveType_SCIP_BENDERSOBJTYPE_MAX: SCIP_BendersObjectiveType = 1;
-pub type SCIP_BendersObjectiveType = ::std::os::raw::c_uint;
+pub type SCIP_BendersObjectiveType = ::std::os::raw::c_int;
 pub use self::SCIP_BendersObjectiveType as SCIP_BENDERSOBJTYPE;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -8364,12 +7178,14 @@ unsafe extern "C" {
     pub fn SCIPbanditGetNActions(bandit: *mut SCIP_BANDIT) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " compares two benderss w. r. to their priority"]
     pub fn SCIPbendersComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting benderss w.r.t. to their name"]
     pub fn SCIPbendersCompName(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -8739,12 +7555,14 @@ unsafe extern "C" {
     ) -> ::std::os::raw::c_uint;
 }
 unsafe extern "C" {
+    #[doc = " compares two Benders' decomposition cuts w. r. to their priority"]
     pub fn SCIPbenderscutComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting Benders' decomposition cuts w.r.t. to their name"]
     pub fn SCIPbenderscutCompName(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -8807,12 +7625,14 @@ unsafe extern "C" {
     );
 }
 unsafe extern "C" {
+    #[doc = " compares two branching rules w. r. to their priority"]
     pub fn SCIPbranchruleComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting branching rules w.r.t. to their name"]
     pub fn SCIPbranchruleCompName(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -8916,12 +7736,14 @@ unsafe extern "C" {
     pub fn SCIPbranchruleIsInitialized(branchrule: *mut SCIP_BRANCHRULE) -> ::std::os::raw::c_uint;
 }
 unsafe extern "C" {
+    #[doc = " compares two conflict handlers w. r. to their priority"]
     pub fn SCIPconflicthdlrComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting conflict handler w.r.t. to their name"]
     pub fn SCIPconflicthdlrCompName(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -8973,24 +7795,28 @@ unsafe extern "C" {
     pub fn SCIPconflicthdlrGetTime(conflicthdlr: *mut SCIP_CONFLICTHDLR) -> f64;
 }
 unsafe extern "C" {
+    #[doc = " compares two constraint handlers w.r.t. their separation priority"]
     pub fn SCIPconshdlrCompSepa(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " compares two constraint handlers w.r.t. their enforcing priority"]
     pub fn SCIPconshdlrCompEnfo(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " compares two constraint handlers w.r.t. their feasibility check priority"]
     pub fn SCIPconshdlrCompCheck(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " compares two constraints w.r.t. their feasibility check priority"]
     pub fn SCIPconsCompCheck(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -9972,7 +8798,7 @@ pub const SCIP_VerbLevel_SCIP_VERBLEVEL_HIGH: SCIP_VerbLevel = 4;
 #[doc = "< all messages are displayed"]
 pub const SCIP_VerbLevel_SCIP_VERBLEVEL_FULL: SCIP_VerbLevel = 5;
 #[doc = " verbosity levels of output"]
-pub type SCIP_VerbLevel = ::std::os::raw::c_uint;
+pub type SCIP_VerbLevel = ::std::os::raw::c_int;
 #[doc = " verbosity levels of output"]
 pub use self::SCIP_VerbLevel as SCIP_VERBLEVEL;
 #[repr(C)]
@@ -10566,6 +9392,7 @@ unsafe extern "C" {
     pub fn SCIPexprhdlrHasGetSymData(exprhdlr: *mut SCIP_EXPRHDLR) -> ::std::os::raw::c_uint;
 }
 unsafe extern "C" {
+    #[doc = " compares two expression handler w.r.t. their name"]
     pub fn SCIPexprhdlrComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -11028,18 +9855,21 @@ unsafe extern "C" {
     pub fn SCIPfclose(fp: *mut SCIP_FILE) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " compares two heuristics w.r.t. to their delay positions and priorities"]
     pub fn SCIPheurComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " compares two heuristics w.r.t. to their priority values"]
     pub fn SCIPheurCompPriority(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting heuristics w.r.t. to their name"]
     pub fn SCIPheurCompName(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -11336,12 +10166,14 @@ unsafe extern "C" {
     pub fn SCIPvariableGraphFree(scip: *mut SCIP, vargraph: *mut *mut SCIP_VGRAPH);
 }
 unsafe extern "C" {
+    #[doc = " compares two compressions w. r. to their priority"]
     pub fn SCIPcomprComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting compressions w.r.t. to their name"]
     pub fn SCIPcomprCompName(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -11491,6 +10323,7 @@ unsafe extern "C" {
     pub fn SCIPiisGetSubscip(iis: *mut SCIP_IIS) -> *mut SCIP;
 }
 unsafe extern "C" {
+    #[doc = " compares two IIS finders w. r. to their priority"]
     pub fn SCIPiisfinderComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -11619,7 +10452,7 @@ pub const SCIP_LPParam_SCIP_LPPAR_POLISHING: SCIP_LPParam = 18;
 #[doc = "< set refactorization interval (0 - automatic)"]
 pub const SCIP_LPParam_SCIP_LPPAR_REFACTOR: SCIP_LPParam = 19;
 #[doc = " LP solver parameters"]
-pub type SCIP_LPParam = ::std::os::raw::c_uint;
+pub type SCIP_LPParam = ::std::os::raw::c_int;
 #[doc = " LP solver parameters"]
 pub use self::SCIP_LPParam as SCIP_LPPARAM;
 #[doc = "< the SCIP/LP interface should use its preferred strategy"]
@@ -11637,7 +10470,7 @@ pub const SCIP_Pricing_SCIP_PRICING_STEEPQSTART: SCIP_Pricing = 5;
 #[doc = "< devex pricing"]
 pub const SCIP_Pricing_SCIP_PRICING_DEVEX: SCIP_Pricing = 6;
 #[doc = " LP pricing strategy"]
-pub type SCIP_Pricing = ::std::os::raw::c_uint;
+pub type SCIP_Pricing = ::std::os::raw::c_int;
 #[doc = " LP pricing strategy"]
 pub use self::SCIP_Pricing as SCIP_PRICING;
 #[doc = "< (slack) variable is at its lower bound"]
@@ -11649,7 +10482,7 @@ pub const SCIP_BaseStat_SCIP_BASESTAT_UPPER: SCIP_BaseStat = 2;
 #[doc = "< free variable is non-basic and set to zero"]
 pub const SCIP_BaseStat_SCIP_BASESTAT_ZERO: SCIP_BaseStat = 3;
 #[doc = " basis status for columns and rows"]
-pub type SCIP_BaseStat = ::std::os::raw::c_uint;
+pub type SCIP_BaseStat = ::std::os::raw::c_int;
 #[doc = " basis status for columns and rows"]
 pub use self::SCIP_BaseStat as SCIP_BASESTAT;
 #[doc = "< estimated condition number of (scaled) basis matrix (SCIP_Real)"]
@@ -11657,7 +10490,7 @@ pub const SCIP_LPSolQuality_SCIP_LPSOLQUALITY_ESTIMCONDITION: SCIP_LPSolQuality 
 #[doc = "< exact condition number of (scaled) basis matrix (SCIP_Real)"]
 pub const SCIP_LPSolQuality_SCIP_LPSOLQUALITY_EXACTCONDITION: SCIP_LPSolQuality = 1;
 #[doc = " LP solution quality quantities"]
-pub type SCIP_LPSolQuality = ::std::os::raw::c_uint;
+pub type SCIP_LPSolQuality = ::std::os::raw::c_int;
 #[doc = " LP solution quality quantities"]
 pub use self::SCIP_LPSolQuality as SCIP_LPSOLQUALITY;
 #[repr(C)]
@@ -11730,7 +10563,7 @@ pub const Ps_dualcostsel_PS_DUALCOSTSEL_NO: Ps_dualcostsel = 0;
 pub const Ps_dualcostsel_PS_DUALCOSTSEL_ACTIVE_FPLP: Ps_dualcostsel = 1;
 #[doc = "< active rows of exact lp"]
 pub const Ps_dualcostsel_PS_DUALCOSTSEL_ACTIVE_EXLP: Ps_dualcostsel = 2;
-pub type Ps_dualcostsel = ::std::os::raw::c_uint;
+pub type Ps_dualcostsel = ::std::os::raw::c_int;
 pub use self::Ps_dualcostsel as PS_DUALCOSTSEL;
 unsafe extern "C" {
     #[doc = " sorts column entries such that LP rows precede non-LP rows and inside both parts lower row indices precede higher ones"]
@@ -11837,6 +10670,7 @@ unsafe extern "C" {
     pub fn SCIPboundtypeOpposite(boundtype: SCIP_BOUNDTYPE) -> SCIP_BOUNDTYPE;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting rows by non-decreasing index"]
     pub fn SCIProwComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -12009,6 +10843,7 @@ pub struct SCIP_LPiExact {
 }
 pub type SCIP_LPIEXACT = SCIP_LPiExact;
 unsafe extern "C" {
+    #[doc = " comparison method for sorting rows by non-decreasing index"]
     pub fn SCIProwExactComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -12103,7 +10938,7 @@ pub const SCIP_Stage_SCIP_STAGE_FREETRANS: SCIP_Stage = 12;
 #[doc = "< SCIP data structures are being freed"]
 pub const SCIP_Stage_SCIP_STAGE_FREE: SCIP_Stage = 13;
 #[doc = " SCIP operation stage"]
-pub type SCIP_Stage = ::std::os::raw::c_uint;
+pub type SCIP_Stage = ::std::os::raw::c_int;
 #[doc = " SCIP operation stage"]
 pub use self::SCIP_Stage as SCIP_STAGE;
 #[doc = "< undefined setting"]
@@ -12115,7 +10950,7 @@ pub const SCIP_Setting_SCIP_AUTO: SCIP_Setting = 2;
 #[doc = "< feature is enabled"]
 pub const SCIP_Setting_SCIP_ENABLED: SCIP_Setting = 3;
 #[doc = " possible settings for enabling/disabling algorithms and other features"]
-pub type SCIP_Setting = ::std::os::raw::c_uint;
+pub type SCIP_Setting = ::std::os::raw::c_int;
 #[doc = " possible settings for enabling/disabling algorithms and other features"]
 pub use self::SCIP_Setting as SCIP_SETTING;
 #[doc = " global SCIP settings"]
@@ -12423,343 +11258,732 @@ unsafe extern "C" {
 pub type __gnuc_va_list = __builtin_va_list;
 unsafe extern "C" {
     pub fn memchr(
-        __s: *const ::std::os::raw::c_void,
-        __c: ::std::os::raw::c_int,
-        __n: ::std::os::raw::c_ulong,
+        _Buf: *const ::std::os::raw::c_void,
+        _Val: ::std::os::raw::c_int,
+        _MaxCount: ::std::os::raw::c_ulonglong,
     ) -> *mut ::std::os::raw::c_void;
 }
 unsafe extern "C" {
     pub fn memcmp(
-        __s1: *const ::std::os::raw::c_void,
-        __s2: *const ::std::os::raw::c_void,
-        __n: ::std::os::raw::c_ulong,
+        _Buf1: *const ::std::os::raw::c_void,
+        _Buf2: *const ::std::os::raw::c_void,
+        _Size: ::std::os::raw::c_ulonglong,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
     pub fn memcpy(
-        __dst: *mut ::std::os::raw::c_void,
-        __src: *const ::std::os::raw::c_void,
-        __n: ::std::os::raw::c_ulong,
+        _Dst: *mut ::std::os::raw::c_void,
+        _Src: *const ::std::os::raw::c_void,
+        _Size: ::std::os::raw::c_ulonglong,
     ) -> *mut ::std::os::raw::c_void;
 }
 unsafe extern "C" {
     pub fn memmove(
-        __dst: *mut ::std::os::raw::c_void,
-        __src: *const ::std::os::raw::c_void,
-        __len: ::std::os::raw::c_ulong,
+        _Dst: *mut ::std::os::raw::c_void,
+        _Src: *const ::std::os::raw::c_void,
+        _Size: ::std::os::raw::c_ulonglong,
     ) -> *mut ::std::os::raw::c_void;
 }
 unsafe extern "C" {
     pub fn memset(
-        __b: *mut ::std::os::raw::c_void,
-        __c: ::std::os::raw::c_int,
-        __len: ::std::os::raw::c_ulong,
+        _Dst: *mut ::std::os::raw::c_void,
+        _Val: ::std::os::raw::c_int,
+        _Size: ::std::os::raw::c_ulonglong,
     ) -> *mut ::std::os::raw::c_void;
 }
 unsafe extern "C" {
-    pub fn strcat(
-        __s1: *mut ::std::os::raw::c_char,
-        __s2: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
     pub fn strchr(
-        __s: *const ::std::os::raw::c_char,
-        __c: ::std::os::raw::c_int,
-    ) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn strcmp(
-        __s1: *const ::std::os::raw::c_char,
-        __s2: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn strcoll(
-        __s1: *const ::std::os::raw::c_char,
-        __s2: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn strcpy(
-        __dst: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn strcspn(
-        __s: *const ::std::os::raw::c_char,
-        __charset: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_ulong;
-}
-unsafe extern "C" {
-    pub fn strerror(__errnum: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn strlen(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_ulong;
-}
-unsafe extern "C" {
-    pub fn strncat(
-        __s1: *mut ::std::os::raw::c_char,
-        __s2: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn strncmp(
-        __s1: *const ::std::os::raw::c_char,
-        __s2: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn strncpy(
-        __dst: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn strpbrk(
-        __s: *const ::std::os::raw::c_char,
-        __charset: *const ::std::os::raw::c_char,
+        _Str: *const ::std::os::raw::c_char,
+        _Val: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     pub fn strrchr(
-        __s: *const ::std::os::raw::c_char,
-        __c: ::std::os::raw::c_int,
+        _Str: *const ::std::os::raw::c_char,
+        _Ch: ::std::os::raw::c_int,
+    ) -> *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn strstr(
+        _Str: *const ::std::os::raw::c_char,
+        _SubStr: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn wcschr(
+        _Str: *const ::std::os::raw::c_ushort,
+        _Ch: ::std::os::raw::c_ushort,
+    ) -> *mut ::std::os::raw::c_ushort;
+}
+unsafe extern "C" {
+    pub fn wcsrchr(_Str: *const wchar_t, _Ch: wchar_t) -> *mut wchar_t;
+}
+unsafe extern "C" {
+    pub fn wcsstr(_Str: *const wchar_t, _SubStr: *const wchar_t) -> *mut wchar_t;
+}
+unsafe extern "C" {
+    pub fn _memicmp(
+        _Buf1: *const ::std::os::raw::c_void,
+        _Buf2: *const ::std::os::raw::c_void,
+        _Size: usize,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _memicmp_l(
+        _Buf1: *const ::std::os::raw::c_void,
+        _Buf2: *const ::std::os::raw::c_void,
+        _Size: usize,
+        _Locale: _locale_t,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn memccpy(
+        _Dst: *mut ::std::os::raw::c_void,
+        _Src: *const ::std::os::raw::c_void,
+        _Val: ::std::os::raw::c_int,
+        _Size: ::std::os::raw::c_ulonglong,
+    ) -> *mut ::std::os::raw::c_void;
+}
+unsafe extern "C" {
+    pub fn memicmp(
+        _Buf1: *const ::std::os::raw::c_void,
+        _Buf2: *const ::std::os::raw::c_void,
+        _Size: usize,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn wcscat_s(
+        _Destination: *mut wchar_t,
+        _SizeInWords: rsize_t,
+        _Source: *const wchar_t,
+    ) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn wcscpy_s(
+        _Destination: *mut wchar_t,
+        _SizeInWords: rsize_t,
+        _Source: *const wchar_t,
+    ) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn wcsncat_s(
+        _Destination: *mut wchar_t,
+        _SizeInWords: rsize_t,
+        _Source: *const wchar_t,
+        _MaxCount: rsize_t,
+    ) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn wcsncpy_s(
+        _Destination: *mut wchar_t,
+        _SizeInWords: rsize_t,
+        _Source: *const wchar_t,
+        _MaxCount: rsize_t,
+    ) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn wcstok_s(
+        _String: *mut wchar_t,
+        _Delimiter: *const wchar_t,
+        _Context: *mut *mut wchar_t,
+    ) -> *mut wchar_t;
+}
+unsafe extern "C" {
+    pub fn _wcsdup(_String: *const wchar_t) -> *mut wchar_t;
+}
+unsafe extern "C" {
+    pub fn wcscat(_Destination: *mut wchar_t, _Source: *const wchar_t) -> *mut wchar_t;
+}
+unsafe extern "C" {
+    pub fn wcscmp(
+        _String1: *const ::std::os::raw::c_ushort,
+        _String2: *const ::std::os::raw::c_ushort,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn wcscpy(_Destination: *mut wchar_t, _Source: *const wchar_t) -> *mut wchar_t;
+}
+unsafe extern "C" {
+    pub fn wcscspn(_String: *const wchar_t, _Control: *const wchar_t) -> usize;
+}
+unsafe extern "C" {
+    pub fn wcslen(_String: *const ::std::os::raw::c_ushort) -> ::std::os::raw::c_ulonglong;
+}
+unsafe extern "C" {
+    pub fn wcsnlen(_Source: *const wchar_t, _MaxCount: usize) -> usize;
+}
+unsafe extern "C" {
+    pub fn wcsncat(
+        _Destination: *mut wchar_t,
+        _Source: *const wchar_t,
+        _Count: usize,
+    ) -> *mut wchar_t;
+}
+unsafe extern "C" {
+    pub fn wcsncmp(
+        _String1: *const ::std::os::raw::c_ushort,
+        _String2: *const ::std::os::raw::c_ushort,
+        _MaxCount: ::std::os::raw::c_ulonglong,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn wcsncpy(
+        _Destination: *mut wchar_t,
+        _Source: *const wchar_t,
+        _Count: usize,
+    ) -> *mut wchar_t;
+}
+unsafe extern "C" {
+    pub fn wcspbrk(_String: *const wchar_t, _Control: *const wchar_t) -> *mut wchar_t;
+}
+unsafe extern "C" {
+    pub fn wcsspn(_String: *const wchar_t, _Control: *const wchar_t) -> usize;
+}
+unsafe extern "C" {
+    pub fn wcstok(
+        _String: *mut wchar_t,
+        _Delimiter: *const wchar_t,
+        _Context: *mut *mut wchar_t,
+    ) -> *mut wchar_t;
+}
+unsafe extern "C" {
+    pub fn _wcserror(_ErrorNumber: ::std::os::raw::c_int) -> *mut wchar_t;
+}
+unsafe extern "C" {
+    pub fn _wcserror_s(
+        _Buffer: *mut wchar_t,
+        _SizeInWords: usize,
+        _ErrorNumber: ::std::os::raw::c_int,
+    ) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn __wcserror(_String: *const wchar_t) -> *mut wchar_t;
+}
+unsafe extern "C" {
+    pub fn __wcserror_s(
+        _Buffer: *mut wchar_t,
+        _SizeInWords: usize,
+        _ErrorMessage: *const wchar_t,
+    ) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn _wcsicmp(_String1: *const wchar_t, _String2: *const wchar_t) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _wcsicmp_l(
+        _String1: *const wchar_t,
+        _String2: *const wchar_t,
+        _Locale: _locale_t,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _wcsnicmp(
+        _String1: *const wchar_t,
+        _String2: *const wchar_t,
+        _MaxCount: usize,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _wcsnicmp_l(
+        _String1: *const wchar_t,
+        _String2: *const wchar_t,
+        _MaxCount: usize,
+        _Locale: _locale_t,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _wcsnset_s(
+        _Destination: *mut wchar_t,
+        _SizeInWords: usize,
+        _Value: wchar_t,
+        _MaxCount: usize,
+    ) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn _wcsnset(_String: *mut wchar_t, _Value: wchar_t, _MaxCount: usize) -> *mut wchar_t;
+}
+unsafe extern "C" {
+    pub fn _wcsrev(_String: *mut wchar_t) -> *mut wchar_t;
+}
+unsafe extern "C" {
+    pub fn _wcsset_s(_Destination: *mut wchar_t, _SizeInWords: usize, _Value: wchar_t) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn _wcsset(_String: *mut wchar_t, _Value: wchar_t) -> *mut wchar_t;
+}
+unsafe extern "C" {
+    pub fn _wcslwr_s(_String: *mut wchar_t, _SizeInWords: usize) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn _wcslwr(_String: *mut wchar_t) -> *mut wchar_t;
+}
+unsafe extern "C" {
+    pub fn _wcslwr_s_l(_String: *mut wchar_t, _SizeInWords: usize, _Locale: _locale_t) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn _wcslwr_l(_String: *mut wchar_t, _Locale: _locale_t) -> *mut wchar_t;
+}
+unsafe extern "C" {
+    pub fn _wcsupr_s(_String: *mut wchar_t, _Size: usize) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn _wcsupr(_String: *mut wchar_t) -> *mut wchar_t;
+}
+unsafe extern "C" {
+    pub fn _wcsupr_s_l(_String: *mut wchar_t, _Size: usize, _Locale: _locale_t) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn _wcsupr_l(_String: *mut wchar_t, _Locale: _locale_t) -> *mut wchar_t;
+}
+unsafe extern "C" {
+    pub fn wcsxfrm(_Destination: *mut wchar_t, _Source: *const wchar_t, _MaxCount: usize) -> usize;
+}
+unsafe extern "C" {
+    pub fn _wcsxfrm_l(
+        _Destination: *mut wchar_t,
+        _Source: *const wchar_t,
+        _MaxCount: usize,
+        _Locale: _locale_t,
+    ) -> usize;
+}
+unsafe extern "C" {
+    pub fn wcscoll(_String1: *const wchar_t, _String2: *const wchar_t) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _wcscoll_l(
+        _String1: *const wchar_t,
+        _String2: *const wchar_t,
+        _Locale: _locale_t,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _wcsicoll(_String1: *const wchar_t, _String2: *const wchar_t) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _wcsicoll_l(
+        _String1: *const wchar_t,
+        _String2: *const wchar_t,
+        _Locale: _locale_t,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _wcsncoll(
+        _String1: *const wchar_t,
+        _String2: *const wchar_t,
+        _MaxCount: usize,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _wcsncoll_l(
+        _String1: *const wchar_t,
+        _String2: *const wchar_t,
+        _MaxCount: usize,
+        _Locale: _locale_t,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _wcsnicoll(
+        _String1: *const wchar_t,
+        _String2: *const wchar_t,
+        _MaxCount: usize,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _wcsnicoll_l(
+        _String1: *const wchar_t,
+        _String2: *const wchar_t,
+        _MaxCount: usize,
+        _Locale: _locale_t,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn wcsdup(_String: *const wchar_t) -> *mut wchar_t;
+}
+unsafe extern "C" {
+    pub fn wcsicmp(_String1: *const wchar_t, _String2: *const wchar_t) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn wcsnicmp(
+        _String1: *const wchar_t,
+        _String2: *const wchar_t,
+        _MaxCount: usize,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn wcsnset(_String: *mut wchar_t, _Value: wchar_t, _MaxCount: usize) -> *mut wchar_t;
+}
+unsafe extern "C" {
+    pub fn wcsrev(_String: *mut wchar_t) -> *mut wchar_t;
+}
+unsafe extern "C" {
+    pub fn wcsset(_String: *mut wchar_t, _Value: wchar_t) -> *mut wchar_t;
+}
+unsafe extern "C" {
+    pub fn wcslwr(_String: *mut wchar_t) -> *mut wchar_t;
+}
+unsafe extern "C" {
+    pub fn wcsupr(_String: *mut wchar_t) -> *mut wchar_t;
+}
+unsafe extern "C" {
+    pub fn wcsicoll(_String1: *const wchar_t, _String2: *const wchar_t) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn strcpy_s(
+        _Destination: *mut ::std::os::raw::c_char,
+        _SizeInBytes: rsize_t,
+        _Source: *const ::std::os::raw::c_char,
+    ) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn strcat_s(
+        _Destination: *mut ::std::os::raw::c_char,
+        _SizeInBytes: rsize_t,
+        _Source: *const ::std::os::raw::c_char,
+    ) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn strerror_s(
+        _Buffer: *mut ::std::os::raw::c_char,
+        _SizeInBytes: usize,
+        _ErrorNumber: ::std::os::raw::c_int,
+    ) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn strncat_s(
+        _Destination: *mut ::std::os::raw::c_char,
+        _SizeInBytes: rsize_t,
+        _Source: *const ::std::os::raw::c_char,
+        _MaxCount: rsize_t,
+    ) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn strncpy_s(
+        _Destination: *mut ::std::os::raw::c_char,
+        _SizeInBytes: rsize_t,
+        _Source: *const ::std::os::raw::c_char,
+        _MaxCount: rsize_t,
+    ) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn strtok_s(
+        _String: *mut ::std::os::raw::c_char,
+        _Delimiter: *const ::std::os::raw::c_char,
+        _Context: *mut *mut ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn _memccpy(
+        _Dst: *mut ::std::os::raw::c_void,
+        _Src: *const ::std::os::raw::c_void,
+        _Val: ::std::os::raw::c_int,
+        _MaxCount: usize,
+    ) -> *mut ::std::os::raw::c_void;
+}
+unsafe extern "C" {
+    pub fn strcat(
+        _Destination: *mut ::std::os::raw::c_char,
+        _Source: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn strcmp(
+        _Str1: *const ::std::os::raw::c_char,
+        _Str2: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _strcmpi(
+        _String1: *const ::std::os::raw::c_char,
+        _String2: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn strcoll(
+        _String1: *const ::std::os::raw::c_char,
+        _String2: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _strcoll_l(
+        _String1: *const ::std::os::raw::c_char,
+        _String2: *const ::std::os::raw::c_char,
+        _Locale: _locale_t,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn strcpy(
+        _Destination: *mut ::std::os::raw::c_char,
+        _Source: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn strcspn(
+        _Str: *const ::std::os::raw::c_char,
+        _Control: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_ulonglong;
+}
+unsafe extern "C" {
+    pub fn _strdup(_Source: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn _strerror(_ErrorMessage: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn _strerror_s(
+        _Buffer: *mut ::std::os::raw::c_char,
+        _SizeInBytes: usize,
+        _ErrorMessage: *const ::std::os::raw::c_char,
+    ) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn strerror(_ErrorMessage: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn _stricmp(
+        _String1: *const ::std::os::raw::c_char,
+        _String2: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _stricoll(
+        _String1: *const ::std::os::raw::c_char,
+        _String2: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _stricoll_l(
+        _String1: *const ::std::os::raw::c_char,
+        _String2: *const ::std::os::raw::c_char,
+        _Locale: _locale_t,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _stricmp_l(
+        _String1: *const ::std::os::raw::c_char,
+        _String2: *const ::std::os::raw::c_char,
+        _Locale: _locale_t,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn strlen(_Str: *const ::std::os::raw::c_char) -> ::std::os::raw::c_ulonglong;
+}
+unsafe extern "C" {
+    pub fn _strlwr_s(_String: *mut ::std::os::raw::c_char, _Size: usize) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn _strlwr(_String: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn _strlwr_s_l(
+        _String: *mut ::std::os::raw::c_char,
+        _Size: usize,
+        _Locale: _locale_t,
+    ) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn _strlwr_l(
+        _String: *mut ::std::os::raw::c_char,
+        _Locale: _locale_t,
+    ) -> *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn strncat(
+        _Destination: *mut ::std::os::raw::c_char,
+        _Source: *const ::std::os::raw::c_char,
+        _Count: ::std::os::raw::c_ulonglong,
+    ) -> *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn strncmp(
+        _Str1: *const ::std::os::raw::c_char,
+        _Str2: *const ::std::os::raw::c_char,
+        _MaxCount: ::std::os::raw::c_ulonglong,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _strnicmp(
+        _String1: *const ::std::os::raw::c_char,
+        _String2: *const ::std::os::raw::c_char,
+        _MaxCount: usize,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _strnicmp_l(
+        _String1: *const ::std::os::raw::c_char,
+        _String2: *const ::std::os::raw::c_char,
+        _MaxCount: usize,
+        _Locale: _locale_t,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _strnicoll(
+        _String1: *const ::std::os::raw::c_char,
+        _String2: *const ::std::os::raw::c_char,
+        _MaxCount: usize,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _strnicoll_l(
+        _String1: *const ::std::os::raw::c_char,
+        _String2: *const ::std::os::raw::c_char,
+        _MaxCount: usize,
+        _Locale: _locale_t,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _strncoll(
+        _String1: *const ::std::os::raw::c_char,
+        _String2: *const ::std::os::raw::c_char,
+        _MaxCount: usize,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn _strncoll_l(
+        _String1: *const ::std::os::raw::c_char,
+        _String2: *const ::std::os::raw::c_char,
+        _MaxCount: usize,
+        _Locale: _locale_t,
+    ) -> ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    pub fn __strncnt(_String: *const ::std::os::raw::c_char, _Count: usize) -> usize;
+}
+unsafe extern "C" {
+    pub fn strncpy(
+        _Destination: *mut ::std::os::raw::c_char,
+        _Source: *const ::std::os::raw::c_char,
+        _Count: ::std::os::raw::c_ulonglong,
+    ) -> *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn strnlen(_String: *const ::std::os::raw::c_char, _MaxCount: usize) -> usize;
+}
+unsafe extern "C" {
+    pub fn _strnset_s(
+        _String: *mut ::std::os::raw::c_char,
+        _SizeInBytes: usize,
+        _Value: ::std::os::raw::c_int,
+        _MaxCount: usize,
+    ) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn _strnset(
+        _Destination: *mut ::std::os::raw::c_char,
+        _Value: ::std::os::raw::c_int,
+        _Count: usize,
+    ) -> *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn strpbrk(
+        _Str: *const ::std::os::raw::c_char,
+        _Control: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn _strrev(_Str: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn _strset_s(
+        _Destination: *mut ::std::os::raw::c_char,
+        _DestinationSize: usize,
+        _Value: ::std::os::raw::c_int,
+    ) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn _strset(
+        _Destination: *mut ::std::os::raw::c_char,
+        _Value: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     pub fn strspn(
-        __s: *const ::std::os::raw::c_char,
-        __charset: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_ulong;
-}
-unsafe extern "C" {
-    pub fn strstr(
-        __big: *const ::std::os::raw::c_char,
-        __little: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
+        _Str: *const ::std::os::raw::c_char,
+        _Control: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_ulonglong;
 }
 unsafe extern "C" {
     pub fn strtok(
-        __str: *mut ::std::os::raw::c_char,
-        __sep: *const ::std::os::raw::c_char,
+        _String: *mut ::std::os::raw::c_char,
+        _Delimiter: *const ::std::os::raw::c_char,
+    ) -> *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn _strupr_s(_String: *mut ::std::os::raw::c_char, _Size: usize) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn _strupr(_String: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn _strupr_s_l(
+        _String: *mut ::std::os::raw::c_char,
+        _Size: usize,
+        _Locale: _locale_t,
+    ) -> errno_t;
+}
+unsafe extern "C" {
+    pub fn _strupr_l(
+        _String: *mut ::std::os::raw::c_char,
+        _Locale: _locale_t,
     ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     pub fn strxfrm(
-        __s1: *mut ::std::os::raw::c_char,
-        __s2: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_ulong;
+        _Destination: *mut ::std::os::raw::c_char,
+        _Source: *const ::std::os::raw::c_char,
+        _MaxCount: ::std::os::raw::c_ulonglong,
+    ) -> ::std::os::raw::c_ulonglong;
 }
 unsafe extern "C" {
-    pub fn strtok_r(
-        __str: *mut ::std::os::raw::c_char,
-        __sep: *const ::std::os::raw::c_char,
-        __lasts: *mut *mut ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
+    pub fn _strxfrm_l(
+        _Destination: *mut ::std::os::raw::c_char,
+        _Source: *const ::std::os::raw::c_char,
+        _MaxCount: usize,
+        _Locale: _locale_t,
+    ) -> usize;
 }
 unsafe extern "C" {
-    pub fn strerror_r(
-        __errnum: ::std::os::raw::c_int,
-        __strerrbuf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
+    pub fn strdup(_String: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn strcmpi(
+        _String1: *const ::std::os::raw::c_char,
+        _String2: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn strdup(__s1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn memccpy(
-        __dst: *mut ::std::os::raw::c_void,
-        __src: *const ::std::os::raw::c_void,
-        __c: ::std::os::raw::c_int,
-        __n: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_void;
-}
-unsafe extern "C" {
-    pub fn stpcpy(
-        __dst: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn stpncpy(
-        __dst: *mut ::std::os::raw::c_char,
-        __src: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn strndup(
-        __s1: *const ::std::os::raw::c_char,
-        __n: ::std::os::raw::c_ulong,
-    ) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn strnlen(__s1: *const ::std::os::raw::c_char, __n: usize) -> usize;
-}
-unsafe extern "C" {
-    pub fn strsignal(__sig: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
-}
-pub type errno_t = ::std::os::raw::c_int;
-unsafe extern "C" {
-    pub fn memset_s(
-        __s: *mut ::std::os::raw::c_void,
-        __smax: rsize_t,
-        __c: ::std::os::raw::c_int,
-        __n: rsize_t,
-    ) -> errno_t;
-}
-unsafe extern "C" {
-    pub fn memmem(
-        __big: *const ::std::os::raw::c_void,
-        __big_len: usize,
-        __little: *const ::std::os::raw::c_void,
-        __little_len: usize,
-    ) -> *mut ::std::os::raw::c_void;
-}
-unsafe extern "C" {
-    pub fn memset_pattern4(
-        __b: *mut ::std::os::raw::c_void,
-        __pattern4: *const ::std::os::raw::c_void,
-        __len: usize,
-    );
-}
-unsafe extern "C" {
-    pub fn memset_pattern8(
-        __b: *mut ::std::os::raw::c_void,
-        __pattern8: *const ::std::os::raw::c_void,
-        __len: usize,
-    );
-}
-unsafe extern "C" {
-    pub fn memset_pattern16(
-        __b: *mut ::std::os::raw::c_void,
-        __pattern16: *const ::std::os::raw::c_void,
-        __len: usize,
-    );
-}
-unsafe extern "C" {
-    pub fn strcasestr(
-        __big: *const ::std::os::raw::c_char,
-        __little: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn strnstr(
-        __big: *const ::std::os::raw::c_char,
-        __little: *const ::std::os::raw::c_char,
-        __len: usize,
-    ) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn strlcat(
-        __dst: *mut ::std::os::raw::c_char,
-        __source: *const ::std::os::raw::c_char,
-        __size: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_ulong;
-}
-unsafe extern "C" {
-    pub fn strlcpy(
-        __dst: *mut ::std::os::raw::c_char,
-        __source: *const ::std::os::raw::c_char,
-        __size: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_ulong;
-}
-unsafe extern "C" {
-    pub fn strmode(__mode: ::std::os::raw::c_int, __bp: *mut ::std::os::raw::c_char);
-}
-unsafe extern "C" {
-    pub fn strsep(
-        __stringp: *mut *mut ::std::os::raw::c_char,
-        __delim: *const ::std::os::raw::c_char,
-    ) -> *mut ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    pub fn swab(
-        arg1: *const ::std::os::raw::c_void,
-        arg2: *mut ::std::os::raw::c_void,
-        arg3: isize,
-    );
-}
-unsafe extern "C" {
-    pub fn timingsafe_bcmp(
-        __b1: *const ::std::os::raw::c_void,
-        __b2: *const ::std::os::raw::c_void,
-        __len: usize,
+    pub fn stricmp(
+        _String1: *const ::std::os::raw::c_char,
+        _String2: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn strsignal_r(
-        __sig: ::std::os::raw::c_int,
-        __strsignalbuf: *mut ::std::os::raw::c_char,
-        __buflen: usize,
+    pub fn strlwr(_String: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn strnicmp(
+        _String1: *const ::std::os::raw::c_char,
+        _String2: *const ::std::os::raw::c_char,
+        _MaxCount: usize,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
-    pub fn bcmp(
-        arg1: *const ::std::os::raw::c_void,
-        arg2: *const ::std::os::raw::c_void,
-        arg3: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn bcopy(
-        arg1: *const ::std::os::raw::c_void,
-        arg2: *mut ::std::os::raw::c_void,
-        arg3: usize,
-    );
-}
-unsafe extern "C" {
-    pub fn bzero(arg1: *mut ::std::os::raw::c_void, arg2: ::std::os::raw::c_ulong);
-}
-unsafe extern "C" {
-    pub fn index(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
+    pub fn strnset(
+        _String: *mut ::std::os::raw::c_char,
+        _Value: ::std::os::raw::c_int,
+        _MaxCount: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn rindex(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: ::std::os::raw::c_int,
+    pub fn strrev(_String: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
+}
+unsafe extern "C" {
+    pub fn strset(
+        _String: *mut ::std::os::raw::c_char,
+        _Value: ::std::os::raw::c_int,
     ) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
-    pub fn ffs(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn strcasecmp(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn strncasecmp(
-        arg1: *const ::std::os::raw::c_char,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: ::std::os::raw::c_ulong,
-    ) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn ffsl(arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn ffsll(arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn fls(arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn flsl(arg1: ::std::os::raw::c_long) -> ::std::os::raw::c_int;
-}
-unsafe extern "C" {
-    pub fn flsll(arg1: ::std::os::raw::c_longlong) -> ::std::os::raw::c_int;
+    pub fn strupr(_String: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 unsafe extern "C" {
     #[doc = " Creates and captures a message handler which deals with warning, information, and dialog (interactive shell) methods.\n\n  Use SCIPsetMessagehdlr() to make SCIP aware of the created message handler.\n  @note The message handler does not handle error messages. For that see SCIPmessageSetErrorPrinting()\n  @note Creating a message handler automatically captures it."]
@@ -16230,12 +15454,14 @@ unsafe extern "C" {
     );
 }
 unsafe extern "C" {
+    #[doc = " default comparer for integers"]
     pub fn SCIPsortCompInt(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " implements argsort\n\n The data pointer is a lookup array of integers."]
     pub fn SCIPsortArgsortInt(
         dataptr: *mut ::std::os::raw::c_void,
         ind1: ::std::os::raw::c_int,
@@ -16243,6 +15469,7 @@ unsafe extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " implements argsort\n\n The data pointer is a lookup array, which are pointer arrays."]
     pub fn SCIPsortArgsortPtr(
         dataptr: *mut ::std::os::raw::c_void,
         ind1: ::std::os::raw::c_int,
@@ -21944,6 +21171,7 @@ unsafe extern "C" {
     );
 }
 unsafe extern "C" {
+    #[doc = " standard hash key comparator for string keys"]
     pub fn SCIPhashKeyEqString(
         userptr: *mut ::std::os::raw::c_void,
         key1: *mut ::std::os::raw::c_void,
@@ -21951,18 +21179,21 @@ unsafe extern "C" {
     ) -> ::std::os::raw::c_uint;
 }
 unsafe extern "C" {
+    #[doc = " standard hashing function for string keys"]
     pub fn SCIPhashKeyValString(
         userptr: *mut ::std::os::raw::c_void,
         key: *mut ::std::os::raw::c_void,
     ) -> u64;
 }
 unsafe extern "C" {
+    #[doc = " gets the element as the key"]
     pub fn SCIPhashGetKeyStandard(
         userptr: *mut ::std::os::raw::c_void,
         elem: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 unsafe extern "C" {
+    #[doc = " returns TRUE iff both keys(pointer) are equal"]
     pub fn SCIPhashKeyEqPtr(
         userptr: *mut ::std::os::raw::c_void,
         key1: *mut ::std::os::raw::c_void,
@@ -21970,6 +21201,7 @@ unsafe extern "C" {
     ) -> ::std::os::raw::c_uint;
 }
 unsafe extern "C" {
+    #[doc = " returns the hash value of the key"]
     pub fn SCIPhashKeyValPtr(
         userptr: *mut ::std::os::raw::c_void,
         key: *mut ::std::os::raw::c_void,
@@ -23082,12 +22314,14 @@ unsafe extern "C" {
     pub fn SCIPparamIsDefault(param: *mut SCIP_PARAM) -> ::std::os::raw::c_uint;
 }
 unsafe extern "C" {
+    #[doc = " compares two presolvers w. r. to their priority"]
     pub fn SCIPpresolComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting presolvers w.r.t. to their name"]
     pub fn SCIPpresolCompName(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -23186,12 +22420,14 @@ unsafe extern "C" {
     pub fn SCIPpresolGetNCalls(presol: *mut SCIP_PRESOL) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " compares two pricers w. r. to their priority"]
     pub fn SCIPpricerComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting pricers w.r.t. to their name"]
     pub fn SCIPpricerCompName(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -23282,12 +22518,14 @@ unsafe extern "C" {
     pub fn SCIPreaderCanWrite(reader: *mut SCIP_READER) -> ::std::os::raw::c_uint;
 }
 unsafe extern "C" {
+    #[doc = " compares two relaxation handlers w. r. to their priority"]
     pub fn SCIPrelaxComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting relaxators w.r.t. to their name"]
     pub fn SCIPrelaxCompName(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -23460,12 +22698,14 @@ unsafe extern "C" {
     pub fn SCIPreoptGetNTotalInfNodes(reopt: *mut SCIP_REOPT) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " compares two separators w. r. to their priority"]
     pub fn SCIPsepaComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting separators w.r.t. to their name"]
     pub fn SCIPsepaCompName(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -23664,24 +22904,28 @@ unsafe extern "C" {
     pub fn SCIPcutselGetNLocalCutsFiltered(cutsel: *mut SCIP_CUTSEL) -> ::std::os::raw::c_longlong;
 }
 unsafe extern "C" {
+    #[doc = " compares two cut selectors w. r. to their priority"]
     pub fn SCIPcutselComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " compares two propagators w. r. to their priority"]
     pub fn SCIPpropComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " compares two propagators w. r. to their presolving priority"]
     pub fn SCIPpropCompPresol(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting propagators w.r.t. to their name"]
     pub fn SCIPpropCompName(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -23940,6 +23184,7 @@ unsafe extern "C" {
     pub fn SCIPsolGetRelConsViolation(sol: *mut SCIP_SOL) -> f64;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting solution by decreasing objective value (best solution will be sorted to the end)"]
     pub fn SCIPsolComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -23978,6 +23223,7 @@ unsafe extern "C" {
     pub fn SCIPtableIsInitialized(table: *mut SCIP_TABLE) -> ::std::os::raw::c_uint;
 }
 unsafe extern "C" {
+    #[doc = " node comparator for best lower bound"]
     pub fn SCIPnodeCompLowerbound(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -24168,6 +23414,7 @@ unsafe extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting active and negated variables by non-decreasing index, active and negated\n  variables are handled as the same variables"]
     pub fn SCIPvarCompActiveAndNegated(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -24178,24 +23425,28 @@ unsafe extern "C" {
     pub fn SCIPvarCompare(var1: *mut SCIP_VAR, var2: *mut SCIP_VAR) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting variables by non-decreasing index"]
     pub fn SCIPvarComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " comparison method for sorting variables by non-decreasing objective coefficient"]
     pub fn SCIPvarCompObj(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[doc = " hash key retrieval function for variables"]
     pub fn SCIPvarGetHashkey(
         userptr: *mut ::std::os::raw::c_void,
         elem: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
 unsafe extern "C" {
+    #[doc = " returns TRUE iff the indices of both variables are equal"]
     pub fn SCIPvarIsHashkeyEq(
         userptr: *mut ::std::os::raw::c_void,
         key1: *mut ::std::os::raw::c_void,
@@ -24203,6 +23454,7 @@ unsafe extern "C" {
     ) -> ::std::os::raw::c_uint;
 }
 unsafe extern "C" {
+    #[doc = " returns the hash value of the key"]
     pub fn SCIPvarGetHashkeyVal(
         userptr: *mut ::std::os::raw::c_void,
         key: *mut ::std::os::raw::c_void,
@@ -25937,7 +25189,9 @@ pub struct SCIP_AggrRow {
     pub slacksign: *mut ::std::os::raw::c_int,
     #[doc = "< weights of rows that have been added to the cutrow"]
     pub rowweights: *mut f64,
+    #[doc = "< right hand side of the cut row"]
     pub rhshi: f64,
+    #[doc = "< right hand side of the cut row"]
     pub rhslo: f64,
     #[doc = "< number of non-zeros in the cut row"]
     pub nnz: ::std::os::raw::c_int,
@@ -31471,6 +30725,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " calls the print callback for an expression\n\n @see SCIP_DECL_EXPRPRINT"]
     pub fn SCIPcallExprPrint(
         scip: *mut SCIP,
         expr: *mut SCIP_EXPR,
@@ -31481,6 +30736,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " calls the curvature callback for an expression\n\n @see SCIP_DECL_EXPRCURVATURE\n\n Returns unknown curvature if callback not implemented."]
     pub fn SCIPcallExprCurvature(
         scip: *mut SCIP,
         expr: *mut SCIP_EXPR,
@@ -31490,6 +30746,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " calls the monotonicity callback for an expression\n\n @see SCIP_DECL_EXPRMONOTONICITY\n\n Returns unknown monotonicity if callback not implemented."]
     pub fn SCIPcallExprMonotonicity(
         scip: *mut SCIP,
         expr: *mut SCIP_EXPR,
@@ -31518,6 +30775,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " calls the interval evaluation callback for an expression\n\n @see SCIP_DECL_EXPRINTEVAL\n\n Returns entire interval if callback not implemented."]
     pub fn SCIPcallExprInteval(
         scip: *mut SCIP,
         expr: *mut SCIP_EXPR,
@@ -31533,6 +30791,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " calls the estimate callback for an expression\n\n @see SCIP_DECL_EXPRESTIMATE\n\n Returns without success if callback not implemented."]
     pub fn SCIPcallExprEstimate(
         scip: *mut SCIP,
         expr: *mut SCIP_EXPR,
@@ -31549,6 +30808,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " calls the initial estimators callback for an expression\n\n @see SCIP_DECL_EXPRINITESTIMATES\n\n Returns no estimators if callback not implemented."]
     pub fn SCIPcallExprInitestimates(
         scip: *mut SCIP,
         expr: *mut SCIP_EXPR,
@@ -31560,6 +30820,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " calls the simplify callback for an expression\n\n @see SCIP_DECL_EXPRSIMPLIFY\n\n Returns unmodified expression if simplify callback not implemented.\n\n Does not simplify descendants (children, etc). Use SCIPsimplifyExpr() for that."]
     pub fn SCIPcallExprSimplify(
         scip: *mut SCIP,
         expr: *mut SCIP_EXPR,
@@ -31598,6 +30859,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " calls the reverse propagation callback for an expression\n\n @see SCIP_DECL_EXPRREVERSEPROP\n\n Returns unmodified `childrenbounds` if reverseprop callback not implemented."]
     pub fn SCIPcallExprReverseprop(
         scip: *mut SCIP,
         expr: *mut SCIP_EXPR,
@@ -31607,6 +30869,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " calls the symmetry information callback for an expression\n\n Returns NULL pointer if not implemented."]
     pub fn SCIPcallExprGetSymData(
         scip: *mut SCIP,
         expr: *mut SCIP_EXPR,
@@ -33122,6 +32385,7 @@ unsafe extern "C" {
     -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " compares two NLPIs w.r.t. their priority"]
     pub fn SCIPnlpiComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -33418,6 +32682,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " gets internal pointer to NLP solver\n\n Depending on the solver interface, a solver pointer may exist for every NLP problem instance.\n For this case, a NLPI problem can be passed in as well."]
     pub fn SCIPgetNlpiSolverPointer(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33425,6 +32690,7 @@ unsafe extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 unsafe extern "C" {
+    #[doc = " creates an empty problem instance"]
     pub fn SCIPcreateNlpiProblem(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33433,6 +32699,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " frees a problem instance"]
     pub fn SCIPfreeNlpiProblem(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33440,6 +32707,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " gets internal pointer to solver-internal problem instance"]
     pub fn SCIPgetNlpiProblemPointer(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33447,6 +32715,7 @@ unsafe extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 unsafe extern "C" {
+    #[doc = " add variables to nlpi"]
     pub fn SCIPaddNlpiVars(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33458,6 +32727,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " add constraints to nlpi"]
     pub fn SCIPaddNlpiConstraints(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33473,6 +32743,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " sets or overwrites objective, a minimization problem is expected"]
     pub fn SCIPsetNlpiObjective(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33485,6 +32756,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " change variable bounds"]
     pub fn SCIPchgNlpiVarBounds(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33496,6 +32768,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " change constraint sides"]
     pub fn SCIPchgNlpiConsSides(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33507,6 +32780,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " delete a set of variables"]
     pub fn SCIPdelNlpiVarSet(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33516,6 +32790,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " delete a set of constraints"]
     pub fn SCIPdelNlpiConsSet(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33525,6 +32800,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " changes or adds linear coefficients in a constraint or objective"]
     pub fn SCIPchgNlpiLinearCoefs(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33536,6 +32812,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " change the expression in the nonlinear part"]
     pub fn SCIPchgNlpiExpr(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33545,6 +32822,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " change the constant offset in the objective"]
     pub fn SCIPchgNlpiObjConstant(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33553,6 +32831,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " sets initial guess"]
     pub fn SCIPsetNlpiInitialGuess(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33564,6 +32843,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " try to solve NLP with all parameters given as SCIP_NLPPARAM struct\n\n Typical use is\n\n     SCIP_NLPPARAM nlparam = { SCIP_NLPPARAM_DEFAULT(scip); }\n     nlpparam.iterlimit = 42;\n     SCIP_CALL( SCIPsolveNlpiParam(scip, nlpi, nlpiproblem, nlpparam) );\n\n or, in \"one\" line:\n\n     SCIP_CALL( SCIPsolveNlpiParam(scip, nlpi, nlpiproblem,\n        (SCIP_NLPPARAM){ SCIP_NLPPARAM_DEFAULT(scip), .iterlimit = 42 }) );\n\n To get the latter, also \\ref SCIPsolveNlpi can be used."]
     pub fn SCIPsolveNlpiParam(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33572,6 +32852,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " gives solution status"]
     pub fn SCIPgetNlpiSolstat(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33579,6 +32860,7 @@ unsafe extern "C" {
     ) -> SCIP_NLPSOLSTAT;
 }
 unsafe extern "C" {
+    #[doc = " gives termination reason"]
     pub fn SCIPgetNlpiTermstat(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33586,6 +32868,7 @@ unsafe extern "C" {
     ) -> SCIP_NLPTERMSTAT;
 }
 unsafe extern "C" {
+    #[doc = " gives primal and dual solution\n for a ranged constraint, the dual variable is positive if the right hand side is active and negative if the left hand side is active"]
     pub fn SCIPgetNlpiSolution(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -33598,6 +32881,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " gives solve statistics"]
     pub fn SCIPgetNlpiStatistics(
         scip: *mut SCIP,
         nlpi: *mut SCIP_NLPI,
@@ -40782,6 +40066,7 @@ unsafe extern "C" {
     pub fn SCIPincludeConshdlrCountsols(scip: *mut SCIP) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the count command"]
     pub fn SCIPdialogExecCountPresolve(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -40790,6 +40075,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the count command"]
     pub fn SCIPdialogExecCount(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -40798,6 +40084,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " execution method of dialog for writing all solutions"]
     pub fn SCIPdialogExecWriteAllsolutions(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -54330,7 +53617,7 @@ pub const SYM_Symtype_SYM_SYMTYPE_PERM: SYM_Symtype = 0;
 #[doc = "< signed permutation symmetries"]
 pub const SYM_Symtype_SYM_SYMTYPE_SIGNPERM: SYM_Symtype = 1;
 #[doc = " define symmetry types detectable by SCIP"]
-pub type SYM_Symtype = ::std::os::raw::c_uint;
+pub type SYM_Symtype = ::std::os::raw::c_int;
 #[doc = " define symmetry types detectable by SCIP"]
 pub use self::SYM_Symtype as SYM_SYMTYPE;
 #[doc = "< operator node"]
@@ -54342,7 +53629,7 @@ pub const SYM_Nodetype_SYM_NODETYPE_CONS: SYM_Nodetype = 2;
 #[doc = "< variable node"]
 pub const SYM_Nodetype_SYM_NODETYPE_VAR: SYM_Nodetype = 3;
 #[doc = " define type of nodes in symmetry detection expression trees"]
-pub type SYM_Nodetype = ::std::os::raw::c_uint;
+pub type SYM_Nodetype = ::std::os::raw::c_int;
 #[doc = " define type of nodes in symmetry detection expression trees"]
 pub use self::SYM_Nodetype as SYM_NODETYPE;
 #[doc = "< unknown constraint type"]
@@ -54380,7 +53667,7 @@ pub const SYM_Consoptype_SYM_CONSOPTYPE_XORINT: SYM_Consoptype = 15;
 #[doc = "< number of predefined enum types, needs to always\n   hold the biggest value"]
 pub const SYM_Consoptype_SYM_CONSOPTYPE_LAST: SYM_Consoptype = 16;
 #[doc = " define type of simple constraints/operators in symmetry detection"]
-pub type SYM_Consoptype = ::std::os::raw::c_uint;
+pub type SYM_Consoptype = ::std::os::raw::c_int;
 #[doc = " define type of simple constraints/operators in symmetry detection"]
 pub use self::SYM_Consoptype as SYM_CONSOPTYPE;
 pub type SYM_HANDLETYPE = u32;
@@ -54391,7 +53678,7 @@ pub const SCIP_LeaderRule_SCIP_LEADERRULE_LASTINORBIT: SCIP_LeaderRule = 1;
 #[doc = "< var with most conflicting vars in its orbit"]
 pub const SCIP_LeaderRule_SCIP_LEADERRULE_MAXCONFLICTSINORBIT: SCIP_LeaderRule = 2;
 #[doc = " selection rules for leaders in SST cuts"]
-pub type SCIP_LeaderRule = ::std::os::raw::c_uint;
+pub type SCIP_LeaderRule = ::std::os::raw::c_int;
 #[doc = " selection rules for leaders in SST cuts"]
 pub use self::SCIP_LeaderRule as SCIP_LEADERRULE;
 #[doc = "< orbit of minimum size"]
@@ -54402,7 +53689,7 @@ pub const SCIP_LeaderTiebreakRule_SCIP_LEADERTIEBREAKRULE_MAXORBIT: SCIP_LeaderT
 pub const SCIP_LeaderTiebreakRule_SCIP_LEADERTIEBREAKRULE_MAXCONFLICTSINORBIT:
     SCIP_LeaderTiebreakRule = 2;
 #[doc = " tie breaks for leader rule based on the leader's orbit"]
-pub type SCIP_LeaderTiebreakRule = ::std::os::raw::c_uint;
+pub type SCIP_LeaderTiebreakRule = ::std::os::raw::c_int;
 #[doc = "< binary variables"]
 pub const SCIP_SSTType_SCIP_SSTTYPE_BINARY: SCIP_SSTType = 1;
 #[doc = "< integer variables"]
@@ -54410,7 +53697,7 @@ pub const SCIP_SSTType_SCIP_SSTTYPE_INTEGER: SCIP_SSTType = 2;
 #[doc = "< continuous variables"]
 pub const SCIP_SSTType_SCIP_SSTTYPE_CONTINUOUS: SCIP_SSTType = 4;
 #[doc = " variable types for leader in Schreier Sims cuts"]
-pub type SCIP_SSTType = ::std::os::raw::c_uint;
+pub type SCIP_SSTType = ::std::os::raw::c_int;
 #[doc = " variable types for leader in Schreier Sims cuts"]
 pub use self::SCIP_SSTType as SCIP_SSTTYPE;
 #[doc = "< constraint is a full orbitope constraint:         rowsum(x) unrestricted"]
@@ -54420,7 +53707,7 @@ pub const SCIP_OrbitopeType_SCIP_ORBITOPETYPE_PARTITIONING: SCIP_OrbitopeType = 
 #[doc = "< constraint is a packing orbitope constraint:      rowsum(x) <= 1"]
 pub const SCIP_OrbitopeType_SCIP_ORBITOPETYPE_PACKING: SCIP_OrbitopeType = 2;
 #[doc = " type of orbitope constraint: full, packing, or partitioning orbitope"]
-pub type SCIP_OrbitopeType = ::std::os::raw::c_uint;
+pub type SCIP_OrbitopeType = ::std::os::raw::c_int;
 #[doc = " type of orbitope constraint: full, packing, or partitioning orbitope"]
 pub use self::SCIP_OrbitopeType as SCIP_ORBITOPETYPE;
 unsafe extern "C" {
@@ -54660,7 +53947,7 @@ pub const SCIP_SetppcType_SCIP_SETPPCTYPE_PACKING: SCIP_SetppcType = 1;
 #[doc = "< constraint is a set covering constraint:     sum(x) >= 1"]
 pub const SCIP_SetppcType_SCIP_SETPPCTYPE_COVERING: SCIP_SetppcType = 2;
 #[doc = " type of setppc constraint: set partitioning, set packing, or set covering"]
-pub type SCIP_SetppcType = ::std::os::raw::c_uint;
+pub type SCIP_SetppcType = ::std::os::raw::c_int;
 #[doc = " type of setppc constraint: set partitioning, set packing, or set covering"]
 pub use self::SCIP_SetppcType as SCIP_SETPPCTYPE;
 unsafe extern "C" {
@@ -55019,6 +54306,7 @@ unsafe extern "C" {
     pub fn SCIPgetSlackConsSuperindicator(cons: *mut SCIP_CONS) -> *mut SCIP_CONS;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the SCIPtransformMinUC() command"]
     pub fn SCIPdialogExecChangeMinUC(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55241,6 +54529,7 @@ unsafe extern "C" {
     pub fn SCIPincludeDispDefault(scip: *mut SCIP) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " standard menu dialog execution method, that displays it's help screen if the remaining command line is empty"]
     pub fn SCIPdialogExecMenu(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55249,6 +54538,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " standard menu dialog execution method, that doesn't display it's help screen"]
     pub fn SCIPdialogExecMenuLazy(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55257,6 +54547,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the change add constraint"]
     pub fn SCIPdialogExecChangeAddCons(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55265,6 +54556,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the change bounds command"]
     pub fn SCIPdialogExecChangeBounds(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55273,6 +54565,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the freetransproblem command"]
     pub fn SCIPdialogExecChangeFreetransproblem(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55281,6 +54574,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the changing the objective sense"]
     pub fn SCIPdialogExecChangeObjSense(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55289,6 +54583,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the checksol command"]
     pub fn SCIPdialogExecChecksol(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55297,6 +54592,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the cliquegraph command"]
     pub fn SCIPdialogExecCliquegraph(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55305,6 +54601,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display benders command"]
     pub fn SCIPdialogExecDisplayBenders(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55313,6 +54610,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display branching command"]
     pub fn SCIPdialogExecDisplayBranching(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55321,6 +54619,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display compression command"]
     pub fn SCIPdialogExecDisplayCompression(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55329,6 +54628,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display conflict command"]
     pub fn SCIPdialogExecDisplayConflict(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55337,6 +54637,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display conshdlrs command"]
     pub fn SCIPdialogExecDisplayConshdlrs(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55345,6 +54646,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display displaycols command"]
     pub fn SCIPdialogExecDisplayDisplaycols(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55353,6 +54655,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display exprhdlrs command"]
     pub fn SCIPdialogExecDisplayExprhdlrs(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55361,6 +54664,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display cutselectors command"]
     pub fn SCIPdialogExecDisplayCutselectors(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55369,6 +54673,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display heuristics command"]
     pub fn SCIPdialogExecDisplayHeuristics(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55377,6 +54682,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display IIS command"]
     pub fn SCIPdialogExecDisplayIIS(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55385,6 +54691,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display memory command"]
     pub fn SCIPdialogExecDisplayMemory(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55393,6 +54700,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display nodeselectors command"]
     pub fn SCIPdialogExecDisplayNodeselectors(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55401,6 +54709,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display nlpi command"]
     pub fn SCIPdialogExecDisplayNlpi(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55409,6 +54718,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display parameters command"]
     pub fn SCIPdialogExecDisplayParameters(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55417,6 +54727,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display presolvers command"]
     pub fn SCIPdialogExecDisplayPresolvers(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55425,6 +54736,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display pricer command"]
     pub fn SCIPdialogExecDisplayPricers(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55433,6 +54745,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display problem command"]
     pub fn SCIPdialogExecDisplayProblem(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55441,6 +54754,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display propagators command"]
     pub fn SCIPdialogExecDisplayPropagators(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55449,6 +54763,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display readers command"]
     pub fn SCIPdialogExecDisplayReaders(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55457,6 +54772,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display relaxators command"]
     pub fn SCIPdialogExecDisplayRelaxators(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55465,6 +54781,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display separators command"]
     pub fn SCIPdialogExecDisplaySeparators(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55473,6 +54790,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display solution command"]
     pub fn SCIPdialogExecDisplaySolution(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55481,6 +54799,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display finitesolution command"]
     pub fn SCIPdialogExecDisplayFiniteSolution(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55489,6 +54808,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display dual solution command"]
     pub fn SCIPdialogExecDisplayDualSolution(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55497,6 +54817,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display of solutions in the pool command"]
     pub fn SCIPdialogExecDisplaySolutionPool(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55505,6 +54826,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display subproblem command"]
     pub fn SCIPdialogExecDisplaySubproblem(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55513,6 +54835,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display subsolution command"]
     pub fn SCIPdialogExecDisplaySubSolution(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55521,6 +54844,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display statistics command"]
     pub fn SCIPdialogExecDisplayStatistics(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55529,6 +54853,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display symmetry command"]
     pub fn SCIPdialogExecDisplaySymmetry(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55537,6 +54862,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display reoptstatistics command"]
     pub fn SCIPdialogExecDisplayReoptStatistics(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55545,6 +54871,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display transproblem command"]
     pub fn SCIPdialogExecDisplayTransproblem(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55553,6 +54880,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display value command"]
     pub fn SCIPdialogExecDisplayValue(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55561,6 +54889,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display varbranchstatistics command"]
     pub fn SCIPdialogExecDisplayVarbranchstatistics(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55569,6 +54898,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display LP solution quality command"]
     pub fn SCIPdialogExecDisplayLPSolutionQuality(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55577,6 +54907,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the display transsolution command"]
     pub fn SCIPdialogExecDisplayTranssolution(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55585,6 +54916,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the help command"]
     pub fn SCIPdialogExecHelp(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55593,6 +54925,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the free command"]
     pub fn SCIPdialogExecFree(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55601,6 +54934,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the newstart command"]
     pub fn SCIPdialogExecNewstart(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55609,6 +54943,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the transform command"]
     pub fn SCIPdialogExecTransform(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55617,6 +54952,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the optimize command"]
     pub fn SCIPdialogExecOptimize(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55625,6 +54961,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the parallelopt command"]
     pub fn SCIPdialogExecConcurrentOpt(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55633,6 +54970,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the presolve command"]
     pub fn SCIPdialogExecPresolve(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55641,6 +54979,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the iis command"]
     pub fn SCIPdialogExecIIS(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55649,6 +54988,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the quit command"]
     pub fn SCIPdialogExecQuit(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55657,6 +54997,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the read command"]
     pub fn SCIPdialogExecRead(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55665,6 +55006,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set default command"]
     pub fn SCIPdialogExecSetDefault(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55673,6 +55015,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set load command"]
     pub fn SCIPdialogExecSetLoad(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55681,6 +55024,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set save command"]
     pub fn SCIPdialogExecSetSave(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55689,6 +55033,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set diffsave command"]
     pub fn SCIPdialogExecSetDiffsave(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55697,6 +55042,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set parameter command"]
     pub fn SCIPdialogExecSetParam(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55705,9 +55051,11 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog description method for the set parameter command"]
     pub fn SCIPdialogDescSetParam(scip: *mut SCIP, dialog: *mut SCIP_DIALOG) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the fix parameter command"]
     pub fn SCIPdialogExecFixParam(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55716,9 +55064,11 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog description method for the fix parameter command"]
     pub fn SCIPdialogDescFixParam(scip: *mut SCIP, dialog: *mut SCIP_DIALOG) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set branching direction command"]
     pub fn SCIPdialogExecSetBranchingDirection(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55727,6 +55077,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set branching priority command"]
     pub fn SCIPdialogExecSetBranchingPriority(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55735,6 +55086,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set heuristics aggressive command"]
     pub fn SCIPdialogExecSetHeuristicsAggressive(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55743,6 +55095,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set heuristics default command"]
     pub fn SCIPdialogExecSetHeuristicsDefault(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55751,6 +55104,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set heuristics fast command"]
     pub fn SCIPdialogExecSetHeuristicsFast(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55759,6 +55113,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set heuristics off command"]
     pub fn SCIPdialogExecSetHeuristicsOff(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55767,6 +55122,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set presolving aggressive command"]
     pub fn SCIPdialogExecSetPresolvingAggressive(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55775,6 +55131,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set presolving default command"]
     pub fn SCIPdialogExecSetPresolvingDefault(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55783,6 +55140,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set presolving fast command"]
     pub fn SCIPdialogExecSetPresolvingFast(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55791,6 +55149,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set presolving off command"]
     pub fn SCIPdialogExecSetPresolvingOff(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55799,6 +55158,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set separating aggressive command"]
     pub fn SCIPdialogExecSetSeparatingAggressive(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55807,6 +55167,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set separating default command"]
     pub fn SCIPdialogExecSetSeparatingDefault(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55815,6 +55176,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set separating fast command"]
     pub fn SCIPdialogExecSetSeparatingFast(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55823,6 +55185,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set separating off command"]
     pub fn SCIPdialogExecSetSeparatingOff(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55831,6 +55194,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set emphasis counter command"]
     pub fn SCIPdialogExecSetEmphasisCounter(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55839,6 +55203,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set emphasis cpsolver command"]
     pub fn SCIPdialogExecSetEmphasisCpsolver(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55847,6 +55212,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set emphasis easy CIP command"]
     pub fn SCIPdialogExecSetEmphasisEasycip(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55855,6 +55221,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set emphasis feasibility command"]
     pub fn SCIPdialogExecSetEmphasisFeasibility(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55863,6 +55230,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set emphasis hard LP command"]
     pub fn SCIPdialogExecSetEmphasisHardlp(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55871,6 +55239,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set emphasis optimality command"]
     pub fn SCIPdialogExecSetEmphasisOptimality(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55879,6 +55248,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set emphasis numerics command"]
     pub fn SCIPdialogExecSetEmphasisNumerics(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55887,6 +55257,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set emphasis benchmark command"]
     pub fn SCIPdialogExecSetEmphasisBenchmark(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55895,6 +55266,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for the set limits objective command"]
     pub fn SCIPdialogExecSetLimitsObjective(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -55903,6 +55275,7 @@ unsafe extern "C" {
     ) -> SCIP_RETCODE;
 }
 unsafe extern "C" {
+    #[doc = " dialog execution method for linear constraint type classification"]
     pub fn SCIPdialogExecDisplayLinearConsClassification(
         scip: *mut SCIP,
         dialog: *mut SCIP_DIALOG,
@@ -57242,6 +56615,7 @@ unsafe extern "C" {
     pub fn SCIPnlhdlrHasSollinearize(nlhdlr: *mut SCIP_NLHDLR) -> ::std::os::raw::c_uint;
 }
 unsafe extern "C" {
+    #[doc = " compares two nonlinear handlers by detection priority\n\n if handlers have same detection priority, then compare by name"]
     pub fn SCIPnlhdlrComp(
         elem1: *mut ::std::os::raw::c_void,
         elem2: *mut ::std::os::raw::c_void,
@@ -58682,5 +58056,14 @@ unsafe extern "C" {
     #[doc = " includes default plugins into SCIP with respect to priorities"]
     pub fn SCIPincludeDefaultPlugins(scip: *mut SCIP) -> SCIP_RETCODE;
 }
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __crt_locale_data {
+    pub _address: u8,
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __crt_multibyte_data {
+    pub _address: u8,
+}
 pub type __builtin_va_list = *mut ::std::os::raw::c_char;
-pub type __uint128_t = u128;


### PR DESCRIPTION
Completes the prebuilt-bundled-bindings work by committing the per-platform bindings generated on CI, plus the runner fixes needed to produce them.

## Contents
- **All 5 prebuilt bindings** (`src/bindings/{linux,linux-arm,macos-arm,macos-intel,windows}.rs`), generated on the GitHub runners. `macos-arm` is refreshed to match runner output (it differed from the locally-generated copy, which would have failed the drift check).
- **Intel runner fix:** `macos-13` was retired as a GitHub-hosted label, so the Intel leg sat queued forever. Switched to `macos-15-intel` in the generate / lean / drift jobs.
- **PR base pinned to `main`** and **`add-paths: src/bindings/*.rs`** so the generate-bindings workflow targets main and never commits the downloaded `artifacts/` directory.

Once merged, the lean path (`--no-default-features --features bundled`) works on every supported platform with no bindgen/libclang, and the drift-check job guards the bindings against the pinned SCIP release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)