### PR TITLE
Support SCIP installations under lib64

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -192,6 +192,54 @@ jobs:
           cargo t create
           cargo t --examples
 
+  # Verifies the build script finds a SCIP install under `lib64` (CMake's
+  # GNUInstallDirs default on 64-bit RHEL/Fedora/SUSE-like systems). The prebuilt
+  # bundled libraries are re-laid into a `lib64` prefix that SCIPOPTDIR points at.
+  # A bogus `lib/libscip*` is planted as well, so the job also fails if `lib`
+  # (where 32-bit libraries live on multilib systems) is preferred over `lib64`.
+  linux-lib64-scipoptdir-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install runtime dependency of the prebuilt SCIP
+        run: sudo apt-get update && sudo apt-get install -y libgfortran5
+      - name: Lay out a lib64-style SCIP install from the bundled prebuilt
+        run: |
+          cargo build --features bundled --release
+          scip_install=$(find target/release -type d -name scip_install | head -1)
+          prefix="$GITHUB_WORKSPACE/scip-lib64"
+          mkdir -p "$prefix/lib64" "$prefix/lib"
+          cp -a "$scip_install/lib/." "$prefix/lib64/"
+          cp -a "$scip_install/include" "$prefix/"
+          # 32-bit libraries live in `lib` on multilib systems; a 64-bit build
+          # must pick `lib64`, so this bogus libscip in `lib` must be ignored.
+          echo "bogus" > "$prefix/lib/libscip.so"
+          echo "SCIPOPTDIR=$prefix" >> "$GITHUB_ENV"
+      - name: Build and run against the lib64 install
+        run: |
+          cargo build --release
+          cargo run --release --example create
+
+  # Builds the from-source feature on a lib64 distro (Rocky Linux 10, RHEL 10
+  # family). This is the environment the lib64 fix targets: CMake's
+  # GNUInstallDirs installs SCIP under `lib64` there. Guards that the
+  # from-source build keeps working on such a system.
+  linux-lib64-from-source-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build and test from-source inside a Rocky Linux 10 container
+        run: |
+          docker run --rm -v "$GITHUB_WORKSPACE:/workspace" -w /workspace rockylinux/rockylinux:10 bash -c '
+            set -e
+            dnf -y install gcc gcc-c++ cmake clang-devel git diffutils which patch perl > /dev/null
+            curl -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
+            . "$HOME/.cargo/env"
+            export LIBCLANG_PATH=/usr/lib64
+            cargo build --features from-source -vv
+            cargo run --features from-source --example create
+          '
+
 #  from-source-linux-arm-test:
 #    runs-on: ubuntu-latest
 #    steps:

--- a/build.rs
+++ b/build.rs
@@ -19,25 +19,51 @@ use std::path::{Path, PathBuf};
 /// Emit the `cargo:` link-search / rpath directives for a SCIP install directory
 /// (one containing `lib/` and `include/`). This is independent of bindgen and is
 /// shared by every path that links against SCIP.
+/// Locate the directory under a SCIP install prefix that actually contains the
+/// SCIP libraries. CMake's GNUInstallDirs installs into `lib64` on many 64-bit
+/// Linux distributions (RHEL/Fedora/SUSE/...) and into `lib` elsewhere, so probe
+/// both instead of assuming `lib`.
+#[cfg(any(feature = "bundled", feature = "bindgen"))]
+fn find_scip_lib_dir(prefix: &str) -> Option<PathBuf> {
+    use glob::glob;
+    // On multilib systems `<prefix>/lib` may hold 32-bit libraries while the
+    // 64-bit ones live in `<prefix>/lib64` (CMake's GNUInstallDirs default on
+    // RHEL/Fedora/SUSE/...). Probe the directory matching the target's pointer
+    // width first so a 64-bit build doesn't pick up a 32-bit libscip.
+    let target_is_64bit = env::var("CARGO_CFG_TARGET_POINTER_WIDTH").as_deref() == Ok("64");
+    let candidates: &[&str] = if target_is_64bit {
+        &["lib64", "lib"]
+    } else {
+        &["lib"]
+    };
+    candidates
+        .into_iter()
+        .map(|sub| PathBuf::from(prefix).join(sub))
+        .find(|dir| {
+            glob(&format!("{}/libscip*", dir.display()))
+                .map(|paths| paths.count() > 0)
+                .unwrap_or(false)
+        })
+}
+
 #[cfg(any(feature = "bundled", feature = "bindgen"))]
 fn emit_link_search(path: &str) {
-    let lib_dir = PathBuf::from(&path).join("lib");
+    let lib_dir = find_scip_lib_dir(path).unwrap_or_else(|| {
+        panic!(
+            "no SCIP library found under {path}/lib or {path}/lib64, \
+             please check your SCIP installation"
+        )
+    });
     let lib_dir_path = lib_dir.to_str().unwrap();
 
-    if lib_dir.exists() {
-        println!("cargo:warning=Using SCIP from {}", lib_dir_path);
-        println!("cargo:rustc-link-search={}", lib_dir_path);
-        println!("cargo:libdir={}", lib_dir_path);
+    println!("cargo:warning=Using SCIP from {}", lib_dir_path);
+    println!("cargo:rustc-link-search={}", lib_dir_path);
+    println!("cargo:libdir={}", lib_dir_path);
 
-        #[cfg(windows)]
-        let lib_dir_path = PathBuf::from(&path).join("bin");
-        #[cfg(windows)]
-        println!("cargo:rustc-link-search={}", lib_dir_path.to_str().unwrap());
-    } else {
-        panic!(
-            "{}/lib does not exist, please check your SCIP installation",
-            path
-        );
+    #[cfg(windows)]
+    {
+        let bin_dir = PathBuf::from(&path).join("bin");
+        println!("cargo:rustc-link-search={}", bin_dir.to_str().unwrap());
     }
 
     println!("cargo:rustc-link-arg=-Wl,-rpath,{}", lib_dir_path);
@@ -144,8 +170,7 @@ fn finalize_and_generate(builder: bindgen::Builder, out_path: &Path) -> Result<(
 
 #[cfg(all(feature = "bindgen", not(feature = "bundled")))]
 fn lib_scip_in_dir(path: &str) -> bool {
-    use glob::glob;
-    glob(&format!("{}/lib/libscip*", path)).unwrap().count() > 0
+    find_scip_lib_dir(path).is_some()
 }
 
 #[cfg(all(feature = "bindgen", not(feature = "bundled")))]

--- a/from_source.rs
+++ b/from_source.rs
@@ -57,6 +57,7 @@ pub fn compile_scip(source_path: PathBuf) -> PathBuf {
         .define("SYM", "snauty")
         .define("ZLIB", "OFF")
         .define("SHARED", "OFF")
+        .define("CMAKE_INSTALL_LIBDIR", "lib")
         .define("GCG", "OFF")
         .define("UG", "OFF")
         .define("SANITIZE_ADDRESS", "OFF")


### PR DESCRIPTION
## Problem

On 64-bit RHEL/Fedora/SUSE-like distributions, CMake's `GNUInstallDirs` installs libraries into `<prefix>/lib64` rather than `<prefix>/lib`. The build script only ever looked in `<prefix>/lib`, so SCIP could not be found there. Both affected paths fail:

- `--features from-source`: SCIP is compiled and installed into `OUT_DIR/lib64`, then the build panics with `<OUT_DIR>/lib does not exist, please check your SCIP installation`.
- `SCIPOPTDIR` / system install: a SCIP installed under `$SCIPOPTDIR/lib64` is not detected, and the build panics with `Could not find SCIP installation`.

This is what users hit when building on e.g. RHEL / Rocky / AlmaLinux. On Debian/Ubuntu (which keep `lib`), the build works, which is why this had gone unnoticed.

## Changes

- **Probe both `lib` and `lib64`** (`find_scip_lib_dir`), and route `emit_link_search()` and `lib_scip_in_dir()` through it. The probe order follows the target pointer width — `lib64` first for 64-bit targets — so a 64-bit build doesn't accidentally pick up a 32-bit `libscip` that may live in a multilib `<prefix>/lib`. (32-bit targets probe only `lib`.)
- **Pin `CMAKE_INSTALL_LIBDIR=lib`** for the from-source build so SCIP is installed into `OUT_DIR/lib` deterministically, regardless of the host distro's `GNUInstallDirs` default.

The `bundled` path is unaffected (its prebuilt layout already uses `lib`, which the probe still finds).

## Testing

Two CI jobs are added to cover this going forward:

- `linux-lib64-scipoptdir-test` (ubuntu): re-lays the prebuilt bundled libraries into a `lib64` prefix (plus a bogus `lib/libscip*`) and builds against it via `SCIPOPTDIR`, exercising lib64 detection and the lib64-first order.
- `linux-lib64-from-source-test`: builds `--features from-source` inside a Rocky Linux 10 container.

I added the CI just to be thorough, but I might have gone a little overboard.