### PR TITLE
Update version to 0.1.28

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scip-sys"
-version = "0.1.27"
+version = "0.1.28"
 edition = "2021"
 description = "Bindings for the C SCIP solver."
 repository = "https://github.com/scipopt/scip-sys"


### PR DESCRIPTION
Patch release bundling the prebuilt-bindings work (#43, #45):

- `bundled` path now ships prebuilt per-platform bindings and skips bindgen.
- `bindgen` is an optional, default-on build-dependency; `--no-default-features --features bundled` drops bindgen + libclang entirely.
- `generate-bindings` workflow + per-platform drift/lean CI guards.

Backward compatible — default builds are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)