### PR TITLE
CI: install gcc in bundled-test on macOS runners

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -22,6 +22,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
+      - name: Install GCC (provides libgfortran for the prebuilt SCIP binary)
+        if: ${{ matrix.os == 'macos-15' || matrix.os == 'macos-14' }}
+        run: brew install gcc
       - name: Test bundled
         run: |
           cargo b --features bundled --release


### PR DESCRIPTION
The prebuilt SCIP binaries (libscip-macos-arm) link against libgfortran.5.dylib at:
  /opt/homebrew/opt/gcc/lib/gcc/current/libgfortran.5.dylib

Newer macOS runner images no longer have the gcc formula installed, so dyld fails to load the library at test runtime. Explicitly installing gcc (via brew) sets up the expected path with the correct libgfortran soversion.


Fixes #48 